### PR TITLE
Added API response HTTP code ratio metric and "lookbackPeriod" config

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -79,6 +79,9 @@
     // prediction
     volumeFullPredictionSampleTime: '6h',
 
+    // The lookback period controls recording rules that aggregate data over time,
+    // such as code_ratio:apiserver_request_count
+    lookbackPeriod: '3d',
 
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -79,10 +79,6 @@
     // prediction
     volumeFullPredictionSampleTime: '6h',
 
-    // The lookback period controls recording rules that aggregate data over time,
-    // such as code_ratio:apiserver_request_count
-    lookbackPeriod: '3d',
-
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
     clusterLabel: 'cluster',

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -171,7 +171,7 @@
                   (sum(code:apiserver_request_count:rate:sum))[%(lookbackPeriod)s:1s]
                 )
               ) OR (
-                absent(code:apiserver_request_count:rate:sum{code=~'5.*'} == 0)
+                absent(code:apiserver_request_count:rate:sum{code=~'5.*'})
               )
             ||| % $._config,
           },

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -155,26 +155,28 @@
               sum(rate(apiserver_request_count{%(kubeApiserverSelector)s}[5m])) by (code)
             ||| % $._config,
           },
+        ] + [
           {
-            record: 'code_ratio:apiserver_request_count',
+            record: 'code_ratio:apiserver_request_count:%s' % duration,
             expr: |||
               (
                 (
                   sum_over_time(
-                    (sum(code:apiserver_request_count:rate:sum))[%(lookbackPeriod)s:1s]
+                    (sum(code:apiserver_request_count:rate:sum))[%(duration)s:1s]
                   ) -
                   sum_over_time(
-                    (sum(code:apiserver_request_count:rate:sum{code=~'5.*'}))[%(lookbackPeriod)s:1s]
+                    (sum(code:apiserver_request_count:rate:sum{code=~'5.*'}))[%(duration)s:1s]
                   )
                 ) /
                 sum_over_time(
-                  (sum(code:apiserver_request_count:rate:sum))[%(lookbackPeriod)s:1s]
+                  (sum(code:apiserver_request_count:rate:sum))[%(duration)s:1s]
                 )
               ) OR (
                 absent(code:apiserver_request_count:rate:sum{code=~'5.*'})
               )
-            ||| % $._config,
-          },
+            ||| % ({ duration: duration } + $._config),
+          }
+          for duration in [ '1d', '3d', '7d', '14d']
         ],
       },
       {

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -161,18 +161,12 @@
             expr: |||
               (
                 (
-                  sum_over_time(
-                    (sum(code:apiserver_request_count:rate:sum))[%(duration)s:1s]
-                  ) -
-                  sum_over_time(
-                    (sum(code:apiserver_request_count:rate:sum{code=~'5.*'}))[%(duration)s:1s]
-                  )
+                  sum(sum_over_time(code:apiserver_request_count:rate:sum[%(duration)s])) -
+                  sum(sum_over_time(code:apiserver_request_count:rate:sum{code=~'5.*'}[%(duration)s]))
                 ) /
-                sum_over_time(
-                  (sum(code:apiserver_request_count:rate:sum))[%(duration)s:1s]
-                )
+                sum(sum_over_time(code:apiserver_request_count:rate:sum[%(duration)s]))
               ) OR (
-                absent(code:apiserver_request_count:rate:sum{code=~'5.*'})
+                absent(code:apiserver_request_count:rate:sum{code=~'5.*'} == 0)
               )
             ||| % ({ duration: duration } + $._config),
           }

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -152,11 +152,7 @@
           {
             record: 'code:apiserver_request_count:rate:sum',
             expr: |||
-              sum(
-                rate(
-                  apiserver_request_count{%(kubeApiserverSelector)s}[5m]
-                )
-              ) by (code)
+              sum(rate(apiserver_request_count{%(kubeApiserverSelector)s}[5m])) by (code)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
We use the ratio of "good" to "bad" HTTP response codes as a service level indicator, since lots of 5XX responses usually is a good flag for something going wrong. To track this, I've added two new recording rules: one to measure the current rate of requests over the last 5m, sum()'d by code, and another to calculate the ratio of 5XX responses to all responses over the last N days, where N is set by `lookbackPeriod` (default to 3 days).