### PR TITLE
Use node_filesystem_avail over node_filesystem_free

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -103,7 +103,7 @@ local gauge = promgrafonnet.gauge;
         |||
           (
             sum(node_filesystem_size{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
-          - sum(node_filesystem_free{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
+          - sum(node_filesystem_avail{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
           ) * 100
             /
           sum(node_filesystem_size{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -73,7 +73,7 @@ local g = import '../lib/grafana.libsonnet';
         .addPanel(
           g.panel('Disk Capacity') +
           g.queryPanel(|||
-            sum(max(node_filesystem_size{fstype=~"ext[24]"} - node_filesystem_free{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace) / scalar(sum(max(node_filesystem_size{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace))) * on (namespace, %(podLabel)s) group_left(node) node_namespace_pod:kube_pod_info:
+            sum(max(node_filesystem_size{fstype=~"ext[24]"} - node_filesystem_avail{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace) / scalar(sum(max(node_filesystem_size{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace))) * on (namespace, %(podLabel)s) group_left(node) node_namespace_pod:kube_pod_info:
           ||| % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
@@ -139,7 +139,7 @@ local g = import '../lib/grafana.libsonnet';
         g.row('Disk')
         .addPanel(
           g.panel('Disk Utilisation') +
-          g.queryPanel('1 - sum(max by (device, node) (node_filesystem_free{fstype=~"ext[24]"})) / sum(max by (device, node) (node_filesystem_size{fstype=~"ext[24]"}))', 'Disk') +
+          g.queryPanel('1 - sum(max by (device, node) (node_filesystem_avail{fstype=~"ext[24]"})) / sum(max by (device, node) (node_filesystem_size{fstype=~"ext[24]"}))', 'Disk') +
           { yaxes: g.yaxes('percentunit') },
         ),
       ),


### PR DESCRIPTION
From https://github.com/prometheus/node_exporter/issues/269 it's noted
that `node_filesystem_free` can provide a less accurate metric for
when a fs write would fail (from full disk).

Usecase: https://github.com/coreos/prometheus-operator/pull/1299