### PR TITLE
Add device label to legend of Disk Space Usage panel

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -135,10 +135,10 @@ local gauge = promgrafonnet.gauge;
           format='percentunit',
         )
         .addTarget(prometheus.target(
-          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='disk used'
+          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='{{device}} disk used'
         ))
         .addTarget(prometheus.target(
-          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='disk free'
+          'node:node_filesystem_usage:{%(clusterLabel)s="$cluster", instance="$instance"}' % $._config, legendFormat='{{device}} disk free'
         ));
 
       local networkReceived =


### PR DESCRIPTION
I've been using the node dashboard as a boilerplate for a node_exporter based VM monitoring and realized that the Disk Space Usage panel doesn't provide any information which disk is using space, because of a missing label in the legend.

If having multiple disks in a system is not intended for this dashboard please proceed with closing the PR.