### PR TITLE
alerts: add optional selector for CPUThrottlingHigh

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -91,9 +91,9 @@
           {
             alert: 'CPUThrottlingHigh',
             expr: |||
-              100 * sum(increase(container_cpu_cfs_throttled_periods_total[5m])) by (container_name, pod_name, namespace) 
+              100 * sum(increase(container_cpu_cfs_throttled_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container_name, pod_name, namespace) 
                 / 
-              sum(increase(container_cpu_cfs_periods_total[5m])) by (container_name, pod_name, namespace)
+              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container_name, pod_name, namespace)
                 > %(cpuThrottlingPercent)s 
             ||| % $._config,
             'for': '15m',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -42,6 +42,7 @@
     certExpirationWarningSeconds: 7 * 24 * 3600,
     certExpirationCriticalSeconds: 1 * 24 * 3600,
     cpuThrottlingPercent: 25,
+    cpuThrottlingSelector: '',
 
     // We alert when a disk is expected to fill up in four days. Depending on
     // the data-set it might be useful to change the sampling-time for the


### PR DESCRIPTION
This PR adds an optional selector used for the CPUThrottlingHigh alert.
The selector can be used to disable the alert on some noisy namespaces.