### PR TITLE
Workload dashboards

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.7
 RUN apk --no-cache add alpine-sdk git openssl-dev
 
 RUN git clone https://github.com/google/jsonnet && \
-    git  -C jsonnet checkout v0.10.0 && \
+    git  -C jsonnet checkout v0.12.1 && \
     make -C jsonnet LDFLAGS=-static
 
 FROM circleci/golang:1.10.3-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: tomwilkie/kubernetes-mixin-build:dont-commit-binary
+      - image: csmarchbanks/kubernetes-mixin-build:jsonnet-0.12.1
 
     working_directory: /go/src/github.com/kubernetes-monitoring/kubernetes-mixin
     steps:

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,84 +1,86 @@
 {
-  _config+:: {
-    // Selectors are inserted between {} in Prometheus queries.
-    cadvisorSelector: 'job="cadvisor"',
-    kubeletSelector: 'job="kubelet"',
-    kubeStateMetricsSelector: 'job="kube-state-metrics"',
-    nodeExporterSelector: 'job="node-exporter"',
-    notKubeDnsSelector: 'job!="kube-dns"',
-    kubeSchedulerSelector: 'job="kube-scheduler"',
-    kubeControllerManagerSelector: 'job="kube-controller-manager"',
-    kubeApiserverSelector: 'job="kube-apiserver"',
-    podLabel: 'pod',
-    namespaceSelector: null,
-    prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
-    hostNetworkInterfaceSelector: 'device!~"veth.+"',
-    hostMountpointSelector: 'mountpoint="/"',
-    wmiExporterSelector: 'job="wmi-exporter"',
+    _config+:: {
+        // Selectors are inserted between {} in Prometheus queries.
+        cadvisorSelector: 'job="cadvisor"',
+        kubeletSelector: 'job="kubelet"',
+        kubeStateMetricsSelector: 'job="kube-state-metrics"',
+        nodeExporterSelector: 'job="node-exporter"',
+        notKubeDnsSelector: 'job!="kube-dns"',
+        kubeSchedulerSelector: 'job="kube-scheduler"',
+        kubeControllerManagerSelector: 'job="kube-controller-manager"',
+        kubeApiserverSelector: 'job="kube-apiserver"',
+        podLabel: 'pod',
+        namespaceSelector: null,
+        prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
+        hostNetworkInterfaceSelector: 'device!~"veth.+"',
+        hostMountpointSelector: 'mountpoint="/"',
+        wmiExporterSelector: 'job="wmi-exporter"',
 
-    // We build alerts for the presence of all these jobs.
-    jobs: {
-      Kubelet: $._config.kubeletSelector,
-      KubeScheduler: $._config.kubeSchedulerSelector,
-      KubeControllerManager: $._config.kubeControllerManagerSelector,
-      KubeAPI: $._config.kubeApiserverSelector,
+        // We build alerts for the presence of all these jobs.
+        jobs: {
+            Kubelet: $._config.kubeletSelector,
+            KubeScheduler: $._config.kubeSchedulerSelector,
+            KubeControllerManager: $._config.kubeControllerManagerSelector,
+            KubeAPI: $._config.kubeApiserverSelector,
+        },
+
+        // Grafana dashboard IDs are necessary for stable links for dashboards
+        grafanaDashboardIDs: {
+            'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
+            'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
+            'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
+            'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
+            'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
+            'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
+            'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
+            'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
+            'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
+            'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
+            'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
+            'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
+            'k8s-resources-windows-pod.json': '40597a704a610e936dc6ed374a7ce023',
+            'k8s-windows-cluster-rsrc-use.json': '53a43377ec9aaf2ff64dfc7a1f539334',
+            'k8s-windows-node-rsrc-use.json': '96e7484b0bb53b74fbc2bcb7723cd40b',
+            'k8s-resources-workloads-namespace.json': 'L29WgMrccBDauPs3Xsti3fwaKjMB6fReufWj6Gl1',
+            'k8s-resources-workload.json': 'hZCNbUPfUqjc95N3iumVsaEVHXzaBr3IFKRFvUJf',
+        },
+
+        // Config for the Grafana dashboards in the Kubernetes Mixin
+        grafanaK8s: {
+            dashboardNamePrefix: 'Kubernetes / ',
+            dashboardTags: ['kubernetes-mixin'],
+
+            // For links between grafana dashboards, you need to tell us if your grafana
+            // servers under some non-root path.
+            linkPrefix: '',
+        },
+
+        // We alert when the aggregate (CPU, Memory) quota for all namespaces is
+        // greater than the amount of the resources in the cluster.  We do however
+        // allow you to overcommit if you wish.
+        namespaceOvercommitFactor: 1.5,
+        kubeletPodLimit: 110,
+        certExpirationWarningSeconds: 7 * 24 * 3600,
+        certExpirationCriticalSeconds: 1 * 24 * 3600,
+        cpuThrottlingPercent: 25,
+        cpuThrottlingSelector: '',
+
+        // We alert when a disk is expected to fill up in four days. Depending on
+        // the data-set it might be useful to change the sampling-time for the
+        // prediction
+        volumeFullPredictionSampleTime: '6h',
+
+
+        // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
+        showMultiCluster: false,
+        clusterLabel: 'cluster',
+
+        // This list of filesystem is referenced in various expressions.
+        fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
+        fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
+
+        // This list of disk device names is referenced in various expressions.
+        diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
+        diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
     },
-
-    // Grafana dashboard IDs are necessary for stable links for dashboards
-    grafanaDashboardIDs: {
-      'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
-      'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
-      'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
-      'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
-      'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
-      'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
-      'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
-      'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
-      'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
-      'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
-      'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
-      'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
-      'k8s-resources-windows-pod.json': '40597a704a610e936dc6ed374a7ce023',
-      'k8s-windows-cluster-rsrc-use.json': '53a43377ec9aaf2ff64dfc7a1f539334',
-      'k8s-windows-node-rsrc-use.json': '96e7484b0bb53b74fbc2bcb7723cd40b',
-    },
-
-    // Config for the Grafana dashboards in the Kubernetes Mixin
-    grafanaK8s: {
-      dashboardNamePrefix: 'Kubernetes / ',
-      dashboardTags: ['kubernetes-mixin'],
-
-      // For links between grafana dashboards, you need to tell us if your grafana
-      // servers under some non-root path.
-      linkPrefix: '',
-    },
-
-    // We alert when the aggregate (CPU, Memory) quota for all namespaces is
-    // greater than the amount of the resources in the cluster.  We do however
-    // allow you to overcommit if you wish.
-    namespaceOvercommitFactor: 1.5,
-    kubeletPodLimit: 110,
-    certExpirationWarningSeconds: 7 * 24 * 3600,
-    certExpirationCriticalSeconds: 1 * 24 * 3600,
-    cpuThrottlingPercent: 25,
-    cpuThrottlingSelector: '',
-
-    // We alert when a disk is expected to fill up in four days. Depending on
-    // the data-set it might be useful to change the sampling-time for the
-    // prediction
-    volumeFullPredictionSampleTime: '6h',
-
-
-    // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
-    showMultiCluster: false,
-    clusterLabel: 'cluster',
-
-    // This list of filesystem is referenced in various expressions.
-    fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
-    fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
-
-    // This list of disk device names is referenced in various expressions.
-    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
-    diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
-  },
 }

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,86 +1,86 @@
 {
-    _config+:: {
-        // Selectors are inserted between {} in Prometheus queries.
-        cadvisorSelector: 'job="cadvisor"',
-        kubeletSelector: 'job="kubelet"',
-        kubeStateMetricsSelector: 'job="kube-state-metrics"',
-        nodeExporterSelector: 'job="node-exporter"',
-        notKubeDnsSelector: 'job!="kube-dns"',
-        kubeSchedulerSelector: 'job="kube-scheduler"',
-        kubeControllerManagerSelector: 'job="kube-controller-manager"',
-        kubeApiserverSelector: 'job="kube-apiserver"',
-        podLabel: 'pod',
-        namespaceSelector: null,
-        prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
-        hostNetworkInterfaceSelector: 'device!~"veth.+"',
-        hostMountpointSelector: 'mountpoint="/"',
-        wmiExporterSelector: 'job="wmi-exporter"',
+  _config+:: {
+    // Selectors are inserted between {} in Prometheus queries.
+    cadvisorSelector: 'job="cadvisor"',
+    kubeletSelector: 'job="kubelet"',
+    kubeStateMetricsSelector: 'job="kube-state-metrics"',
+    nodeExporterSelector: 'job="node-exporter"',
+    notKubeDnsSelector: 'job!="kube-dns"',
+    kubeSchedulerSelector: 'job="kube-scheduler"',
+    kubeControllerManagerSelector: 'job="kube-controller-manager"',
+    kubeApiserverSelector: 'job="kube-apiserver"',
+    podLabel: 'pod',
+    namespaceSelector: null,
+    prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
+    hostNetworkInterfaceSelector: 'device!~"veth.+"',
+    hostMountpointSelector: 'mountpoint="/"',
+    wmiExporterSelector: 'job="wmi-exporter"',
 
-        // We build alerts for the presence of all these jobs.
-        jobs: {
-            Kubelet: $._config.kubeletSelector,
-            KubeScheduler: $._config.kubeSchedulerSelector,
-            KubeControllerManager: $._config.kubeControllerManagerSelector,
-            KubeAPI: $._config.kubeApiserverSelector,
-        },
-
-        // Grafana dashboard IDs are necessary for stable links for dashboards
-        grafanaDashboardIDs: {
-            'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
-            'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
-            'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
-            'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
-            'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
-            'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
-            'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
-            'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
-            'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
-            'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
-            'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
-            'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
-            'k8s-resources-windows-pod.json': '40597a704a610e936dc6ed374a7ce023',
-            'k8s-windows-cluster-rsrc-use.json': '53a43377ec9aaf2ff64dfc7a1f539334',
-            'k8s-windows-node-rsrc-use.json': '96e7484b0bb53b74fbc2bcb7723cd40b',
-            'k8s-resources-workloads-namespace.json': 'L29WgMrccBDauPs3Xsti3fwaKjMB6fReufWj6Gl1',
-            'k8s-resources-workload.json': 'hZCNbUPfUqjc95N3iumVsaEVHXzaBr3IFKRFvUJf',
-        },
-
-        // Config for the Grafana dashboards in the Kubernetes Mixin
-        grafanaK8s: {
-            dashboardNamePrefix: 'Kubernetes / ',
-            dashboardTags: ['kubernetes-mixin'],
-
-            // For links between grafana dashboards, you need to tell us if your grafana
-            // servers under some non-root path.
-            linkPrefix: '',
-        },
-
-        // We alert when the aggregate (CPU, Memory) quota for all namespaces is
-        // greater than the amount of the resources in the cluster.  We do however
-        // allow you to overcommit if you wish.
-        namespaceOvercommitFactor: 1.5,
-        kubeletPodLimit: 110,
-        certExpirationWarningSeconds: 7 * 24 * 3600,
-        certExpirationCriticalSeconds: 1 * 24 * 3600,
-        cpuThrottlingPercent: 25,
-        cpuThrottlingSelector: '',
-
-        // We alert when a disk is expected to fill up in four days. Depending on
-        // the data-set it might be useful to change the sampling-time for the
-        // prediction
-        volumeFullPredictionSampleTime: '6h',
-
-
-        // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
-        showMultiCluster: false,
-        clusterLabel: 'cluster',
-
-        // This list of filesystem is referenced in various expressions.
-        fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
-        fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
-
-        // This list of disk device names is referenced in various expressions.
-        diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
-        diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+    // We build alerts for the presence of all these jobs.
+    jobs: {
+      Kubelet: $._config.kubeletSelector,
+      KubeScheduler: $._config.kubeSchedulerSelector,
+      KubeControllerManager: $._config.kubeControllerManagerSelector,
+      KubeAPI: $._config.kubeApiserverSelector,
     },
+
+    // Grafana dashboard IDs are necessary for stable links for dashboards
+    grafanaDashboardIDs: {
+      'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
+      'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
+      'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
+      'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
+      'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
+      'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
+      'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
+      'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
+      'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
+      'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
+      'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
+      'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
+      'k8s-resources-windows-pod.json': '40597a704a610e936dc6ed374a7ce023',
+      'k8s-windows-cluster-rsrc-use.json': '53a43377ec9aaf2ff64dfc7a1f539334',
+      'k8s-windows-node-rsrc-use.json': '96e7484b0bb53b74fbc2bcb7723cd40b',
+      'k8s-resources-workloads-namespace.json': 'L29WgMrccBDauPs3Xsti3fwaKjMB6fReufWj6Gl1',
+      'k8s-resources-workload.json': 'hZCNbUPfUqjc95N3iumVsaEVHXzaBr3IFKRFvUJf',
+    },
+
+    // Config for the Grafana dashboards in the Kubernetes Mixin
+    grafanaK8s: {
+      dashboardNamePrefix: 'Kubernetes / ',
+      dashboardTags: ['kubernetes-mixin'],
+
+      // For links between grafana dashboards, you need to tell us if your grafana
+      // servers under some non-root path.
+      linkPrefix: '',
+    },
+
+    // We alert when the aggregate (CPU, Memory) quota for all namespaces is
+    // greater than the amount of the resources in the cluster.  We do however
+    // allow you to overcommit if you wish.
+    namespaceOvercommitFactor: 1.5,
+    kubeletPodLimit: 110,
+    certExpirationWarningSeconds: 7 * 24 * 3600,
+    certExpirationCriticalSeconds: 1 * 24 * 3600,
+    cpuThrottlingPercent: 25,
+    cpuThrottlingSelector: '',
+
+    // We alert when a disk is expected to fill up in four days. Depending on
+    // the data-set it might be useful to change the sampling-time for the
+    // prediction
+    volumeFullPredictionSampleTime: '6h',
+
+
+    // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
+    showMultiCluster: false,
+    clusterLabel: 'cluster',
+
+    // This list of filesystem is referenced in various expressions.
+    fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
+    fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
+
+    // This list of disk device names is referenced in various expressions.
+    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
+    diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+  },
 }

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -283,7 +283,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #F': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      ) + { tags: $._config.grafanaK8s.dashboardTags },
 
     'k8s-resources-workload.json':
       local tableStyles = {
@@ -383,7 +383,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      ) + { tags: $._config.grafanaK8s.dashboardTags },
 
     'k8s-resources-pod.json':
       local tableStyles = {

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -183,7 +183,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
         },
         workload_type: {
           alias: 'Workload Type',
@@ -221,7 +221,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu_cores', 'memory_bytes');
 
       g.dashboard(
-        'K8s / Compute Resources / Workloads by Namespace',
+        '%(dashboardNamePrefix)sCompute Resources / Workloads by Namespace' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
       ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
@@ -260,7 +260,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Memory Usage') +
           g.queryPanel(memUsageQuery, '{{workload}}') +
           g.stack +
-          { yaxes: g.yaxes('decbytes') },
+          { yaxes: g.yaxes('bytes') },
         )
       )
       .addRow(
@@ -276,10 +276,10 @@ local g = import 'grafana-builder/grafana.libsonnet';
             memUsageQuery + '/' + memLimitsQuery,
           ], tableStyles {
             'Value #A': { alias: 'Running Pods', decimals: 0 },
-            'Value #B': { alias: 'Memory Usage', unit: 'decbytes' },
-            'Value #C': { alias: 'Memory Requests', unit: 'decbytes' },
+            'Value #B': { alias: 'Memory Usage', unit: 'bytes' },
+            'Value #C': { alias: 'Memory Requests', unit: 'bytes' },
             'Value #D': { alias: 'Memory Requests %', unit: 'percentunit' },
-            'Value #E': { alias: 'Memory Limits', unit: 'decbytes' },
+            'Value #E': { alias: 'Memory Limits', unit: 'bytes' },
             'Value #F': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
@@ -289,8 +289,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
-        }
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+        },
       };
 
       local cpuUsageQuery = |||
