### PR TITLE
Ensure rule is an alert when adding runbook link

### DIFF
--- a/alerts/add-runbook-links.libsonnet
+++ b/alerts/add-runbook-links.libsonnet
@@ -15,9 +15,8 @@ local lower(x) =
 
   prometheusAlerts+::
     local addRunbookURL(rule) = rule {
-      local alert = lower(super.alert),
-      annotations+: {
-        runbook_url: $._config.runbookURLPattern % alert,
+      [if 'alert' in rule then 'annotations']+: {
+        runbook_url: $._config.runbookURLPattern % lower(rule.alert),
       },
     };
     utils.mapRuleGroups(addRunbookURL),

--- a/dashboards/add-dashboard-uid.libsonnet
+++ b/dashboards/add-dashboard-uid.libsonnet
@@ -7,6 +7,6 @@
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
     }
-      for filename in std.objectFields(grafanaDashboards)
-    }
+    for filename in std.objectFields(grafanaDashboards)
+  },
 }


### PR DESCRIPTION
This ensures, that only actual alert definitions get the runbook added, and instead of `super.alert` it uses the passed `rule` variable.

(also formats the repo once, it seems we missed to do this at some point)

@tomwilkie 