### PR TITLE
Make volume prediction more sophisticated

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -23,14 +23,14 @@
           {
             alert: 'KubePersistentVolumeFullInFourDays',
             expr: |||
-              predict_linear(kubelet_volume_stats_available_bytes{%(kubeletSelector)s}[1h], 4 * 24 * 3600) < 0
+              kubelet_volume_stats_available_bytes{%(kubeletSelector)s} and predict_linear(kubelet_volume_stats_available_bytes{%(kubeletSelector)s}[%(volumeFullPredictionSampleTime)s], 4 * 24 * 3600) < 0
             ||| % $._config,
             'for': '5m',
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'Based on recent sampling, the persistent volume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is expected to fill up within four days.',
+              message: 'Based on recent sampling, the persistent volume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ value }} bytes are available.',
             },
           },
         ],

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -40,6 +40,11 @@
     certExpirationWarningSeconds: 7 * 24 * 3600,
     certExpirationCriticalSeconds: 1 * 24 * 3600,
 
+    // We alert when a disk is expected to fill up in four days. Depending on
+    // the data-set it might be useful to change the sampling-time for the
+    // prediction
+    volumeFullPredictionSampleTime: '6h',
+
     // For links between grafana dashboards, you need to tell us if your grafana
     // servers under some non-root path.
     grafanaPrefix: '',


### PR DESCRIPTION
Currently the KubePersistentVolumeFullInFourDays check uses 1 hour
of sampling data to predict 4 days of volume fill up. To make the
check more sophisticated the sampling time is now configurable and
defaults to 6 hours.
Also to prevent already deleted volumes from alerting we check, if
there is most recent data of a volume before predicting its status.

Fixes #54