### PR TITLE
Reference the pod_name instead of container name

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -101,7 +101,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for {{ $labels.container_name }}.',
+              message: '{{ printf "%0.0f" $value }}% throttling of CPU in namespace {{ $labels.namespace }} for container {{ $labels.container_name }} in pod {{ $labels.pod_name }}.',
             },
           },
         ],


### PR DESCRIPTION
Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>