### PR TITLE
Fix build

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -7,5 +7,9 @@ RUN git clone https://github.com/google/jsonnet && \
     git  -C jsonnet checkout v0.12.1 && \
     make -C jsonnet LDFLAGS=-static
 
+FROM prom/prometheus:v2.8.1
+
 FROM circleci/golang:1.10.3-stretch
 COPY --from=0 jsonnet/jsonnet /usr/bin
+COPY --from=1 /bin/promtool /usr/bin
+RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,15 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: csmarchbanks/kubernetes-mixin-build:jsonnet-0.12.1
+      - image: csmarchbanks/kubernetes-mixin-build:0.1.1
 
     working_directory: /go/src/github.com/kubernetes-monitoring/kubernetes-mixin
     steps:
       - checkout
-      - run:
-          name: Install tools
-          command: |
-            go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-            go get github.com/prometheus/prometheus/cmd/promtool
       - run: jb install
       - run: make


### PR DESCRIPTION
Install the dependencies directly into the build container rather than
at runtime. This will keep the build more stable than relying on master.

Current build is failing with this message:
```
#!/bin/bash -eo pipefail
go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
go get github.com/prometheus/prometheus/cmd/promtool
# github.com/prometheus/prometheus/vendor/github.com/prometheus/tsdb/goversion
../../prometheus/prometheus/vendor/github.com/prometheus/tsdb/goversion/init.go:17:9: undefined: _SoftwareRequiresGOVERSION1_12
Exited with code 2
```