@@ -323,7 +323,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu_cores', 'memory_bytes');
 
       g.dashboard(
-        'K8s / Compute Resources / Workload',
+        '%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workload.json']),
       ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
@@ -361,7 +361,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Memory Usage') +
           g.queryPanel(memUsageQuery, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('decbytes') },
+          { yaxes: g.yaxes('bytes') },
         )
       )
       .addRow(
@@ -375,10 +375,10 @@ local g = import 'grafana-builder/grafana.libsonnet';
             memLimitsQuery,
             memUsageQuery + '/' + memLimitsQuery,
           ], tableStyles {
-            'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
-            'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
+            'Value #A': { alias: 'Memory Usage', unit: 'bytes' },
+            'Value #B': { alias: 'Memory Requests', unit: 'bytes' },
             'Value #C': { alias: 'Memory Requests %', unit: 'percentunit' },
-            'Value #D': { alias: 'Memory Limits', unit: 'decbytes' },
+            'Value #D': { alias: 'Memory Limits', unit: 'bytes' },
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
@@ -544,7 +544,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Memory Usage (w/o cache)') +
           // Not using container_memory_usage_bytes here because that includes page cache
           g.queryPanel('sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes('decbytes') },
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('bytes') },
         )
       )
       .addRow(

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -76,7 +76,7 @@
                   label_replace(
                     kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet"},
                     "replicaset", "$1", "owner_name", "(.*)"
-                  ) * on(replicaset) group_left(owner_name) kube_replicaset_owner{%(kubeStateMetricsSelector)s},
+                  ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{%(kubeStateMetricsSelector)s},
                   "workload", "$1", "owner_name", "(.*)"
                 )
               ) by (namespace, workload, pod)


