### PR TITLE
Use https remote

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -4,7 +4,7 @@
             "name": "grafonnet",
             "source": {
                 "git": {
-                    "remote": "git@github.com:grafana/grafonnet-lib",
+                    "remote": "https://github.com/grafana/grafonnet-lib",
                     "subdir": "grafonnet"
                 }
             },


### PR DESCRIPTION
Without the https remote users of this package will need to use an ssh
key to authenticate with github, with https this is not necessary
therefore it's easier to consume.

(this is the new default behavior when using jsonnet-bundler to install a dependency)

@tomwilkie 