### PR TITLE
Only trigger KubeClientErrors on 5xx status codes

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -36,7 +36,7 @@
             // this is normal and an expected error, therefore it should be
             // ignored in this alert.
             expr: |||
-              (sum(rate(rest_client_requests_total{code!~"2..|404"}[5m])) by (instance, job)
+              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
                 /
               sum(rate(rest_client_requests_total[5m])) by (instance, job))
               * 100 > 1


### PR DESCRIPTION
IMHO deploying a misconfigured workload is not an indication of the clusters health, hence exclude all 4XX errors