### PR TITLE
Count overcommit memory only for pods in Pending or Running status

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -51,7 +51,7 @@
             record: 'namespace_name:kube_pod_container_resource_requests_memory_bytes:sum',
             expr: |||
               sum by (namespace, label_name) (
-                sum(kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s}) by (namespace, pod)
+                sum(kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
               * on (namespace, pod) group_left(label_name)
                 label_replace(kube_pod_labels{%(kubeStateMetricsSelector)s}, "pod_name", "$1", "pod", "(.*)")
               )


### PR DESCRIPTION
In our cluster we have a bunch of cron jobs. Currently, with the existing query, it appears to be counting the pods that are already completed or failed.

As far as I understood, I believe the overcommit should count only the pods in Pending or Running state.

This change should be applied to the line 64, where it counts the CPU overcommit. It was changed in the PR #18.

I did not change them all because I wan't to check where this is a valid change or not, since it is not very clear to me and my colleagues.