### PR TITLE
Fix iotime yaxe

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -123,7 +123,7 @@ local gauge = promgrafonnet.gauge;
           ],
           yaxes: [
             self.yaxe(format='bytes'),
-            self.yaxe(format='ms'),
+            self.yaxe(format='s'),
           ],
         };
 


### PR DESCRIPTION
node exporter 0.16.0 introduce metric name change, include:

```
node_disk_io_time_ms -> node_disk_io_time_seconds_total
```

but the yaxe still be ms in the config.

Checked source file https://github.com/prometheus/node_exporter/blob/master//collector/diskstats_linux.go#L118 , it should be seconds.