### PR TITLE
dashboards: reuse disk space usage metrics as a recording rule

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -133,9 +133,7 @@ local gauge = promgrafonnet.gauge;
         format='percentunit',
       ).addTarget(prometheus.target(
         |||
-          max ((node_filesystem_size{%(fstypeSelector)s,instance="$instance"}
-          - node_filesystem_avail{%(fstypeSelector)s,instance="$instance"})
-          / node_filesystem_size{%(fstypeSelector)s,instance="$instance"}) by (namespace, %(podLabel)s, device)
+          node:node_filesystem_usage:
         ||| % $._config, legendFormat='{{device}}',
       ));
 

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -149,8 +149,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk Utilisation') +
           g.queryPanel(
             |||
-              max ((node_filesystem_size{%(fstypeSelector)s} - node_filesystem_avail{%(fstypeSelector)s})
-              / node_filesystem_size{%(fstypeSelector)s}) by (namespace, %(podLabel)s, device)
+              node:node_filesystem_usage:
               * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:{node="$node"}
             ||| % $._config,
             '{{device}}',

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -309,6 +309,20 @@
             ||| % $._config,
           },
           {
+            record: 'node:node_filesystem_usage:',
+            expr: |||
+              max by (namespace, %(podLabel)s, device) ((node_filesystem_size{%(fstypeSelector)s}
+              - node_filesystem_avail{%(fstypeSelector)s})
+              / node_filesystem_size{%(fstypeSelector)s})
+            ||| % $._config,
+          },
+          {
+            record: 'node:node_filesystem_avail:',
+            expr: |||
+              max by (namespace, %(podLabel)s, device) (node_filesystem_avail{%(fstypeSelector)s} / node_filesystem_size{%(fstypeSelector)s})
+            ||| % $._config,
+          },
+          {
             record: ':node_net_utilisation:sum_irate',
             expr: |||
               sum(irate(node_network_receive_bytes{%(nodeExporterSelector)s,%(hostNetworkInterfaceSelector)s}[1m])) +


### PR DESCRIPTION
This allows reusing node disk space calculations in dashboards
as well as in various alerts.

Fixes #71

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>