### PR TITLE
Disable KubeClientCertificateExpiration when metric 0

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -166,7 +166,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeClientCertificateExpiration',
             expr: |||
-              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationWarningSeconds)s
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationWarningSeconds)s > 0
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -178,7 +178,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeClientCertificateExpiration',
             expr: |||
-              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationCriticalSeconds)s
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{%(kubeApiserverSelector)s}[5m]))) < %(certExpirationCriticalSeconds)s > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
The alert should not fire if the metric value is exactly 0, i.e. not
expiration duration was recorded by the server.
This happens for example with aws-iam-authenticator on EKS.