### PR TITLE
Allow a configurable value with a default for alerting on KubeAPILatencyHigh

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -80,7 +80,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > $._config.kubeAPILatencyLimit
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -80,7 +80,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > $._config.kubeAPILatencyLimit
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyLimit)
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -80,7 +80,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyLimit)
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyLimit)s
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -80,7 +80,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyLimit)s
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyWarningSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -93,7 +93,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > %(kubeAPILatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -65,7 +65,8 @@
     certExpirationCriticalSeconds: 1 * 24 * 3600,
     cpuThrottlingPercent: 25,
     cpuThrottlingSelector: '',
-    kubeAPILatencyLimit: 1,
+    kubeAPILatencyWarningSeconds: 1,
+    kubeAPILatencyCriticalSeconds: 4,
 
     // We alert when a disk is expected to fill up in four days. Depending on
     // the data-set it might be useful to change the sampling-time for the

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -65,6 +65,7 @@
     certExpirationCriticalSeconds: 1 * 24 * 3600,
     cpuThrottlingPercent: 25,
     cpuThrottlingSelector: '',
+    kubeAPILatencyLimit: 1,
 
     // We alert when a disk is expected to fill up in four days. Depending on
     // the data-set it might be useful to change the sampling-time for the

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -127,7 +127,7 @@ local gauge = promgrafonnet.gauge;
           ],
         };
 
-      local diskSpaceUsage = 
+      local diskSpaceUsage =
         graphPanel.new(
           'Disk Space Usage',
           datasource='$datasource',


### PR DESCRIPTION
The p99 default limit triggers a little too often some of the clusters we run so while the default is pretty fine for most, in some cases it is useful to change it.