### PR TITLE
Handle perpetually firing KubeVersionMismatch when using Amazon EKS

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -22,7 +22,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+              count(count by(major, minor) (kubernetes_build_info)) > 1
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
This is like #150 again.  However, now the issue seems to be that the
EKS control plane runs a different point release of kubernetes than
the EKS-provided-AMI's kubelet.

If I query `count by(gitVersion,job)( kubernetes_build_info)` I see:

    {gitVersion="v1.13.8-eks-cd3eb0",job="kubelet"}
    {gitVersion="v1.13.10-eks-5ac0f1",job="apiserver"}

We can fix this by only matching on minor releases rather than point
releases - which also makes the query simpler because minor releases
have a dedicated label, instead of using a regular expression.