### PR TITLE
Ignore failed pods for KubePodNotReady

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -19,7 +19,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (kube_pod_status_phase{%(kubeStateMetricsSelector)s, phase!~"Running|Succeeded"}) > 0
+              sum by (namespace, pod) (kube_pod_status_phase{%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

Essentially is something is evicted, or exits with non-zero, it gets rescheduled. Now, the failed pod sticks around until `--terminated-pod-gc-threshold`.

> The only exception to this rule is that Pods with a phase of Succeeded or Failed for more than some duration (determined by terminated-pod-gc-threshold in the master) will expire and be automatically destroyed

```
--terminated-pod-gc-threshold int32     Default: 12500
Number of terminated pods that can exist before the terminated pod garbage collector starts deleting terminated pods. If <= 0, the terminated pod garbage collector is disabled.
```

This is causing us some alerts like: 
<img width="483" alt="screen shot 2018-08-28 at 16 06 27" src="https://user-images.githubusercontent.com/7354143/44718015-5a575500-aadc-11e8-985c-b67aec406e55.png">
