### PR TITLE
Change datasource to $datasource in gauge helpers

### DIFF
--- a/lib/promgrafonnet/gauge.libsonnet
+++ b/lib/promgrafonnet/gauge.libsonnet
@@ -6,7 +6,7 @@ local prometheus = grafana.prometheus;
   new(title, query)::
     singlestat.new(
       title,
-      datasource='prometheus',
+      datasource='$datasource',
       span=3,
       format='percent',
       valueName='current',

--- a/lib/promgrafonnet/numbersinglestat.libsonnet
+++ b/lib/promgrafonnet/numbersinglestat.libsonnet
@@ -6,7 +6,7 @@ local prometheus = grafana.prometheus;
   new(title, query)::
     singlestat.new(
       title,
-      datasource='prometheus',
+      datasource='$datasource',
       span=3,
       valueName='current',
       valueMaps=[


### PR DESCRIPTION
I had broken singlestats on the node dashboard, because my datasources aren't called Prometheus, but DigitalOcean.