### PR TITLE
Only include scheduled pods in the resource usage calculation

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -50,7 +50,7 @@
             record: 'namespace_name:kube_pod_container_resource_requests_cpu_cores:sum',
             expr: |||
               sum by (namespace, label_name) (
-                sum(kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}) by (namespace, pod)
+                sum(kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
               * on (namespace, pod) group_left(label_name)
                 label_replace(kube_pod_labels{%(kubeStateMetricsSelector)s}, "pod_name", "$1", "pod", "(.*)")
               )


### PR DESCRIPTION
Related to https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/17

Excludes non-scheduled pods (evicted, completed etc.) from request calculation.