### PR TITLE
Alert directly on containers for CPUThrottlingHigh alert

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -91,8 +91,8 @@
           {
             alert: 'CPUThrottlingHigh',
             expr: |||
-              100 * sum(increase(container_cpu_cfs_throttled_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container_name, pod_name, namespace) 
-                / 
+              100 * sum(increase(container_cpu_cfs_throttled_periods_total{container_name!="", %(cpuThrottlingSelector)s}[5m])) by (container_name, pod_name, namespace)
+                /
               sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container_name, pod_name, namespace)
                 > %(cpuThrottlingPercent)s 
             ||| % $._config,


### PR DESCRIPTION
The CPUThrottlingHigh alert currently fires on pod and container level. That means that if a container gets throtteled we not only alert on the alert but also on the pod.
As we always have the container available, we should simply alert on the container directly and exclusively, by filtering to `container_name!=""` in the expression.
Furthermore is the message for this alert written so that it uses `{{  $labels.container_name }}`. For the pod level alert we don't have these values and thus the message is broken.

Here's both levels of alerts:
![all](https://user-images.githubusercontent.com/872251/51384672-4eb50b00-1b1d-11e9-8f13-4d843ddb0b2a.png)

Here's only the container directly:
![onlycontainers](https://user-images.githubusercontent.com/872251/51384685-583e7300-1b1d-11e9-9e13-54ff5a882451.png)


