### PR TITLE
Override all tooltips to have single values

### DIFF
--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -7,6 +7,22 @@
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
       timezone: '',
+
+      // Modify tooltip to only show a single value
+      rows: [
+        row {
+          panels: [
+            panel {
+              tooltip+: {
+                shared: false,
+              },
+            }
+            for panel in super.panels
+          ],
+        }
+        for row in super.rows
+      ],
+
     }
     for filename in std.objectFields(grafanaDashboards)
   },


### PR DESCRIPTION
When having a lot of namespaces in the cluster dashboard the tooltip becomes to big and the user might not be able to see the most interesting value.

Therefore we override all dashboard tooltips to only show the single value that the cursor currently hovers.

Previously:
![all](https://user-images.githubusercontent.com/872251/52357038-b338fb00-2a35-11e9-8029-d6d6a05e7510.png)
New:
![single](https://user-images.githubusercontent.com/872251/52357055-b9c77280-2a35-11e9-8af2-b45c1c559e84.png)

/cc @brancz @tomwilkie 