### PR TITLE
Fix rule KubeCPUOvercommit

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -11,7 +11,7 @@
                 /
               sum(kube_node_status_allocatable_cpu_cores)
                 >
-              (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
+              (sum(kube_node_status_allocatable_cpu_cores)-1) / sum(kube_node_status_allocatable_cpu_cores)
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Hi!
Looks like I found a mistake in the **KubeCPUOvercommit** alerting rule.
As I got, the goal of that rule is too check that at least one core of a cluster is idle. But `count(kube_node_status_allocatable_cpu_cores)` returns workers count, not CPU count as we need. **kube_node_status_allocatable_cpu_cores** contains cores count for each worker, so we just need to change **count** to **sum** function.

#### Example
I have two nodes cluster, each node has 4 cores.
Expected result is `(8-1)/8 = 0.875` but current function returns `(2-1)/2 = 0.5`:
<img width="777" alt="Screenshot 2019-10-21 at 15 08 40" src="https://user-images.githubusercontent.com/3237625/67203914-ff399d80-f414-11e9-87e9-91a8bba98092.png">
Updated function returns the expected result:
<img width="779" alt="Screenshot 2019-10-21 at 15 08 35" src="https://user-images.githubusercontent.com/3237625/67203982-2e500f00-f415-11e9-8d4b-21d782fe2934.png">

