### PR TITLE
Use interface for the hostNetworkInterfaceSelector and omit lo + docker0

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -12,7 +12,7 @@
     podLabel: 'pod',
     namespaceSelector: null,
     prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
-    hostNetworkInterfaceSelector: 'device!~"veth.+"',
+    hostNetworkInterfaceSelector: 'interface!~"veth.+|lo|docker0"',
     hostMountpointSelector: 'mountpoint="/"',
     wmiExporterSelector: 'job="wmi-exporter"',
 


### PR DESCRIPTION
`device` is no longer a relevant label, it uses `interface` instead.