### PR TITLE
Split network panels on node dashboard out by device.

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -147,8 +147,9 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
           span=6,
           format='bytes',
+          stack=true,
         )
-        .addTarget(prometheus.target('max(rate(node_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
+        .addTarget(prometheus.target('rate(node_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m])' % $._config, legendFormat='{{device}}'));
 
       local networkTransmitted =
         graphPanel.new(
@@ -156,8 +157,9 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
           span=6,
           format='bytes',
+          stack=true,
         )
-        .addTarget(prometheus.target('max(rate(node_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
+        .addTarget(prometheus.target('rate(node_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m])' % $._config, legendFormat='{{device}}'));
 
       local inodesGraph =
         graphPanel.new(


### PR DESCRIPTION
 This involves removing max from the associated queries. The max in the existing queries is hiding some information. [Discussion in slack](https://kubernetes.slack.com/archives/CAX9GU941/p1548439002093700).