### PR TITLE
disk usage per instance

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -135,10 +135,10 @@ local gauge = promgrafonnet.gauge;
           format='percentunit',
         )
         .addTarget(prometheus.target(
-          'max by (namespace, pod, device) ((node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s} - node_filesystem_avail_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s}) / node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s})' % $._config, legendFormat='disk used'
+          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='disk used'
         ))
         .addTarget(prometheus.target(
-          'max by (namespace, pod, device) (node_filesystem_avail_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s} / node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s})' % $._config, legendFormat='disk free'
+          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='disk free'
         ));
 
       local networkReceived =

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -127,14 +127,19 @@ local gauge = promgrafonnet.gauge;
           ],
         };
 
-      local diskSpaceUsage = graphPanel.new(
-        'Disk Space Usage',
-        datasource='$datasource',
-        span=6,
-        format='percentunit',
-      ).addTarget(prometheus.target(
-        'node:node_filesystem_usage:{%(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{device}}',
-      ));
+      local diskSpaceUsage = 
+        graphPanel.new(
+          'Disk Space Usage',
+          datasource='$datasource',
+          span=6,
+          format='percentunit',
+        )
+        .addTarget(prometheus.target(
+          'max by (namespace, pod, device) ((node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s} - node_filesystem_avail_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s}) / node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s})' % $._config, legendFormat='disk used'
+        ))
+        .addTarget(prometheus.target(
+          'max by (namespace, pod, device) (node_filesystem_avail_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s} / node_filesystem_size_bytes{%(clusterLabel)s="$cluster", fstype=~"ext[234]|btrfs|xfs|zfs", instance="$instance", %(nodeExporterSelector)s})' % $._config, legendFormat='disk free'
+        ));
 
       local networkReceived =
         graphPanel.new(

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -377,7 +377,7 @@
           {
             record: 'node:node_filesystem_usage:',
             expr: |||
-              max by (namespace, %(podLabel)s, device) ((node_filesystem_size_bytes{%(fstypeSelector)s}
+              max by (instance, namespace, %(podLabel)s, device) ((node_filesystem_size_bytes{%(fstypeSelector)s}
               - node_filesystem_avail_bytes{%(fstypeSelector)s})
               / node_filesystem_size_bytes{%(fstypeSelector)s})
             ||| % $._config,
@@ -385,7 +385,7 @@
           {
             record: 'node:node_filesystem_avail:',
             expr: |||
-              max by (namespace, %(podLabel)s, device) (node_filesystem_avail_bytes{%(fstypeSelector)s} / node_filesystem_size_bytes{%(fstypeSelector)s})
+              max by (instance, namespace, %(podLabel)s, device) (node_filesystem_avail_bytes{%(fstypeSelector)s} / node_filesystem_size_bytes{%(fstypeSelector)s})
             ||| % $._config,
           },
           {


### PR DESCRIPTION
diskSpaceUsage was showing all devices of current k8s master/worker instead of current selected instance

before:
![before](https://user-images.githubusercontent.com/18538628/56882345-87a23b80-6a8d-11e9-956a-b4dcae9ba818.png)


after:
![after](https://user-images.githubusercontent.com/18538628/56882322-75280200-6a8d-11e9-86b9-b1c93027cf3a.png)