### PR TITLE
Use histogram for cert expiry alerts, make it configurable.

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -129,27 +129,27 @@
             },
           },
           {
-            alert: 'KubeCertificateExpiration',
+            alert: 'KubeClientCertificateExpiration',
             expr: |||
-              sum(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s,le="604800"}) > 0
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationWarningSeconds)s
             ||| % $._config,
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'Kubernetes API certificate is expiring in less than 7 days.',
+              message: 'Kubernetes API certificate is expiring in less than %d days.' % ($._config.certExpirationWarningSeconds / 3600 / 24),
             },
           },
           {
-            alert: 'KubeCertificateExpiration',
+            alert: 'KubeClientCertificateExpiration',
             expr: |||
-              sum(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s,le="86400"}) > 0
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationCriticalSeconds)s
             ||| % $._config,
             labels: {
-              severity: 'warning',
+              severity: 'critical',
             },
             annotations: {
-              message: 'Kubernetes API certificate is expiring in less than 1 day.',
+              message: 'Kubernetes API certificate is expiring in less than %d day.' % ($._config.certExpirationCriticalSeconds / 3600 / 24),
             },
           },
         ],

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -24,6 +24,8 @@
     // allow you to overcommit if you wish.
     namespaceOvercommitFactor: 1.5,
     kubeletTooManyPods: 100,
+    certExpirationWarningSeconds: 7 * 24 * 3600,
+    certExpirationCriticalSeconds: 1 * 24 * 3600,
 
     // For links between grafana dashboards, you need to tell us if your grafana
     // servers under some non-root path.


### PR DESCRIPTION
This isn't perfect, as it won't alert if one random cert with very low valid period is used once vs certificates with long life thousands of times.  Alternative would be to let users pick from the hard coded buckets, but that seems fragile.  WDYT, @brancz?

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>