### PR TITLE
alerts/utils: Print humanized time in floating point decimal format

### DIFF
--- a/alerts/utils.libsonnet
+++ b/alerts/utils.libsonnet
@@ -1,6 +1,6 @@
 {
   humanizeSeconds(s)::
     if s > 60 * 60 * 24
-    then '%d days' % (s / 60 / 60 / 24)
-    else '%d hours' % (s / 60 / 60),
+    then '%.1f days' % (s / 60 / 60 / 24)
+    else '%.1f hours' % (s / 60 / 60),
 }


### PR DESCRIPTION
Instead of printing the time as an integer, print it as a floating point
decimal with precision of one. When humanizing 5400 (1.5 h), with this
patch, `1.5 days` instead of `1 days` is printed.

This is a small follow up to https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/168.