### PR TITLE
Fix kube overcommit expression

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -43,7 +43,7 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="requests.cpu"})
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="cpu"})
                 /
               sum(node:node_num_cpu:sum)
                 > %(namespaceOvercommitFactor)s
@@ -59,7 +59,7 @@
           {
             alert: 'KubeMemOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="requests.memory"})
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"})
                 /
               sum(node_memory_MemTotal{%(nodeExporterSelector)s})
                 > %(namespaceOvercommitFactor)s


### PR DESCRIPTION
This PR fixes the label values on the Kube(CPU|Mem)Overcommit alert