### PR TITLE
Fix KubePodNotReady alert for Jobs

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -19,7 +19,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"}) > 0
+              sum by (namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
Kubernetes Jobs when a pod fails, creates a new Pod and leaves the failing pod in not ready state. This is a normal behaviour and shouldn't trigger a critical alert. 

This PR filters out Job pod's from `KubePodNotReady` alert.