### PR TITLE
Add string interpolation for Pods restart expr

### DIFF
--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -87,7 +87,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local restartAnnotation = annotation.datasource(
         'Restarts',
         '$datasource',
-        expr='time() == BOOL timestamp(rate(kube_pod_container_status_restarts_total{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[2m]) > 0)',
+        expr='time() == BOOL timestamp(rate(kube_pod_container_status_restarts_total{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[2m]) > 0)' % $._config,
         enable=true,
         hide=false,
         iconColor='rgba(215, 44, 44, 1)',


### PR DESCRIPTION
Follow up for #178. We missed to actually interpolate the templated expr string.
Works now, tested with kube-prometheus.

/cc @desaintmartin @csmarchbanks 