### PR TITLE
alerts: Increase `for` statement of PersistentVolumeClaim alerts

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -25,7 +25,7 @@
             expr: |||
               predict_linear(kubelet_volume_stats_available_bytes{%(kubeletSelector)s}[1h], 4 * 24 * 3600) < 0
             ||| % $._config,
-            'for': '5m',
+            'for': '1h',
             labels: {
               severity: 'critical',
             },


### PR DESCRIPTION
Applications that occasionally have I/O bursts can easily trigger the
alert. Given that the prediction looks at the next four days, it doesn't
hurt to increase the `for` timespan, to make this alert less flaky.

For me this alert is flaky on the PVCs used by my Prometheus servers as when I roll out a new version of some software (a large somewhat large number of kubelets in my exact case), that Prometheus is scraping a lot of metrics from that causes a lot of new time-series being created which has effect on storage usage. Even though the rollout is almost instant the prediction takes around half an hour to recover. As the prediction looks four days into the future this should make this alert a lot more reliable.

![screenshot from 2018-09-02 12-37-15](https://user-images.githubusercontent.com/4546722/44959525-159d3680-aead-11e8-9f59-40a2c99da35c.png)

@metalmatze @tomwilkie 
