### PR TITLE
Some tweaks to Nodes and Pods dashboard

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -20,7 +20,8 @@ local gauge = promgrafonnet.gauge;
         )
         .addTarget(prometheus.target('max(node_load1{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 1m'))
         .addTarget(prometheus.target('max(node_load5{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 5m'))
-        .addTarget(prometheus.target('max(node_load15{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'));
+        .addTarget(prometheus.target('max(node_load15{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'))
+        .addTarget(prometheus.target('count(node_cpu_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", mode="user"})' % $._config, legendFormat='logical cores'));
 
       local cpuByCore =
         graphPanel.new(

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -83,11 +83,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         )
         .addTarget(prometheus.target(
           'sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}[1m])))' % $._config,
-          legendFormat='RX: pod = {{ pod_name }}',
+          legendFormat='RX: {{ pod_name }}',
         ))
         .addTarget(prometheus.target(
           'sort_desc(sum by (pod_name) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}[1m])))' % $._config,
-          legendFormat='TX: pod = {{ pod_name }}',
+          legendFormat='TX: {{ pod_name }}',
         ))
       );
 
@@ -96,7 +96,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         graphPanel.new(
           'Total Restarts Per Container',
           datasource='$datasource',
-          format='bytes',
+          format='short',
           min=0,
           span=12,
           legend_rightSide=true,
@@ -106,7 +106,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         )
         .addTarget(prometheus.target(
           'max by (container) (kube_pod_container_status_restarts_total{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,
-          legendFormat='Restarts {{ container }}',
+          legendFormat='Restarts: {{ container }}',
         ))
       );
 


### PR DESCRIPTION
Changes to Nodes:

* cpu cores added to system load graph to provide context for load1, load5, load15

Changes to Pods:

* added cached memory
* added cpu requests and limits
* added network Transmitted (prev only showed received)
* added new panel to show container restarts
* fix Pod's cpu usage query to hide containers that weren't selected in dropdown

Figure (below) - Nodes dashboard showing 32 "logical cores" at left, same as number of cpus in legend at right
![image](https://user-images.githubusercontent.com/5599664/52806254-ba6b9480-3045-11e9-8b7f-eb5807381238.png)

Figure (below) - Pods dashboard with new bits circled in red
![image](https://user-images.githubusercontent.com/5599664/52807082-d07a5480-3047-11e9-9855-02f2eb31a8c8.png)
