### PR TITLE
Increase the pods dashboard query rate

### DIFF
--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -56,7 +56,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[4m]))' % $._config,
+          'sum by (container) (irate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[4m]))' % $._config,
           legendFormat='Current: {{ container }}',
         ))
         .addTarget(prometheus.target(
@@ -83,11 +83,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
+          'sort_desc(sum by (pod) (irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
           legendFormat='RX: {{ pod }}',
         ))
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
+          'sort_desc(sum by (pod) (irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
           legendFormat='TX: {{ pod }}',
         ))
       );

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -56,7 +56,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[1m]))' % $._config,
+          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[$interval]))' % $._config,
           legendFormat='Current: {{ container }}',
         ))
         .addTarget(prometheus.target(
@@ -83,11 +83,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[$interval])))' % $._config,
           legendFormat='RX: {{ pod }}',
         ))
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[$interval])))' % $._config,
           legendFormat='TX: {{ pod }}',
         ))
       );
@@ -180,6 +180,15 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           label='Container',
           refresh='time',
           includeAll=true,
+        )
+      )
+      .addTemplate(
+        template.new(
+          'interval',
+          '$datasource',
+          '1m,2m,5m,10m',
+          label='Interval',
+          refresh='time',
         )
       )
       .addAnnotation(restartAnnotation)

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -56,7 +56,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[$interval]))' % $._config,
+          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[1m]))' % $._config,
           legendFormat='Current: {{ container }}',
         ))
         .addTarget(prometheus.target(
@@ -83,11 +83,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[$interval])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
           legendFormat='RX: {{ pod }}',
         ))
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[$interval])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
           legendFormat='TX: {{ pod }}',
         ))
       );
@@ -180,15 +180,6 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           label='Container',
           refresh='time',
           includeAll=true,
-        )
-      )
-      .addTemplate(
-        template.new(
-          'interval',
-          '$datasource',
-          '1m,2m,5m,10m',
-          label='Interval',
-          refresh='time',
         )
       )
       .addAnnotation(restartAnnotation)

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -56,7 +56,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[1m]))' % $._config,
+          'sum by (container) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", pod="$pod", container=~"$container", container!="POD"}[4m]))' % $._config,
           legendFormat='Current: {{ container }}',
         ))
         .addTarget(prometheus.target(
@@ -83,11 +83,11 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
           legendFormat='RX: {{ pod }}',
         ))
         .addTarget(prometheus.target(
-          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+          'sort_desc(sum by (pod) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[4m])))' % $._config,
           legendFormat='TX: {{ pod }}',
         ))
       );


### PR DESCRIPTION
The pods dashboard uses a hardcoded rate interval of 1m in the CPU and Network I/O panels. A rate interval should be at least four times the scrape interval in Prometheus, in order to avoid flakes in the graph (see https://github.com/prometheus/prometheus/issues/4229#issuecomment-395113148). This means that the scrape interval for the source data would have to be 15s in order for the graph to display reliably. This commit makes the rate configurable and so allows the user to select a longer interval if necessary.

Closes #213 