### PR TITLE
Disk usage expression enhancements

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -43,5 +43,9 @@
     // For links between grafana dashboards, you need to tell us if your grafana
     // servers under some non-root path.
     grafanaPrefix: '',
+
+    // This list of filesystem is referenced in various expressions.
+    fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
+    fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
   },
 }

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -129,12 +129,8 @@ local gauge = promgrafonnet.gauge;
       local diskSpaceUsage = gauge.new(
         'Disk Space Usage',
         |||
-          (
-            sum(node_filesystem_size{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
-          - sum(node_filesystem_avail{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
-          ) * 100
-            /
-          sum(node_filesystem_size{%(nodeExporterSelector)s, device!="rootfs", instance="$instance"})
+          (1 - max (node_filesystem_avail{%(fstypeSelector)s, instance="$instance"}
+          / node_filesystem_size{%(fstypeSelector)s, instance="$instance"}) by (device,instance)) * 100
         ||| % $._config,
       ).withLowerBeingBetter();
 

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -19,10 +19,10 @@ local g = import 'grafana-builder/grafana.libsonnet';
            height: '100px',
            showTitle: false,
          })
-         .addPanel(
-           g.panel('CPU Utilisation') +
-           g.statPanel('1 - avg(rate(node_cpu{mode="idle"}[1m]))')
-         )
+        .addPanel(
+          g.panel('CPU Utilisation') +
+          g.statPanel('1 - avg(rate(node_cpu{mode="idle"}[1m]))')
+        )
         .addPanel(
           g.panel('CPU Requests Commitment') +
           g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)')

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -147,7 +147,14 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Disk')
         .addPanel(
           g.panel('Disk Utilisation') +
-          g.queryPanel('1 - sum(max by (device, node) (node_filesystem_avail{fstype=~"ext[24]"})) / sum(max by (device, node) (node_filesystem_size{fstype=~"ext[24]"}))', 'Disk') +
+          g.queryPanel(
+            |||
+              max ((node_filesystem_size{%(fstypeSelector)s} - node_filesystem_avail{%(fstypeSelector)s})
+              / node_filesystem_size{%(fstypeSelector)s}) by (namespace, %(podLabel)s, device)
+              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:{node="$node"}
+            ||| % $._config,
+            '{{device}}',
+          ) +
           { yaxes: g.yaxes('percentunit') },
         ),
       ),

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -74,9 +74,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Storage')
         .addPanel(
           g.panel('Disk Capacity') +
-          g.queryPanel(|||
-            sum(max(node_filesystem_size{fstype=~"ext[24]"} - node_filesystem_avail{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace) / scalar(sum(max(node_filesystem_size{fstype=~"ext[24]"}) by (device,%(podLabel)s,namespace))) * on (namespace, %(podLabel)s) group_left(node) node_namespace_pod:kube_pod_info:
-          ||| % $._config, '{{node}}', legendLink) +
+          g.queryPanel(
+            |||
+              sum(max(node_filesystem_size{%(fstypeSelector)s} - node_filesystem_avail{%(fstypeSelector)s}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace)
+              / scalar(sum(max(node_filesystem_size{%(fstypeSelector)s}) by (device,%(podLabel)s,namespace)))
+              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:
+            ||| % $._config, '{{node}}', legendLink
+          ) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),


### PR DESCRIPTION
* dashboards: jsonnet fmt

* USE (Nodes): Add node grouping and filter

Currently the "Disk Utilisation" expression references the "node" label but
it is not present in the node_filesystem_* metrics.

This fixes it by grouping with the node_namespace_pod:kube_pod_info:
recording rule.

Finally it adds the "$node" filter which was ignored previously.

* USE (Nodes): use fstypeSelector

This prettifies the Disk Capacity expression and references the
fstypeSelector for filtering file systems.

* Nodes: deduplicate devices in Disk Space Usage calculation

If node exporter is deployed as a container, this currently sum all bind
mounts despite being the same source device.

This fixes it by deduplicating the values.

* config: add global filesystem selector

Quite some expressions reference a set of file systems (i.e. disk space
usage expressions).

This centralizes them in config.libsonnet.