### PR TITLE
Add alerts for long kubelet PLEG intervals

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -2,11 +2,6 @@
   _config+:: {
     kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
     kubeletSelector: error 'must provide selector for kubelet',
-
-    // The upper bound for the `kubelet_pleg_relist_duration_seconds` histogram
-    // buckets is set to `10` seconds. Therefore the max value returned from
-    // the  `histogram_quantile` function of the PLEG duration alert is capped at 10.
-    kubeletPlegDurationWarningSeconds: 10,
   },
 
   prometheusAlerts+:: {
@@ -55,9 +50,9 @@
           {
             alert: 'KubeNodeReadinessFlapping',
             expr: |||
-              sum(changes(kube_node_status_condition{status='true',condition='Ready'}[15m])) by (node) > 2
+              sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (node) > 2
             ||| % $._config,
-            'for': '1m',
+            'for': '15m',
             labels: {
               severity: 'warning',
             },
@@ -68,7 +63,7 @@
           {
             alert: 'KubeletPlegDurationHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (node, le)) >= %(kubeletPlegDurationWarningSeconds)s
+              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (node, le)) >= 10
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -75,7 +75,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'The Kubelet Pod Liecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.',
+              message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.',
             },
           },
           (import '../lib/absent_alert.libsonnet') {

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -63,7 +63,7 @@
           {
             alert: 'KubeletPlegDurationHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) >= 10
+              node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -2,6 +2,11 @@
   _config+:: {
     kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
     kubeletSelector: error 'must provide selector for kubelet',
+
+    // The upper bound for the `kubelet_pleg_relist_duration_seconds` histogram
+    // buckets is set to `10` seconds. Therefore the max value returned from
+    // the  `histogram_quantile` function of the PLEG duration alert is capped at 10.
+    kubeletPlegDurationWarningSeconds: 10,
   },
 
   prometheusAlerts+:: {
@@ -45,6 +50,32 @@
             },
             annotations: {
               message: "Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.",
+            },
+          },
+          {
+            alert: 'KubeNodeReadinessFlapping',
+            expr: |||
+              sum(changes(kube_node_status_condition{status='true',condition='Ready'}[15m])) by (node) > 2
+            ||| % $._config,
+            'for': '1m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'The readiness status of node {{ $labels.node }} has changed {{ $value }} times in the last 15 minutes.',
+            },
+          },
+          {
+            alert: 'KubeletPlegDurationHigh',
+            expr: |||
+              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (node, le)) >= %(kubeletPlegDurationWarningSeconds)s
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'The Kubelet Pod Liecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.',
             },
           },
           (import '../lib/absent_alert.libsonnet') {

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -63,7 +63,7 @@
           {
             alert: 'KubeletPlegDurationHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (node, le)) >= 10
+              histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) >= 10
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -1,0 +1,25 @@
+{
+  _config+:: {
+    kubeletSelector: 'job="kubelet"',
+  },
+
+  prometheusRules+:: {
+    groups+: [
+      {
+        name: 'kubelet.rules',
+        rules: [
+          {
+            record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile',
+            expr: |||
+              histogram_quantile(%(quantile)s, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s})
+            ||| % ({ quantile: quantile } + $._config),
+            labels: {
+              quantile: quantile,
+            },
+          }
+          for quantile in ['0.99', '0.9', '0.5']
+        ],
+      },
+    ],
+  },
+}

--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -1,4 +1,5 @@
 (import 'kube_apiserver.libsonnet') +
 (import 'apps.libsonnet') +
 (import 'kube_scheduler.libsonnet') +
-(import 'node.libsonnet')
+(import 'node.libsonnet') +
+(import 'kubelet.libsonnet')

--- a/tests.yaml
+++ b/tests.yaml
@@ -153,6 +153,7 @@ tests:
     - exp_labels:
         instance: 10.0.2.15:10250
         node: minikube
+        quantile: 0.99
         severity: warning
       exp_annotations:
         message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of 10 seconds on node minikube.'

--- a/tests.yaml
+++ b/tests.yaml
@@ -152,20 +152,20 @@ tests:
         node: ip-10-1-2-3.us-east-1.compute.internal
         severity: warning
       exp_annotations:
-        message: 'The Kubelet Pod Liecycle Event Generator has a 99th percentile duration of 10 seconds on node ip-10-1-2-3.us-east-1.compute.internal.'
+        message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of 10 seconds on node ip-10-1-2-3.us-east-1.compute.internal.'
         runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh'
 
 - interval: 1m
   input_series:
   - series: 'kube_node_status_condition{condition="Ready",endpoint="https-main",instance="100.110.41.47:8443",job="kube-state-metrics",namespace="monitoring",node="ip-10-1-2-3.us-east-1.compute.internal",pod="kube-state-metrics-b894d84cc-d6htw",service="kube-state-metrics",status="true"}'
-    values: '1 1 1 0 0 0 1 1 1 1 1 1 1 0 0'
+    values: '1 0 1 0 1 0 0 0 1 0 1 0 0 0 1 0 1 0 0 1'
   alert_rule_test:
