### PR TITLE
Use 5 minute range for KubePodCrashLooping message

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -6,13 +6,13 @@
         rules: [
           {
             expr: |||
-              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) > 0
+              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) * 60 * 5 > 0
             ||| % $._config,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / second.',
+              message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.',
             },
             'for': '1h',
             alert: 'KubePodCrashLooping',


### PR DESCRIPTION
As a per second restart rate for a lot of pods is quite small the KubePodCrashLooping message often looks like

```
{{namespace}}/{{pod}} is restarting 0.00 / second
```

As this information gives about no extra value (besides the fact, that its restarting), this PR increases the printed value to a 5-minute rate over the last 15 minutes of data and increases the decimal places to 3.