### PR TITLE
Remove KubeVersionMismatch alert

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -9,19 +9,6 @@
         name: 'kubernetes-system',
         rules: [
           {
-            alert: 'KubeVersionMismatch',
-            expr: |||
-              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
-            ||| % $._config,
-            'for': '15m',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'There are {{ $value }} different semantic versions of Kubernetes components running.',
-            },
-          },
-          {
             alert: 'KubeClientErrors',
             // Many clients use get requests to check the existence of objects,
             // this is normal and an expected error, therefore it should be

--- a/runbook.md
+++ b/runbook.md
@@ -99,9 +99,6 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeNodeNotReady"
 + *Message*: `{{ $labels.node }} has been unready for more than an 15 minutes"`
 + *Severity*: warning
-##### Alert Name: "KubeVersionMismatch"
-+ *Message*: `There are {{ $value }} different versions of Kubernetes components running.`
-+ *Severity*: warning
 ##### Alert Name: "KubeClientErrors"
 + *Message*: `Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors.'`
 + *Severity*: warning


### PR DESCRIPTION
This alert is being fired in case you upgrading existing Kubernetes clusters where there is high chance a different levels of components are running at that time. Having version skew is perfectly normal and it should be tolerated.

/cc @s-urbaniak 