### PR TITLE
Add alerts for StatefulSets

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -60,6 +60,36 @@
             'for': '15m',
             alert: 'KubeDeploymentReplicasMismatch',
           },
+          {
+            expr: |||
+              kube_statefulset_status_replicas_ready{%(kube_state_metrics_selector)s}
+                !=
+              kube_statefulset_status_replicas{%(kube_state_metrics_selector)s}
+            ||| % $._config,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} replica mismatch',
+            },
+            'for': '15m',
+            alert: 'KubeStatefulSetReplicasMismatch',
+          },
+          {
+            expr: |||
+              kube_statefulset_status_observed_generation{%(kube_state_metrics_selector)s}
+                !=
+              kube_statefulset_metadata_generation{%(kube_state_metrics_selector)s}
+            ||| % $._config,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'StatefulSet {{ $labels.namespace }}/{{ labels.statefulset }} generation mismatch',
+            },
+            'for': '15m',
+            alert: 'KubeDeploymentGenerationMismatch',
+          },
         ],
       },
     ],

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -62,9 +62,9 @@
           },
           {
             expr: |||
-              kube_statefulset_status_replicas_ready{%(kube_state_metrics_selector)s}
+              kube_statefulset_status_replicas_ready{%(kubeStateMetricsSelector)s}
                 !=
-              kube_statefulset_status_replicas{%(kube_state_metrics_selector)s}
+              kube_statefulset_status_replicas{%(kubeStateMetricsSelector)s}
             ||| % $._config,
             labels: {
               severity: 'critical',
@@ -77,9 +77,9 @@
           },
           {
             expr: |||
-              kube_statefulset_status_observed_generation{%(kube_state_metrics_selector)s}
+              kube_statefulset_status_observed_generation{%(kubeStateMetricsSelector)s}
                 !=
-              kube_statefulset_metadata_generation{%(kube_state_metrics_selector)s}
+              kube_statefulset_metadata_generation{%(kubeStateMetricsSelector)s}
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
These alerts mirror the alerts for Deployments
- replicas ready != replicas
- observed generation != metadata generation