### PR TITLE
use lower cardinality metric for 'cluster' picker query

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -31,7 +31,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
-      ).addTemplate('cluster', 'node_cpu_seconds_total', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addRow(
         (g.row('Headlines') +
          {
@@ -132,7 +132,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Namespace (Pods)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
-      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
       .addRow(
         g.row('CPU Usage')
@@ -241,7 +241,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
-      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
       .addRow(
         g.row('CPU Usage')
@@ -343,7 +343,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workload.json']),
-      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
       .addTemplate('workload', 'mixin_pod_workload{%(clusterLabel)s="$cluster", namespace="$namespace"}' % $._config, 'workload')
       .addTemplate('type', 'mixin_pod_workload{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload"}' % $._config, 'workload_type')
@@ -413,7 +413,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Pod' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
-      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
       .addTemplate('pod', 'kube_pod_info{%(clusterLabel)s="$cluster", namespace="$namespace"}' % $._config, 'pod')
       .addRow(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -8,7 +8,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sUSE Method / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
-      ).addTemplate('cluster', 'kube_node_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addRow(
         g.row('CPU')
         .addPanel(
@@ -91,7 +91,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         '%(dashboardNamePrefix)sUSE Method / Node' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
-      ).addTemplate('cluster', 'kube_node_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      ).addTemplate('cluster', ':kube_pod_info_node_count:', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
       .addTemplate('node', 'kube_node_info{%(clusterLabel)s="$cluster"}' % $._config, 'node')
       .addRow(
         g.row('CPU')


### PR DESCRIPTION
The 'cluster' picker atop these dashboards can get 'cluster' label values more cheaply by querying a lower cardinality metric.

Without this change, we're seeing max payload sizes exceeded returning the `label_values(node_cpu_seconds_total, cluster)` query from cortex to grafana
![image](https://user-images.githubusercontent.com/5599664/65359761-bcd53480-dbba-11e9-80f6-096b979f28da.png)

Submitting this PR against the release-0.1 branch to apply to kubernetes 1.13