### PR TITLE
Fix Grafana dashboard overrides example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ kubernetes {
     cadvisorSelector: 'job="kubernetes-cadvisor"',
     nodeExporterSelector: 'job="kubernetes-node-exporter"',
     kubeletSelector: 'job="kubernetes-kubelet"',
-    grafanaK8s.dashboardNamePrefix: 'Mixin / ',
-    grafanaK8s.dashboardTags: ['kubernetes', 'infrastucture'],
+    grafanaK8s+:: {
+      dashboardNamePrefix: 'Mixin / ',
+      dashboardTags: ['kubernetes', 'infrastucture'],
+    },
   },
 }
 ```


### PR DESCRIPTION
Current Jsonnet snippet is not valid:

    STATIC ERROR: mixin.libsonnet:9:15: expected token OPERATOR but got "."

Breaking change was introduced in https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/143/commits/6b82a1d445e2d91870c3522e08df27b0d0cc3702#diff-04c6e90faac2675aa89e2176d2eec7d8R123