### PR TITLE
humanizePercentage to get rid of many decimals.

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -118,13 +118,13 @@
             expr: |||
               kube_daemonset_status_number_ready{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 /
-              kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} * 100 < 100
+              kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} < 1.00
             ||| % $._config,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.',
+              message: 'Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.',
             },
             'for': '15m',
           },


### PR DESCRIPTION
When dividing a lot of decimals are normally present in the result.
This change uses the Prometheus filter humanizePercentage to minimize
the number of decimals, and also removes the conversion to percentage in
the calculation of the result itself.