### PR TITLE
alerts/system_alerts.libsonnet: Remove broken alert

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -52,19 +52,6 @@ local utils = import 'utils.libsonnet';
             },
           },
           {
-            alert: 'KubeClientErrors',
-            expr: |||
-              sum(rate(ksm_scrape_error_total{%(kubeStateMetricsSelector)s}[5m])) by (instance, job) > 0.1
-            ||| % $._config,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / second.",
-            },
-          },
-          {
             alert: 'KubeletTooManyPods',
             expr: |||
               100 * max(max(kubelet_running_pod_count{%(kubeletSelector)s}) by(instance) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) by(node) / max(kube_node_status_capacity_pods{%(kubeStateMetricsSelector)s}) by(node) > 95


### PR DESCRIPTION
`ksm_scrape_error_total metric` was removed from kube-state-metric in the
release v1.5.0.
https://github.com/kubernetes/kube-state-metrics/blob/b31a4006d5a5fbe6642902a38e3b27fd96a1331a/CHANGELOG.md#v150--2019-01-10

Not sure if we want to rewrite this alert using another metric, but I guess we can do this in a follow up? cc @metalmatze @brancz 