### PR TITLE
Remove double declaration of KubeAPIErrorsHigh

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -106,7 +106,7 @@
             expr: |||
               sum(rate(apiserver_request_count{%(kubeApiserverSelector)s,code=~"^(?:5..)$"}[5m])) without(instance, %(podLabel)s)
                 /
-              sum(rate(apiserver_request_count{%(kubeApiserverSelector)s}[5m])) without(instance, pod) * 100 > 5
+              sum(rate(apiserver_request_count{%(kubeApiserverSelector)s}[5m])) without(instance, pod) * 100 > 15
             ||| % $._config,
             'for': '10m',
             labels: {


### PR DESCRIPTION
The KubeAPIErrorsHigh was defined two times (only) with different level of severity:

```
$ diff -rN /tmp/warn.txt /tmp/crit.txt
10c10
<               severity: 'warning',
---
>               severity: 'critical',
```
(warn.txt being L119-133, crit.txt L104-118 of `alerts/system_alerts.libsonnet`.) This PR removes the double declaration