### PR TITLE
Fix Usage per Core panel in Node dashboard

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -30,7 +30,7 @@ local gauge = promgrafonnet.gauge;
           span=6,
           format='percentunit',
         )
-        .addTarget(prometheus.target('avg by (cpu) (irate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle", instance="$instance"}[5m])) * 100' % $._config, legendFormat='{{cpu}}'));
+        .addTarget(prometheus.target('sum by (cpu) (irate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, legendFormat='{{cpu}}'));
 
       local memoryGraph =
         graphPanel.new(


### PR DESCRIPTION
Currently the `node_cpu_seconds_total` metric values are averaged per cpu core. As the labels are `app controller_revision_hash cpu instance job mode namespace pod pod_template_generation` (especially `cpu` and `mode`) the `avg by(cpu)` will calculate the average by all modes (and multiply it by 100, which is also wrong as the dashboard is percentage in 0-1 syntax).
This PR fixes the graph  