### PR TITLE
Readme: "metrics overhaul" link updated (now to issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 | master  | Kubernetes 1.14+           | Prometheus 2.11.0+       |
 | v0.1.x  | Kubernetes 1.13 and before |                          |
 
-In Kubernetes 1.14 there was a major [metrics overhaul](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md) implemented.
+In Kubernetes 1.14 there was a major [metrics overhaul](https://github.com/kubernetes/enhancements/issues/1206) implemented.
 Therefore v0.1.x of this repository is the last release to support Kubernetes 1.13 and previous version on a best effort basis.
 
 Some alerts now use Prometheus filters made available in Prometheus 2.11.0, which makes this version of Prometheus a dependency.


### PR DESCRIPTION
The URL to the KEP is outdated (now has creation date `20181106` in it).

I suggest to link to the issue instead the KPE. It includes the link to the KEP as well and gives an better overview (which is also more up to date).