### PR DESCRIPTION
Add Views to look at Workloads. The idea of a Workload is an abstraction between a Namespace and 
a Pod, generally what is in a Deployment/StatefulSet/DaemonSet. The problem with the current `Compute Resources / Namespace` dashboard is that in a namespace with lots of Pods it becomes useless due to the amount of pods on single graphs or in one table. The Workload abstraction allows you to reason about the general types running in that namespace easily, and drill down to a single misbehaving service.

Two new dashboards are added:
* `Compute Resources / Workloads by Namespace` - A view of all the Workloads in a namespace. You can drill down to the single workload level.
* `Compute Resources / Workload` - A view of all the pods in a Workload. You can drill down to the Pod dashboard.

Eventually you can imagine a hierarchy from Cluster > Namespace By Workload > Workload > Pod if this workload abstraction is found to be useful. For now I wanted these as adjacent dashboards so that people could try them out and give me feedback.

Right now the only included Workloads are deployments, daemonsets, and statefulsets. I have found these to be the most common/useful workloads that are deployed (others being ReplicaSets without belonging to a deployment, Jobs, and Cron Jobs).

Screenshots:
![workloads_by_namespace](https://user-images.githubusercontent.com/3280472/52013376-1bb63400-249a-11e9-83cd-d62dc1e3d739.png)
![workload](https://user-images.githubusercontent.com/3280472/52013396-35577b80-249a-11e9-8ad0-dc079469a788.png)
