### PR TITLE
alerts: make kubelet pod limit a templated const

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -65,14 +65,14 @@
           {
             alert: 'KubeletTooManyPods',
             expr: |||
-              kubelet_running_pod_count{%(kubeletSelector)s} > %(kubeletTooManyPods)s
+              kubelet_running_pod_count{%(kubeletSelector)s} > %(kubeletPodLimit)s * 0.9
             ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of 110.',
+              message: 'Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of %d.' % $._config.kubeletPodLimit,
             },
           },
           {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -38,7 +38,7 @@
     // greater than the amount of the resources in the cluster.  We do however
     // allow you to overcommit if you wish.
     namespaceOvercommitFactor: 1.5,
-    kubeletTooManyPods: 100,
+    kubeletPodLimit: 110,
     certExpirationWarningSeconds: 7 * 24 * 3600,
     certExpirationCriticalSeconds: 1 * 24 * 3600,
 


### PR DESCRIPTION
This commit changes the Kubelet Pod limit of 110 into a
constant that is templated from the `_config` object.

cc @mxinden @metalmatze 

Fixes: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/81#discussion_r215987116