### PR TITLE
add missing tags on network usage dashboards - fixes #286

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -343,6 +343,7 @@ local gauge = promgrafonnet.gauge;
 
       dashboard.new(
         title='%(dashboardNamePrefix)sNetworking / Cluster' % $._config.grafanaK8s,
+        tags=($._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
         refresh='30s',

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -353,6 +353,7 @@ local gauge = promgrafonnet.gauge;
 
       dashboard.new(
         title='%(dashboardNamePrefix)sNetworking / Namespace (Pods)' % $._config.grafanaK8s,
+        tags=($._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
         refresh='30s',

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -372,6 +372,7 @@ local gauge = promgrafonnet.gauge;
 
       dashboard.new(
         title='%(dashboardNamePrefix)sNetworking / Namespace (Workload)' % $._config.grafanaK8s,
+        tags=($._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
         refresh='30s',

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -240,6 +240,7 @@ local gauge = promgrafonnet.gauge;
 
       dashboard.new(
         title='%(dashboardNamePrefix)sNetworking / Pod' % $._config.grafanaK8s,
+        tags=($._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
         refresh='30s',

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -244,6 +244,7 @@ local gauge = promgrafonnet.gauge;
 
       dashboard.new(
         title='%(dashboardNamePrefix)sNetworking / Workload' % $._config.grafanaK8s,
+        tags=($._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
         refresh='30s',


### PR DESCRIPTION
Fix network-usage dashboards to add tagging with tags set in config\

Fixes #286 