### PR TITLE
Fix labels, typos

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -166,7 +166,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'CronJob {{ $labels.namespaces }}/{{ $labels.cronjob }} is taking more than 1h to complete.',
+              message: 'CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.',
             },
           },
           {
@@ -179,7 +179,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Job {{ $labels.namespaces }}/{{ $labels.job_name }} is taking more than one hour to complete.',
+              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.',
             },
           },
           {
@@ -192,7 +192,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Job {{ $labels.namespaces }}/{{ $labels.job_name }} failed to complete.',
+              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.',
             },
           },
         ],

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -32,7 +32,7 @@
           },
           {
             alert: 'KubeClientErrors',
-            // Many clients use get requests to check the existance of objects,
+            // Many clients use get requests to check the existence of objects,
             // this is normal and an expected error, therefore it should be
             // ignored in this alert.
             expr: |||
@@ -46,7 +46,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'",
+              message: "Kubernetes API server client '{{ $labels.job_name }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'",
             },
           },
           {
@@ -59,7 +59,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / second.",
+              message: "Kubernetes API server client '{{ $labels.job_name }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / second.",
             },
           },
           {

--- a/runbook.md
+++ b/runbook.md
@@ -55,19 +55,19 @@ This page collects this repositories alerts and begins the process of describing
 + *Severity*: warning
 
 ##### Alert Name: "KubeCronJobRunning"
-+ *Message*: `CronJob {{ $labels.namespaces }}/{{ $labels.cronjob }} is taking more than 1h to complete.`
++ *Message*: `CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.`
 + *Severity*: warning
-+ *Action*: Check the cronjob using `kubectl decribe cronjob <cronjob>` and look at the pod logs using `kubectl logs <pod>` for further information.
++ *Action*: Check the cronjob using `kubectl describe cronjob <cronjob>` and look at the pod logs using `kubectl logs <pod>` for further information.
 
 ##### Alert Name: "KubeJobCompletion"
-+ *Message*: `Job {{ $labels.namespaces }}/{{ $labels.job }} is taking more than 1h to complete.`
++ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 1h to complete.`
 + *Severity*: warning
-+ *Action*: Check the job using `kubectl decribe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
++ *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
 
 ##### Alert Name: "KubeJobFailed"
-+ *Message*: `Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete.`
++ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.`
 + *Severity*: warning
-+ *Action*: Check the job using `kubectl decribe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
++ *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
 
 ### Group Name: "kubernetes-resources"
 ##### Alert Name: "KubeCPUOvercommit"
@@ -100,10 +100,10 @@ This page collects this repositories alerts and begins the process of describing
 + *Message*: `There are {{ $value }} different versions of Kubernetes components running.`
 + *Severity*: warning
 ##### Alert Name: "KubeClientErrors"
-+ *Message*: `Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'`
++ *Message*: `Kubernetes API server client '{{ $labels.job_name }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'`
 + *Severity*: warning
 ##### Alert Name: "KubeClientErrors"
-+ *Message*: `Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / sec.'`
++ *Message*: `Kubernetes API server client '{{ $labels.job_name }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / sec.'`
 + *Severity*: warning
 ##### Alert Name: "KubeletTooManyPods"
 + *Message*: `Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of 110.`


### PR DESCRIPTION
Fixes https://github.com/helm/charts/issues/9034 and allows (replaces?) https://github.com/coreos/prometheus-operator/pull/2096.
Replacements list:
```
{{ $labels.job }} -> {{ $labels. job_name }}
{{ $labels.namespaces }} -> {{ $labels.namespace }}
```

---

It fixes following condition:
Labels set for alert:
```
alertname="KubeJobCompletion"
endpoint="http"
instance="10.36.1.129:8080"
job="kube-state-metrics"
job_name="some_job-1537981200"
namespace="dev-env"
pod="prometheus-kube-state-metrics-69db7f65dc-t7nz9"
service="prometheus-kube-state-metrics"
severity="warning"
```
Alert annotation:
```
message
    Job /kube-state-metrics is taking more than one hour to complete.
```
**What you expected to happen**:
Alert annotation:
```
message
    Job dev-env/some_job-1537981200 is taking more than one hour to complete.
```