### PR TITLE
alerts: allow overriding runbooks

### DIFF
--- a/alerts/absent_alerts.libsonnet
+++ b/alerts/absent_alerts.libsonnet
@@ -8,13 +8,14 @@
             alert: '%sDown' % name,
             expr: |||
               absent(up{%s} == 1)
-            ||| % $._config.jobs[name],
+            ||| % $._config.jobs[name].selector,
             'for': '15m',
             labels: {
               severity: 'critical',
             },
             annotations: {
               message: '%s has disappeared from Prometheus target discovery.' % name,
+              [if 'absent_runbook_url' in $._config.jobs[name] then 'runbook_url']: $._config.jobs[name].runbook_url,
             },
           }
           for name in std.objectFields($._config.jobs)

--- a/alerts/add-runbook-links.libsonnet
+++ b/alerts/add-runbook-links.libsonnet
@@ -16,7 +16,7 @@ local lower(x) =
   prometheusAlerts+::
     local addRunbookURL(rule) = rule {
       [if 'alert' in rule then 'annotations']+: {
-        runbook_url: $._config.runbookURLPattern % lower(rule.alert),
+        [if !('runbook_url' in rule.annotations) then 'runbook_url']: $._config.runbookURLPattern % lower(rule.alert),
       },
     };
     utils.mapRuleGroups(addRunbookURL),

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -16,10 +16,18 @@
 
     // We build alerts for the presence of all these jobs.
     jobs: {
-      Kubelet: $._config.kubeletSelector,
-      KubeScheduler: $._config.kubeSchedulerSelector,
-      KubeControllerManager: $._config.kubeControllerManagerSelector,
-      KubeAPI: $._config.kubeApiserverSelector,
+      Kubelet: {
+        selector: $._config.kubeletSelector,
+      },
+      KubeScheduler: {
+        selector: $._config.kubeSchedulerSelector,
+      },
+      KubeControllerManager: {
+        selector: $._config.kubeControllerManagerSelector,
+      },
+      KubeAPI: {
+        selector: $._config.kubeApiserverSelector,
+      },
     },
 
     // Grafana dashboard IDs are necessary for stable links for dashboards


### PR DESCRIPTION
This commit allows runbook URLs to be overridden. Now, if an alert has a
`runbook_url` annotation, then the it will not be overridden.
Furthermore, jobs in the `_config` can now be given custom runbook URLs
for the absent alert by setting the `absent_runbook_url` field.

cc @brancz @s-urbaniak 