-  - eval_time: 15m
+  - eval_time: 18m
     alertname: KubeNodeReadinessFlapping
     exp_alerts:
     - exp_labels:
         node: ip-10-1-2-3.us-east-1.compute.internal
         severity: warning
       exp_annotations:
-        message: 'The readiness status of node ip-10-1-2-3.us-east-1.compute.internal has changed 3 times in the last 15 minutes.'
+        message: 'The readiness status of node ip-10-1-2-3.us-east-1.compute.internal has changed 10 times in the last 15 minutes.'
         runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping'

--- a/tests.yaml
+++ b/tests.yaml
@@ -120,52 +120,55 @@ tests:
 - interval: 1m
   input_series:
   # Create a histogram where all of the last 10 samples are in the +Inf (> 10 seconds) bucket.
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.005", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.005", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.01", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.01", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.025", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.025", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.05", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.05", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.1", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.1", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.25", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.25", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.5", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="1", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="1", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="2.5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="2.5", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="5", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="10", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="10", instance="10.0.2.15:10250"}'
     values: '1+0x10'
-  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="+Inf", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="+Inf", instance="10.0.2.15:10250"}'
     values: '30+1x10'
+  - series: 'kubelet_node_name{endpoint="https-metrics",instance="10.0.2.15:10250",job="kubelet",namespace="kube-system",node="minikube",service="kubelet"}'
+    values: '1 1 1 1 1 1 1 1 1 1'
   alert_rule_test:
   - eval_time: 10m
     alertname: KubeletPlegDurationHigh
     exp_alerts:
     - exp_labels:
-        node: ip-10-1-2-3.us-east-1.compute.internal
+        instance: 10.0.2.15:10250
+        node: minikube
         severity: warning
       exp_annotations:
-        message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of 10 seconds on node ip-10-1-2-3.us-east-1.compute.internal.'
+        message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of 10 seconds on node minikube.'
         runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh'
 
 - interval: 1m
   input_series:
-  - series: 'kube_node_status_condition{condition="Ready",endpoint="https-main",instance="100.110.41.47:8443",job="kube-state-metrics",namespace="monitoring",node="ip-10-1-2-3.us-east-1.compute.internal",pod="kube-state-metrics-b894d84cc-d6htw",service="kube-state-metrics",status="true"}'
+  - series: 'kube_node_status_condition{condition="Ready",endpoint="https-main",instance="10.0.2.15:10250",job="kube-state-metrics",namespace="monitoring",node="minikube",pod="kube-state-metrics-b894d84cc-d6htw",service="kube-state-metrics",status="true"}'
     values: '1 0 1 0 1 0 0 0 1 0 1 0 0 0 1 0 1 0 0 1'
   alert_rule_test:
   - eval_time: 18m
     alertname: KubeNodeReadinessFlapping
     exp_alerts:
     - exp_labels:
-        node: ip-10-1-2-3.us-east-1.compute.internal
+        node: minikube
         severity: warning
       exp_annotations:
-        message: 'The readiness status of node ip-10-1-2-3.us-east-1.compute.internal has changed 10 times in the last 15 minutes.'
+        message: 'The readiness status of node minikube has changed 10 times in the last 15 minutes.'
         runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping'

--- a/tests.yaml
+++ b/tests.yaml
@@ -116,3 +116,56 @@ tests:
     exp_samples:
     - value: 1.0e+9
       labels: 'namespace:kube_pod_container_resource_requests_memory_bytes:sum{namespace="kube-apiserver"}'
+
+- interval: 1m
+  input_series:
+  # Create a histogram where all of the last 10 samples are in the +Inf (> 10 seconds) bucket.
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.005", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.01", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.025", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.05", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.1", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.25", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="1", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="2.5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="5", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="10", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '1+0x10'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="+Inf", node="ip-10-1-2-3.us-east-1.compute.internal"}'
+    values: '30+1x10'
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: KubeletPlegDurationHigh
+    exp_alerts:
+    - exp_labels:
+        node: ip-10-1-2-3.us-east-1.compute.internal
+        severity: warning
+      exp_annotations:
+        message: 'The Kubelet Pod Liecycle Event Generator has a 99th percentile duration of 10 seconds on node ip-10-1-2-3.us-east-1.compute.internal.'
+        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh'
+
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_condition{condition="Ready",endpoint="https-main",instance="100.110.41.47:8443",job="kube-state-metrics",namespace="monitoring",node="ip-10-1-2-3.us-east-1.compute.internal",pod="kube-state-metrics-b894d84cc-d6htw",service="kube-state-metrics",status="true"}'
+    values: '1 1 1 0 0 0 1 1 1 1 1 1 1 0 0'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeNodeReadinessFlapping
+    exp_alerts:
+    - exp_labels:
+        node: ip-10-1-2-3.us-east-1.compute.internal
+        severity: warning
+      exp_annotations:
+        message: 'The readiness status of node ip-10-1-2-3.us-east-1.compute.internal has changed 3 times in the last 15 minutes.'
+        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping'


### PR DESCRIPTION
Fire warning and critical alerts when the Kubelet's Pod Liecycle Event Generator (PLEG) interval metric exceeds configured durations.