### PR TITLE
Add Ephemeral storage alerts

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -52,6 +52,18 @@
               message: 'The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.',
             },
           },
+          {
+            alert: 'KubePodIsUsingTooMuchEphemeralStorage',
+            expr: |||
+              container_fs_usage_bytes{%(cadvisorSelector)s,pod!=""} / container_fs_limit_bytes{%(cadvisorSelector)s,pod!=""} > 0.2
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'A pod {{ $labels.pod }} is using 20% of node ephemeral storage.',
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
This is a WIP alert config

I would like to alert when a single pod uses more than X % of total ephemeral storage. 

FYI if Kubelet is low on ephemeral storage it will evict pods. Ephemeral storage is a node shared resource.


Other ideas:
- Use Predict Linear and do "Pod will exhaust ephemeral storage and will be evicted in 4 days"
- Don't alert on this?

This is roughly how this looks:
I've launched a couple of shell containers and generated some big files:
```
dd if=/dev/zero of=file2.txt count=10240 bs=1048576
```

![2019-07-24-080714](https://user-images.githubusercontent.com/22289110/61766628-28cd3380-adea-11e9-8592-1c126724cde7.png)

![2019-07-24-075708](https://user-images.githubusercontent.com/22289110/61766634-31be0500-adea-11e9-96de-31c117f03b22.png)

Container limit is 30GiB, as it's the size of the root volume
