### PR TITLE
WIP: alerts: Alert when a node evicts pods for any reason

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -89,6 +89,19 @@
             },
           },
           {
+            alert: 'KubeNodeEvictedPods',
+            expr: |||
+              increase(kubelet_evictions{%(kubeStateMetricsSelector)s}[5m]) > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $labels.node }} has evicted {{ $value }} pods.',
+            },
+            'for': '5m',
+          },
+          {
             alert: 'CPUThrottlingHigh',
             expr: |||
               sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)


### PR DESCRIPTION
Evictions are unusual and may be a sign of resource pressure. While
it is not a strong error signal, it is important to know when these
events occur as they may be symptomatic of workload, node, or cluster
problems. In a healthy cluster, eviction should be rare.

The kubelet_evictions metric was added in Kubernetes 1.16.

Still testing this alert