### PR TITLE
Use dashboards uids from _config

### DIFF
--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -5,7 +5,7 @@
   // of the file name and set the timezone to be 'default'.
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
-      uid: std.md5(filename),
+      uid: $._config.grafanaDashboardIDs[filename],
       timezone: '',
     }
     for filename in std.objectFields(grafanaDashboards)

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -158,7 +158,6 @@ local gauge = promgrafonnet.gauge;
       dashboard.new(
         'Nodes',
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(
         {
           current: {

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -75,7 +75,6 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       dashboard.new(
         'Pods',
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['pods.json']),
       ).addTemplate(
         {
           current: {

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,13 +6,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-namespace.json'] },
         },
       };
 
       g.dashboard(
         'K8s / Compute Resources / Cluster',
-        uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       ).addRow(
         (g.row('Headlines') +
          {
@@ -106,13 +105,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'] },
         },
       };
 
       g.dashboard(
         'K8s / Compute Resources / Namespace',
-        uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
         g.row('CPU Usage')
@@ -178,7 +176,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
       g.dashboard(
         'K8s / Compute Resources / Pod',
-        uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')
       .addRow(

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -104,7 +104,6 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       dashboard.new(
         'StatefulSets',
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['statefulset.json']),
       ).addTemplate(
         {
           current: {


### PR DESCRIPTION
After this PR dashboards will start using uid from config.
This adds requirement for kubernetes-mixin dashboards to have uid reserved in `_config.grafanaDashboardIDs`.
This also fixed "Drilling in" for resource dashboards

@brancz @tomwilkie 