### PR TITLE
Fix KubeJobFailed alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -185,7 +185,7 @@
           {
             alert: 'KubeJobFailed',
             expr: |||
-              kube_job_status_failed{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
+              kube_job_failed{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
I have a completed job, which previously failed 3x times:

```
status:
  completionTime: "2019-08-27T05:31:06Z"
  conditions:
  - lastProbeTime: "2019-08-27T05:31:06Z"
    lastTransitionTime: "2019-08-27T05:31:06Z"
    status: "True"
    type: Complete
  failed: 3
  startTime: "2019-08-27T05:29:00Z"
  succeeded: 1
```

status metric returns:
```
kube_job_status_failed{".."} 3
```

although job has completed:
```
kubectl get job                       
NAME             COMPLETIONS   DURATION   AGE
job-name   1/1           2m6s       3d
```

So the alert never closes.

Ref https://github.com/kubernetes/kube-state-metrics/issues/367

The metric `kube_job_failed` is based on last job condition, so I think it should give us an alert which will close:

https://github.com/kubernetes/kube-state-metrics/blob/master/internal/store/job.go#L213-L214