### PR TITLE
Add dashboard IDs in order to make links work

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -19,6 +19,18 @@
       KubeAPI: $._config.kubeApiserverSelector,
     },
 
+    // Grafana dashboard IDs are necessary for stable links for dashboards
+    grafanaDashboardIDs: {
+      'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
+      'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
+      'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
+      'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
+      'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
+      'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
+      'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
+      'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
+    },
+
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however
     // allow you to overcommit if you wish.

--- a/dashboards/add-dashboard-uid.libsonnet
+++ b/dashboards/add-dashboard-uid.libsonnet
@@ -1,0 +1,12 @@
+{
+  local grafanaDashboards = super.grafanaDashboards,
+
+  // Automatically add a uid to each dashboard based on the base64 encoding
+  // of the file name.
+  grafanaDashboards:: {
+    [filename]: grafanaDashboards[filename] {
+      uid: std.base64(filename),
+    }
+      for filename in std.objectFields(grafanaDashboards)
+    }
+}

--- a/dashboards/add-dashboard-uid.libsonnet
+++ b/dashboards/add-dashboard-uid.libsonnet
@@ -5,7 +5,7 @@
   // of the file name.
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
-      uid: std.base64(filename),
+      uid: std.md5(filename),
     }
       for filename in std.objectFields(grafanaDashboards)
     }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -2,4 +2,5 @@
 (import 'pods.libsonnet') +
 (import 'resources.libsonnet') +
 (import 'statefulset.libsonnet') +
-(import 'use.libsonnet')
+(import 'use.libsonnet') +
+(import 'add-dashboard-uid.libsonnet')

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -128,8 +128,11 @@ local gauge = promgrafonnet.gauge;
         )
         .addTarget(prometheus.target('rate(node_network_transmit_bytes{%(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m])' % $._config, legendFormat='{{device}}'));
 
-      dashboard.new('Nodes', time_from='now-1h')
-      .addTemplate(
+      dashboard.new(
+        'Nodes',
+        time_from='now-1h',
+        uid=($._config.grafanaDashboardIDs['nodes.json']),
+      ).addTemplate(
         {
           current: {
             text: 'Prometheus',

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -72,8 +72,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         ))
       );
 
-      dashboard.new('Pods', time_from='now-1h')
-      .addTemplate(
+      dashboard.new(
+        'Pods',
+        time_from='now-1h',
+        uid=($._config.grafanaDashboardIDs['pods.json']),
+      ).addTemplate(
         {
           current: {
             text: 'Prometheus',

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,12 +6,14 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%s/dashboard/file/k8s-resources-namespace.json?var-datasource=$datasource&var-namespace=$__cell' % $._config.grafanaPrefix,
+          link: '%(prefix)s/d/%(dashboardID)s/k8s-resources-namespace.json?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
         },
       };
 
-      g.dashboard('K8s / Compute Resources / Cluster')
-      .addRow(
+      g.dashboard(
+        'K8s / Compute Resources / Cluster',
+        uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
+      ).addRow(
         (g.row('Headlines') +
          {
            height: '100px',
@@ -96,12 +98,14 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%s/dashboard/file/k8s-resources-pod.json?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % $._config.grafanaPrefix,
+          link: '%(prefix)s/d/%(dashboardID)s/k8s-resources-pod.json?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
         },
       };
 
-      g.dashboard('K8s / Compute Resources / Namespace')
-      .addTemplate('namespace', 'kube_pod_info', 'namespace')
+      g.dashboard(
+        'K8s / Compute Resources / Namespace',
+        uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
+      ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
         g.row('CPU Usage')
         .addPanel(
@@ -164,8 +168,10 @@ local g = import '../lib/grafana.libsonnet';
         },
       };
 
-      g.dashboard('K8s / Compute Resources / Pod')
-      .addTemplate('namespace', 'kube_pod_info', 'namespace')
+      g.dashboard(
+        'K8s / Compute Resources / Pod',
+        uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
+      ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')
       .addRow(
         g.row('CPU Usage')

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,7 +6,7 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-namespace.json') },
         },
       };
 
@@ -98,7 +98,7 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,7 +6,7 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(dashboardID)s/k8s-resources-namespace.json?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-resources-namespace.json') },
         },
       };
 
@@ -98,7 +98,7 @@ local g = import '../lib/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(dashboardID)s/k8s-resources-pod.json?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-resources-pod.json') },
         },
       };
 

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -101,8 +101,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         row.new()
         .addPanel(replicasGraph);
 
-      dashboard.new('StatefulSets', time_from='now-1h')
-      .addTemplate(
+      dashboard.new(
+        'StatefulSets',
+        time_from='now-1h',
+        uid=($._config.grafanaDashboardIDs['statefulset.json']),
+      ).addTemplate(
         {
           current: {
             text: 'Prometheus',

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -3,7 +3,7 @@ local g = import '../lib/grafana.libsonnet';
 {
   grafanaDashboards+:: {
     'k8s-cluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(dashboardID)s/k8s-node-rsrc-use.json' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-node-rsrc-use.json'] };
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-node-rsrc-use.json') };
 
       g.dashboard(
         'K8s / USE Method / Cluster',

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -3,7 +3,7 @@ local g = import '../lib/grafana.libsonnet';
 {
   grafanaDashboards+:: {
     'k8s-cluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.base64('k8s-node-rsrc-use.json') };
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
       g.dashboard(
         'K8s / USE Method / Cluster',

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -3,10 +3,12 @@ local g = import '../lib/grafana.libsonnet';
 {
   grafanaDashboards+:: {
     'k8s-cluster-rsrc-use.json':
-      local legendLink = '%s/dashboard/file/k8s-node-rsrc-use.json' % $._config.grafanaPrefix;
+      local legendLink = '%(prefix)s/d/%(dashboardID)s/k8s-node-rsrc-use.json' % { prefix: $._config.grafanaPrefix, dashboardID: $._config.grafanaDashboardIDs['k8s-node-rsrc-use.json'] };
 
-      g.dashboard('K8s / USE Method / Cluster')
-      .addRow(
+      g.dashboard(
+        'K8s / USE Method / Cluster',
+        uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
+      ).addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
@@ -81,8 +83,10 @@ local g = import '../lib/grafana.libsonnet';
       ),
 
     'k8s-node-rsrc-use.json':
-      g.dashboard('K8s / USE Method / Node')
-      .addTemplate('node', 'kube_node_info', 'node')
+      g.dashboard(
+        'K8s / USE Method / Node',
+        uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
+      ).addTemplate('node', 'kube_node_info', 'node')
       .addRow(
         g.row('CPU')
         .addPanel(

--- a/lib/grafana.libsonnet
+++ b/lib/grafana.libsonnet
@@ -1,5 +1,5 @@
 {
-  dashboard(title):: {
+  dashboard(title, uid=''):: {
     // Stuff that isn't materialised.
     _nextPanel:: 0,
     addRow(row):: self {
@@ -71,6 +71,7 @@
     },
 
     // Stuff that is materialised.
+    uid: uid,
     annotations: {
       list: [],
     },


### PR DESCRIPTION
This PR adds a randomly generated ID to each dashboard, so that drill-down links can work. Beyond that it also means that even if Grafana gets re-deployed links will be stable, so dashboards links can be shared.

One thing I wonder about is, that I could not find the "legendLinks" used in the dashboards in the Grafana dashboard definition. Was this possibly available in Grafana v4 but removed in v5?

@tomwilkie @metalmatze 