### PR TITLE
Update node memory metrics

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -139,7 +139,7 @@ local template = grafana.template;
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_memory_bytes{%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_memory_bytes{%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +
@@ -1281,7 +1281,7 @@ local template = grafana.template;
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(kube_node_status_allocatable_memory_bytes)' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable_memory_bytes)' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +

--- a/rules/node.libsonnet
+++ b/rules/node.libsonnet
@@ -35,12 +35,19 @@
               ))
             ||| % $._config,
           },
-          // Add separate rules for Free, so we can aggregate across clusters in dashboards.
-          // TODO: adjust recording rule name to match best practices
+          // Add separate rules for Available memory, so we can aggregate across clusters in dashboards.
           {
-            record: ':node_memory_MemFreeCachedBuffers_bytes:sum',
+            record: ':node_memory_MemAvailable_bytes:sum',
             expr: |||
-              sum(node_memory_MemFree_bytes{%(nodeExporterSelector)s} + node_memory_Cached_bytes{%(nodeExporterSelector)s} + node_memory_Buffers_bytes{%(nodeExporterSelector)s})
+              sum(
+                node_memory_MemAvailable_bytes{%(nodeExporterSelector)s} or
+                (
+                  node_memory_Buffers_bytes{%(nodeExporterSelector)s} +
+                  node_memory_Cached_bytes{%(nodeExporterSelector)s} +
+                  node_memory_MemFree_bytes{%(nodeExporterSelector)s} +
+                  node_memory_Slab_bytes{%(nodeExporterSelector)s}
+                )
+              )
             ||| % $._config,
           },
         ],


### PR DESCRIPTION
Use modern kernel "MemAvailable" metric when possible.
* Update recording rule name.
* Fallback to old MemFree+Buffers+Cached method for older kernels.
* Also include Slab memory[0].

[0]: https://github.com/prometheus/node_exporter/issues/1519#issuecomment-542025507