### PR TITLE
Count overcommit CPU only for pods in Pending or Running status

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -61,7 +61,7 @@
             record: 'namespace_name:kube_pod_container_resource_requests_cpu_cores:sum',
             expr: |||
               sum by (namespace, label_name) (
-                sum(kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
+                sum(kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s} * on (endpoint, instance, job, namespace, pod, service) group_left(phase) (kube_pod_status_phase{phase=~"^(Pending|Running)$"} == 1)) by (namespace, pod)
               * on (namespace, pod) group_left(label_name)
                 label_replace(kube_pod_labels{%(kubeStateMetricsSelector)s}, "pod_name", "$1", "pod", "(.*)")
               )


### PR DESCRIPTION
In #154 we changed the memory request rule to only take running or pending pods into account, but we forgot to change it for CPU.

This PR changes the CPU requests to only take running and pending pods into account too.
Tested by running the old and new query next to each other both with namespaces containing completed Pods and only Pending|Running pods.

This was reported to us in https://bugzilla.redhat.com/show_bug.cgi?id=1691893

/cc @brancz @squat 