### PR TITLE
alerts: Fire an alert if a node is tainted as unreachable

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -20,6 +20,18 @@ local utils = import 'utils.libsonnet';
             alert: 'KubeNodeNotReady',
           },
           {
+            expr: |||
+              kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.',
+            },
+            alert: 'KubeNodeUnreachable',
+          },
+          {
             alert: 'KubeVersionMismatch',
             expr: |||
               count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1


### PR DESCRIPTION
When nodes fail to renew their lease within a specified time limit
determined by the cluster or by administrative configuration, the
node is tainted and stateless workloads that do not tolerate the
taint will be terminated and recreated elsewhere. This is a serious
condition (often indicating network partition or total node failure)
and should result in an alert within a very short time period.

Clusters experiencing frequent unreachable nodes are considered
misconfigured and the cluster threshold for unreachable should be
increased, which should make a quick alert trigger reasonable.

Spawned as a follow up to #236