### PR TITLE
Fix KubeVersionMismatch not correct

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -22,7 +22,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
             ||| % $._config,
             'for': '1h',
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -5,7 +5,7 @@
     kubeletSelector: 'job="kubelet"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
     nodeExporterSelector: 'job="node-exporter"',
-    notKubeDnsSelector: 'job!="kube-dns"',
+    notKubeDnsCoreDnsSelector: 'job!~"kube-dns|coredns"',
     kubeSchedulerSelector: 'job="kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-controller-manager"',
     kubeApiserverSelector: 'job="kube-apiserver"',


### PR DESCRIPTION
I'm using GKE and the metrics `kubernetes_build_info` returning series with label `job=coredns`:

```

kubernetes_build_info{buildDate="1970-01-01T00:00:00Z",compiler="gc",endpoint="http-metrics",gitCommit="$Format:%H$",gitTreeState="not  a git  tree",gitVersion="v1.5.2-beta.0+$Format:%h$",goVersion="go1.10.3",instance="10.32.2.4:10055",job="coredns",major="1",minor="5+",namespace="kube-system",platform="linux/amd64",pod="kube-dns-564d97dc9c-fgqvj",service="prometheus-coredns"} | 1
-- | --
kubernetes_build_info{buildDate="1970-01-01T00:00:00Z",compiler="gc",endpoint="http-metrics",gitCommit="$Format:%H$",gitTreeState="not  a git  tree",gitVersion="v1.5.2-beta.0+$Format:%h$",goVersion="go1.10.3",instance="10.32.3.5:10055",job="coredns",major="1",minor="5+",namespace="kube-system",platform="linux/amd64",pod="kube-dns-564d97dc9c-vvm2w",service="prometheus-coredns"}
```

As a result this rule is causing false alert on my cluster: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules/kubernetes-system.yaml#L35