### PR TITLE
Introduce configurable pod label

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -6,6 +6,7 @@
     kubeStateMetricsSelector: 'job="default/kube-state-metrics"',
     nodeExporterSelector: 'job="default/node-exporter"',
     notKubeDnsSelector: 'job!="kube-system/kube-dns"',
+    podLabel: 'pod',
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -72,7 +72,9 @@ local g = import '../lib/grafana.libsonnet';
         g.row('Storage')
         .addPanel(
           g.panel('Disk Capacity') +
-          g.queryPanel('sum(max(node_filesystem_size{fstype=~"ext[24]"} - node_filesystem_free{fstype=~"ext[24]"}) by (device,instance,namespace)) by (instance,namespace) / scalar(sum(max(node_filesystem_size{fstype=~"ext[24]"}) by (device,instance,namespace))) * on (namespace, instance) group_left(node) node_namespace_instance:kube_pod_info:', '{{node}}', legendLink) +
+          g.queryPanel(|||
+            sum(max(node_filesystem_size{fstype=~"ext[24]"} - node_filesystem_free{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace) / scalar(sum(max(node_filesystem_size{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace))) * on (namespace, %(podLabel)s) group_left(node) node_namespace_pod:kube_pod_info:
+          ||| % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -70,9 +70,9 @@
           {
             // This rule results in the tuples (node, namespace, instance) => 1;
             // it is used to calculate per-node metrics, given namespace & instance.
-            record: 'node_namespace_instance:kube_pod_info:',
+            record: 'node_namespace_pod:kube_pod_info:',
             expr: |||
-              max(label_replace(kube_pod_info{%(kubeStateMetricsSelector)s}, "instance", "$1", "pod", "(.*)")) by (node, namespace, instance)
+              max(label_replace(kube_pod_info{%(kubeStateMetricsSelector)s}, "%(podLabel)s", "$1", "pod", "(.*)")) by (node, namespace, %(podLabel)s)
             ||| % $._config,
           },
           {
@@ -81,8 +81,8 @@
             expr: |||
               count by (node) (sum by (node, cpu) (
                 node_cpu{%(nodeExporterSelector)s}
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               ))
             ||| % $._config,
           },
@@ -99,8 +99,8 @@
             expr: |||
               1 - avg by (node) (
                 rate(node_cpu{%(nodeExporterSelector)s,mode="idle"}[1m])
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:)
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:)
             ||| % $._config,
           },
           {
@@ -120,8 +120,8 @@
             expr: |||
               sum by (node) (
                 node_load1{%(nodeExporterSelector)s}
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
               /
               node:node_num_cpu:sum
@@ -143,8 +143,8 @@
             expr: |||
               sum by (node) (
                 (node_memory_MemFree{%(nodeExporterSelector)s} + node_memory_Cached{%(nodeExporterSelector)s} + node_memory_Buffers{%(nodeExporterSelector)s})
-                * on (namespace, instance) group_left(node)
-                  node_namespace_instance:kube_pod_info:
+                * on (namespace, %(podLabel)s) group_left(node)
+                  node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -155,8 +155,8 @@
             expr: |||
               sum by (node) (
                 node_memory_MemTotal{%(nodeExporterSelector)s}
-                * on (namespace, instance) group_left(node)
-                  node_namespace_instance:kube_pod_info:
+                * on (namespace, %(podLabel)s) group_left(node)
+                  node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -186,14 +186,14 @@
               1 -
               sum by (node) (
                 (node_memory_MemFree{%(nodeExporterSelector)s} + node_memory_Cached{%(nodeExporterSelector)s} + node_memory_Buffers{%(nodeExporterSelector)s})
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
               /
               sum by (node) (
                 node_memory_MemTotal{%(nodeExporterSelector)s}
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -211,8 +211,8 @@
               1e3 * sum by (node) (
                 (rate(node_vmstat_pgpgin{%(nodeExporterSelector)s}[1m])
                + rate(node_vmstat_pgpgout{%(nodeExporterSelector)s}[1m]))
-               * on (namespace, instance) group_left(node)
-                 node_namespace_instance:kube_pod_info:
+               * on (namespace, %(podLabel)s) group_left(node)
+                 node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -229,8 +229,8 @@
             expr: |||
               avg by (node) (
                 irate(node_disk_io_time_ms{%(nodeExporterSelector)s,device=~"(sd|xvd).+"}[1m]) / 1e3
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -247,8 +247,8 @@
             expr: |||
               avg by (node) (
                 irate(node_disk_io_time_weighted{%(nodeExporterSelector)s,device=~"(sd|xvd).+"}[1m]) / 1e3
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -265,8 +265,8 @@
               sum by (node) (
                 (irate(node_network_receive_bytes{%(nodeExporterSelector)s,device="eth0"}[1m]) +
                 irate(node_network_transmit_bytes{%(nodeExporterSelector)s,device="eth0"}[1m]))
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },
@@ -283,8 +283,8 @@
               sum by (node) (
                 (irate(node_network_receive_drop{%(nodeExporterSelector)s,device="eth0"}[1m]) +
                 irate(node_network_transmit_drop{%(nodeExporterSelector)s,device="eth0"}[1m]))
-              * on (namespace, instance) group_left(node)
-                node_namespace_instance:kube_pod_info:
+              * on (namespace, %(podLabel)s) group_left(node)
+                node_namespace_pod:kube_pod_info:
               )
             ||| % $._config,
           },


### PR DESCRIPTION
The default label here is "instance", whereas in our configuration this
is done with the "pod" label, therefore change makes the label to use
configurable.

@tomwilkie 