### PR TITLE
Fix false positive kubeversionmismatch for Kubernetes < 1.14

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -22,7 +22,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
             ||| % $._config,
             'for': '1h',
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -5,7 +5,7 @@
     kubeletSelector: 'job="kubelet"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
     nodeExporterSelector: 'job="node-exporter"',
-    notKubeDnsSelector: 'job!="kube-dns"',
+    notKubeDnsCoreDnsSelector: 'job!~"kube-dns|coredns"',
     kubeSchedulerSelector: 'job="kube-scheduler"',
     kubeControllerManagerSelector: 'job="kube-controller-manager"',
     kubeApiserverSelector: 'job="kube-apiserver"',


### PR DESCRIPTION
As discussed in this issue: https://github.com/helm/charts/pull/16157#issuecomment-521244633
I need the fix to be on Kubernetes 1.13 also, so I'm creating this PR to backport the fix to release-0.1.