### PR TITLE
Fix memory quota query

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -224,7 +224,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod", container_name!="POD", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container)',
             'sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
             'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod", container_name!=""}) by (container)',
+            'sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod", container!=""}) by (container)',
             'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },


### PR DESCRIPTION
`kube_pod_container_resource_limits_memory_bytes` metric comes from kube-state-metrics which uses `container` as label. 
Neighboring metrics come from cadvisor which uses `container_name`. This lead to error when C&P, looking into group by labels shows discrepancy :P 

@brancz @tomwilkie 