### PR TITLE
alerts/system_alerts: Display cert expiration in days or hours

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -1,3 +1,5 @@
+local utils = import 'utils.libsonnet';
+
 {
   prometheusAlerts+:: {
     groups+: [
@@ -140,7 +142,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %d days.' % ($._config.certExpirationWarningSeconds / 3600 / 24),
+              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationWarningSeconds)),
             },
           },
           {
@@ -152,7 +154,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %d hours.' % ($._config.certExpirationCriticalSeconds / 3600),
+              message: 'A client certificate used to authenticate to the apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationCriticalSeconds)),
             },
           },
         ],

--- a/alerts/utils.libsonnet
+++ b/alerts/utils.libsonnet
@@ -1,0 +1,6 @@
+{
+  humanizeSeconds(s)::
+    if s > 60 * 60 * 24
+    then '%d days' % (s / 60 / 60 / 24)
+    else '%d hours' % (s / 60 / 60),
+}


### PR DESCRIPTION
Display time till expiration in KubeClientCertificateExpiration message
annotation either in days or hours, depending on users configuration.