### PR TITLE
Set the cluster resource namespace’s memory to correct format

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -146,7 +146,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Memory Usage') +
           g.queryPanel('sum(container_memory_usage_bytes{namespace="$namespace", container_name!=""}) by (pod_name)', '{{pod_name}}') +
-          g.stack,
+          g.stack +
+          { yaxes: g.yaxes('decbytes') },
         )
       )
       .addRow(


### PR DESCRIPTION
It currently only shows 1.42 Bil instead of 1.42 Gi