### PR TITLE
Revert label_replace for kube node info metric

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -164,7 +164,7 @@
             // it is used to calculate per-node metrics, given namespace & instance.
             record: 'node_namespace_pod:kube_pod_info:',
             expr: |||
-              max(kube_pod_info{%(kubeStateMetricsSelector)s}) by (node, namespace, %(podLabel)s)
+              max(label_replace(kube_pod_info{%(kubeStateMetricsSelector)s}, "%(podLabel)s", "$1", "pod", "(.*)")) by (node, namespace, %(podLabel)s)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
[This change here](https://github.com/kubernetes-monitoring/kubernetes-mixin/commit/4ae5fc9e3fa90113046439dc6645ce1af9ef588b#diff-8df69bc7655ece61718c18db0cbc990cL163) has caused the kubernetes-mixin to regress for us since we use `instance` as a pod label. Since the default podLabel is already `pod` this change should be a noop for most deployments.

Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>