### PR TITLE
Fix typo in KubePersistentVolumeFullInFourDays message

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -30,7 +30,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Based on recent sampling, the persistent volume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ value }} bytes are available.',
+              message: 'Based on recent sampling, the persistent volume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value }} bytes are available.',
             },
           },
         ],


### PR DESCRIPTION
Fix the typo found in https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/72#issuecomment-418768321