### PR TITLE
Fix KubePersistentVolumeFullInFourDays again

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -23,11 +23,11 @@
           {
             alert: 'KubePersistentVolumeFullInFourDays',
             expr: |||
-              (
-                kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
+              100 * (
+                kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
                   /
                 kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
-              ) > 0.85
+              ) < 15
               and
               predict_linear(kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}[%(volumeFullPredictionSampleTime)s], 4 * 24 * 3600) < 0
             ||| % $._config,
@@ -36,7 +36,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanize1024 }} is available.',
+              message: 'Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ printf "%0.2f" $value }}% is available.',
             },
           },
         ],

--- a/tests.yaml
+++ b/tests.yaml
@@ -33,7 +33,9 @@ tests:
 - interval: 1m
   input_series:
   - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
-    values: '10240 9216 8192 7168 6144 5120 4096 3072 2048 1024 0'
+    values: '128 64 32 16 8 4 2 1'
+  - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024 1024 1024 1024 1024 1024 1024 1024'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubePersistentVolumeFullInFourDays
@@ -46,5 +48,5 @@ tests:
         persistentvolumeclaim: somepvc
         severity: critical
       exp_annotations:
-        message: 'Based on recent sampling, the PersistentVolume claimed by somepvc in Namespace monitoring is expected to fill up within four days. Currently 4ki is available.'
+        message: 'Based on recent sampling, the PersistentVolume claimed by somepvc in Namespace monitoring is expected to fill up within four days. Currently 0.20% is available.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays


### PR DESCRIPTION
This is the first time our CI found a bug in an alert. :tada: 

It turns out that #101 and #102 are incompatible and the `KubePersistentVolumeFullInFourDays` needs to be fixed.

Instead of using `...used_bytes` is moved to `...available_bytes` to show the percentage of available storage rather than the used percentage.
We cannot show the number of available bytes as we compute the percentage within the alert and thus showing that now in the message.

/cc @brancz 