### PR TITLE
Improve hostNetworkSelector by excluding the ones we don't want

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -12,7 +12,7 @@
     podLabel: 'pod',
     namespaceSelector: null,
     prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
-    hostNetworkInterfaceSelector: 'device="eth0"',
+    hostNetworkInterfaceSelector: 'device!~"veth.+"',
     hostMountpointSelector: 'mountpoint="/"',
 
     // We build alerts for the presence of all these jobs.


### PR DESCRIPTION
Instead of selecting specific interfaces and try to match as much as possible, we should rather exclude the we don't want to include.

This was fixed downstream for us and we want to contribute it upstream: https://github.com/openshift/cluster-monitoring-operator/pull/226

/cc @brancz @tomwilkie 