### PR TITLE
alerts: fix typo on KubeDeploymentGenerationMismatch

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -40,7 +40,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Deployment {{ $labels.namespace }}/{{ labels.deployment }} generation mismatch',
+              message: 'Deployment {{ $labels.namespace }}/{{ $labels.deployment }} generation mismatch',
             },
             'for': '15m',
             alert: 'KubeDeploymentGenerationMismatch',


### PR DESCRIPTION
```
level=warn 
ts=2018-05-09T04:41:12.860180827Z 
caller=alerting.go:220 component="rule manager" 
alert=KubeDeploymentGenerationMismatch 
msg="Expanding alert template failed" 
err="error parsing template __alert_KubeDeploymentGenerationMismatch: template: __alert_KubeDeploymentGenerationMismatch:1: function \"labels\" not defined" 
data="unsupported value type"
```