### PR TITLE
Update Makefile to support jsonnet >= 0.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-JSONNET_FMT := jsonnet fmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
+JSONNET_ARGS := -n 2 --max-blank-lines 2 --string-style s --comment-style s
+ifneq (,$(shell which jsonnetfmt))
+	JSONNET_FMT_CMD := jsonnetfmt
+else
+	JSONNET_FMT_CMD := jsonnet
+	JSONNET_FMT_ARGS := fmt $(JSONNET_ARGS)
+endif
+JSONNET_FMT := $(JSONNET_FMT_CMD) $(JSONNET_FMT_ARGS)
 
 all: fmt prometheus_alerts.yaml prometheus_rules.yaml dashboards_out lint test
 


### PR DESCRIPTION
From the [v0.13.0](https://github.com/google/jsonnet/releases/tag/v0.13.0) release notes:

> If you've got scripts that run jsonnet fmt, you will need to delete the space from them.