### PR TITLE
Fix node:node_memory_utilisation:ratio rule

### DIFF
--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -12,7 +12,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.queryPanel('node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum / scalar(sum(node:node_num_cpu:sum))', '{{node}}', legendLink) +
+          g.queryPanel('node:cluster_cpu_utilisation:ratio', '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
@@ -27,7 +27,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Memory')
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.queryPanel('node:node_memory_utilisation:ratio', '{{node}}', legendLink) +
+          g.queryPanel('node:cluster_memory_utilisation:ratio', '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -223,7 +223,7 @@
             expr: |||
               (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
               /
-              scalar(sum(node:node_memory_bytes_total:sum))
+              node:node_memory_bytes_total:sum
             |||,
           },
           {

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -146,6 +146,17 @@
             ||| % $._config,
           },
           {
+            // CPU utilisation per node, normalized by cluster-wide CPUs
+            record: 'node:cluster_cpu_utilisation:ratio',
+            expr: |||
+              node:node_cpu_utilisation:avg1m
+                *
+              node:node_num_cpu:sum
+                /
+              scalar(sum(node:node_num_cpu:sum))
+            ||| % $._config,
+          },
+          {
             // CPU saturation is 1min avg run queue length / number of CPUs.
             // Can go over 100%.  >100% is bad.
             record: ':node_cpu_saturation_load1:',
@@ -224,6 +235,15 @@
               (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
               /
               node:node_memory_bytes_total:sum
+            |||,
+          },
+          {
+            // Memory utilisation per node, normalized by cluster-wide memory
+            record: 'node:cluster_memory_utilisation:ratio',
+            expr: |||
+              (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+              /
+              scalar(sum(node:node_memory_bytes_total:sum))
             |||,
           },
           {


### PR DESCRIPTION
Currently the node:node_memory_utilisation:ratio calculates the
node memory usage normalized by the whole cluster memory. This
change fixes the normalization to actually be per node.