### PR TITLE
use shared prefix for all dashboard names

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ TODO
 ## Customising the mixin
 
 Kubernetes-mixin allows you to override the selectors used for various jobs,
-to match those used in your Prometheus set.
+to match those used in your Prometheus set. You can also customize the dashboard
+names and add grafana tags.
 
 In a new directory, add a file `mixin.libsonnet`:
 
@@ -119,6 +120,8 @@ kubernetes {
     cadvisorSelector: 'job="kubernetes-cadvisor"',
     nodeExporterSelector: 'job="kubernetes-node-exporter"',
     kubeletSelector: 'job="kubernetes-kubelet"',
+    grafanaDashboardNamePrefix: 'Mixin / ',
+    grafanaDashboardTags: ['kubernetes', 'infrastucture'],
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ kubernetes {
     cadvisorSelector: 'job="kubernetes-cadvisor"',
     nodeExporterSelector: 'job="kubernetes-node-exporter"',
     kubeletSelector: 'job="kubernetes-kubelet"',
-    grafanaDashboardNamePrefix: 'Mixin / ',
-    grafanaDashboardTags: ['kubernetes', 'infrastucture'],
+    grafanaK8s.dashboardNamePrefix: 'Mixin / ',
+    grafanaK8s.dashboardTags: ['kubernetes', 'infrastucture'],
   },
 }
 ```

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -35,6 +35,7 @@
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
     grafanaDashboardNamePrefix : "K8s / ",
+    grafanaDashboardTags: ["kubernetes-mixin"],
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -34,6 +34,7 @@
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
+    grafanaDashboardNamePrefix : "K8s / ",
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -34,7 +34,7 @@
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
-    grafanaDashboardNamePrefix : "K8s / ",
+    grafanaDashboardNamePrefix : "Kubernetes / ",
     grafanaDashboardTags: ["kubernetes-mixin"],
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -34,8 +34,16 @@
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
-    grafanaDashboardNamePrefix : "Kubernetes / ",
-    grafanaDashboardTags: ["kubernetes-mixin"],
+
+    // Config for the Grafana dashboards in the Kubernetes Mixin
+    grafanaK8s :{
+      dashboardNamePrefix : "Kubernetes / ",
+      dashboardTags: ["kubernetes-mixin"],
+
+      // For links between grafana dashboards, you need to tell us if your grafana
+      // servers under some non-root path.
+      linkPrefix: '',
+    },
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however
@@ -52,9 +60,6 @@
     // prediction
     volumeFullPredictionSampleTime: '6h',
 
-    // For links between grafana dashboards, you need to tell us if your grafana
-    // servers under some non-root path.
-    grafanaPrefix: '',
 
     // This list of filesystem is referenced in various expressions.
     fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -187,7 +187,7 @@ local gauge = promgrafonnet.gauge;
       ).withLowerBeingBetter();
 
       dashboard.new(
-        'Nodes',
+        '%(grafanaDashboardNamePrefix)sNodes' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -190,6 +190,7 @@ local gauge = promgrafonnet.gauge;
         '%(grafanaDashboardNamePrefix)sNodes' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -187,10 +187,10 @@ local gauge = promgrafonnet.gauge;
       ).withLowerBeingBetter();
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)sNodes' % $._config,
+        '%(dashboardNamePrefix)sNodes' % $._config.grafanaK8s,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
-        tags=($._config.grafanaDashboardTags),
+        tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -60,7 +60,7 @@ local gauge = promgrafonnet.gauge;
       ));
 
       dashboard.new(
-        'Persistent Volumes',
+        '%(grafanaDashboardNamePrefix)sPersistent Volumes' % $._config,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -60,10 +60,10 @@ local gauge = promgrafonnet.gauge;
       ));
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)sPersistent Volumes' % $._config,
+        '%(dashboardNamePrefix)sPersistent Volumes' % $._config.grafanaK8s,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
-        tags=($._config.grafanaDashboardTags),
+        tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -63,6 +63,7 @@ local gauge = promgrafonnet.gauge;
         '%(grafanaDashboardNamePrefix)sPersistent Volumes' % $._config,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -73,10 +73,10 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       );
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)sPods' % $._config,
+        '%(dashboardNamePrefix)sPods' % $._config.grafanaK8s,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
-        tags=($._config.grafanaDashboardTags),
+        tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -73,7 +73,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       );
 
       dashboard.new(
-        'Pods',
+        '%(grafanaDashboardNamePrefix)sPods' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
       ).addTemplate(

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -76,6 +76,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         '%(grafanaDashboardNamePrefix)sPods' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -100,7 +100,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-resources-namespace.json':
       local tableStyles = {
@@ -168,7 +168,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-resources-pod.json':
       local tableStyles = {
@@ -235,6 +235,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
   },
 }

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,12 +6,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
         },
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)sCompute Resources / Cluster' % $._config,
+        '%(dashboardNamePrefix)sCompute Resources / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       ).addRow(
         (g.row('Headlines') +
@@ -100,18 +100,18 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      )+{ tags: $._config.grafanaDashboardTags },
+      )+{ tags: $._config.grafanaK8s.dashboardTags },
 
     'k8s-resources-namespace.json':
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)sCompute Resources / Namespace' % $._config,
+        '%(dashboardNamePrefix)sCompute Resources / Namespace' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
@@ -168,7 +168,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      )+{ tags: $._config.grafanaDashboardTags },
+      )+{ tags: $._config.grafanaK8s.dashboardTags },
 
     'k8s-resources-pod.json':
       local tableStyles = {
@@ -178,7 +178,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)sCompute Resources / Pod' % $._config,
+        '%(dashboardNamePrefix)sCompute Resources / Pod' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')
@@ -235,6 +235,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      )+{ tags: $._config.grafanaDashboardTags },
+      )+{ tags: $._config.grafanaK8s.dashboardTags },
   },
 }

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -11,7 +11,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Cluster',
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       ).addRow(
         (g.row('Headlines') +
@@ -111,7 +111,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Namespace',
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Namespace' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
@@ -178,7 +178,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Pod',
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Pod' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -105,6 +105,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         '%(grafanaDashboardNamePrefix)sStatefulSets' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -102,10 +102,10 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         .addPanel(replicasGraph);
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)sStatefulSets' % $._config,
+        '%(dashboardNamePrefix)sStatefulSets' % $._config.grafanaK8s,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
-        tags=($._config.grafanaDashboardTags),
+        tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -102,7 +102,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         .addPanel(replicasGraph);
 
       dashboard.new(
-        'StatefulSets',
+        '%(grafanaDashboardNamePrefix)sStatefulSets' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
       ).addTemplate(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -3,10 +3,10 @@ local g = import 'grafana-builder/grafana.libsonnet';
 {
   grafanaDashboards+:: {
     'k8s-cluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)sUSE Method / Cluster' % $._config,
+        '%(dashboardNamePrefix)sUSE Method / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
       ).addRow(
         g.row('CPU')
@@ -84,11 +84,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),
-      )+{ tags: $._config.grafanaDashboardTags },
+      )+{ tags: $._config.grafanaK8s.dashboardTags },
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)sUSE Method / Node' % $._config,
+        '%(dashboardNamePrefix)sUSE Method / Node' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
       ).addTemplate('node', 'kube_node_info', 'node')
       .addRow(
@@ -156,6 +156,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
-      )+{ tags: $._config.grafanaDashboardTags },
+      )+{ tags: $._config.grafanaK8s.dashboardTags },
   },
 }

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -6,7 +6,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
       g.dashboard(
-        'K8s / USE Method / Cluster',
+        '%(grafanaDashboardNamePrefix)sUSE Method / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
       ).addRow(
         g.row('CPU')
@@ -88,7 +88,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
-        'K8s / USE Method / Node',
+        '%(grafanaDashboardNamePrefix)sUSE Method / Node' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
       ).addTemplate('node', 'kube_node_info', 'node')
       .addRow(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -84,7 +84,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
@@ -156,6 +156,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
   },
 }


### PR DESCRIPTION
This way people can tell which all dashboards came from the mixin as opposed to their other internally-developed dashboards

* allow prefix to be empty string