### PR TITLE
alerts: fix KubeQuotaExceeded potential division by zero

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -77,7 +77,7 @@
             expr: |||
               100 * kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}
                 / ignoring(instance, job, type)
-              kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"}
+              (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
                 > 90
             ||| % $._config,
             'for': '15m',


### PR DESCRIPTION
This fixes an issue with the KubeQuotaExceeded alert when having some hard limit set to 0 (for instance services.loadbalancers set to 0).
The alert was triggering with +Inf or NaN results.