### PR TITLE
Fix node_disk_saturation rules (should return seconds).

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -314,7 +314,7 @@
             // Disk saturation (ms spent, by rate() it's bound by 1 second)
             record: ':node_disk_saturation:avg_irate',
             expr: |||
-              avg(irate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m]) / 1e3)
+              avg(irate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m]))
             ||| % $._config,
           },
           {
@@ -322,7 +322,7 @@
             record: 'node:node_disk_saturation:avg_irate',
             expr: |||
               avg by (node) (
-                irate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m]) / 1e3
+                irate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m])
               * on (namespace, %(podLabel)s) group_left(node)
                 node_namespace_pod:kube_pod_info:
               )

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -293,14 +293,14 @@
             ||| % $._config,
           },
           {
-            // Disk utilisation (ms spent, by rate() it's bound by 1 second)
+            // Disk utilisation (seconds spent, by rate() it's bound by 1 second)
             record: ':node_disk_utilisation:avg_irate',
             expr: |||
               avg(irate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m]))
             ||| % $._config,
           },
           {
-            // Disk utilisation (ms spent, by rate() it's bound by 1 second)
+            // Disk utilisation (seconds spent, by rate() it's bound by 1 second)
             record: 'node:node_disk_utilisation:avg_irate',
             expr: |||
               avg by (node) (
@@ -311,14 +311,14 @@
             ||| % $._config,
           },
           {
-            // Disk saturation (ms spent, by rate() it's bound by 1 second)
+            // Disk saturation (seconds spent, by rate() it's bound by 1 second)
             record: ':node_disk_saturation:avg_irate',
             expr: |||
               avg(irate(node_disk_io_time_weighted_seconds_total{%(nodeExporterSelector)s,%(diskDeviceSelector)s}[1m]))
             ||| % $._config,
           },
           {
-            // Disk saturation (ms spent, by rate() it's bound by 1 second)
+            // Disk saturation (seconds spent, by rate() it's bound by 1 second)
             record: 'node:node_disk_saturation:avg_irate',
             expr: |||
               avg by (node) (


### PR DESCRIPTION
I believe this is a result of node-exporter updating the metric from `node_disk_io_time_ms` to the current `node_disk_io_time_weighted_seconds_total`

Since the new metric returns its value in seconds, the division by 1,000 is no longer required.