### PR TITLE
Update certificate expiration alert message

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -140,7 +140,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Kubernetes API certificate is expiring in less than %d days.' % ($._config.certExpirationWarningSeconds / 3600 / 24),
+              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %d days.' % ($._config.certExpirationWarningSeconds / 3600 / 24),
             },
           },
           {
@@ -152,7 +152,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Kubernetes API certificate is expiring in less than %d hours.' % ($._config.certExpirationCriticalSeconds / 3600),
+              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %d hours.' % ($._config.certExpirationCriticalSeconds / 3600),
             },
           },
         ],


### PR DESCRIPTION
Update the `KubeClientCertificateExpiration` alert description to more
accurately reflect the meaning of the metric. This metric is used to
observe the expiration of client certificates used for authentication,
and in this case, for authentication to the apiserver. It does not mean
that the apiserver's server certificate is expiring which can be implied
by the existing message.

I initially requested the change in https://github.com/coreos/prometheus-operator/pull/2058, but was referred here. Also submitted a request to the helm chart https://github.com/helm/charts/pull/10840

Reference: https://github.com/kubernetes/kubernetes/pull/50387