### PR TITLE
container in waiting state alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -130,7 +130,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} * on(namespace, pod) group_left(owner_kind) kube_pod_owner)  > 0
+              sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -129,6 +129,19 @@
             'for': '15m',
           },
           {
+            expr: |||
+              sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} * on(namespace, pod) group_left(owner_kind) kube_pod_owner)  > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.',
+            },
+            'for': '1h',
+            alert: 'KubeContainerWaiting',
+          },
+          {
             alert: 'KubeDaemonSetNotScheduled',
             expr: |||
               kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}

--- a/runbook.md
+++ b/runbook.md
@@ -46,6 +46,9 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeDaemonSetRolloutStuck"
 + *Message*: `Only {{$value | humanizePercentage }} of desired pods scheduled and ready for daemon set {{$labels.namespace}}/{{$labels.daemonset}}`
 + *Severity*: critical
+##### Alert Name: "KubeContainerWaiting"
++ *Message*: `{{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state.`
++ *Severity*: warning
 ##### Alert Name: "KubeDaemonSetNotScheduled"
 + *Message*: `A number of pods of daemonset {{$labels.namespace}}/{{$labels.daemonset}} are not scheduled.`
 + *Severity*: warning


### PR DESCRIPTION
Resolves #271 

Adds an alert when a pod cannot be in a ready state due a container being in waiting state.
Container could be in any of `ContainerCreating|CrashLoopBackOff|ErrImagePull|ImagePullBackOff|CreateContainerConfigError|InvalidImageName|CreateContainerError` these states.