### PR TITLE
Fix Compute Resources Node Pods Memory Usage

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -515,7 +515,7 @@ local template = grafana.template;
         .addPanel(
           g.panel('Memory Usage (w/o cache)') +
           // Like above, without page cache
-          g.queryPanel('sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node="$node", container!=""}) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node="$node", container!=""}) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('bytes') },
         )


### PR DESCRIPTION
* Memory Usage graph filters by $node, which isn't present directly in container_memory_working_set_bytes, but is in the recording rule added by
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/274
* It appears #274 fixed the Memory Quota table, but missed fixing the usage graph