### PR TITLE
Introduce apiserver SLO of 99% with multiple burn rate alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ fmt:
 		xargs -n 1 -- $(JSONNET_FMT) -i
 
 prometheus_alerts.yaml: mixin.libsonnet lib/alerts.jsonnet alerts/*.libsonnet
-	jsonnet -S lib/alerts.jsonnet > $@
+	jsonnet -J vendor -S lib/alerts.jsonnet > $@
 
 prometheus_rules.yaml: mixin.libsonnet lib/rules.jsonnet rules/*.libsonnet
-	jsonnet -S lib/rules.jsonnet > $@
+	jsonnet -J vendor -S lib/rules.jsonnet > $@
 
 dashboards_out: mixin.libsonnet lib/dashboards.jsonnet dashboards/*.libsonnet
 	@mkdir -p dashboards_out

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -14,6 +14,12 @@ local utils = import 'utils.libsonnet';
   prometheusAlerts+:: {
     groups+: [
       {
+        name: 'kube-apiserver-error',
+        rules:
+          $._config.SLOs.apiserver.errors.alerts +
+          $._config.SLOs.apiserver.errors.recordingrules,
+      },
+      {
         name: 'kubernetes-system-apiserver',
         rules: [
           {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,5 +1,20 @@
+local slo = import 'slo-libsonnet/slo.libsonnet';
+
 {
   _config+:: {
+    SLOs: {
+      apiserver: {
+        // This is templating a Multiple Burn Rate Alerts for Kubernetes Apiservers.
+        // We will alert on burning too much error budget over 30 days.
+        // By default we have 99% availability (1% unavailability = 7h12m in 30d).
+        errors: slo.errorburn({
+          metric: 'apiserver_request_total',
+          selectors: [$._config.kubeApiserverSelector],
+          errorBudget: 1 - 0.99,
+        }),
+      },
+    },
+
     // Selectors are inserted between {} in Prometheus queries.
     cadvisorSelector: 'job="cadvisor"',
     kubeletSelector: 'job="kubelet"',

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -19,6 +19,16 @@
                 }
             },
             "version": "master"
+        },
+        {
+            "name": "slo-libsonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/metalmatze/slo-libsonnet",
+                    "subdir": "slo-libsonnet"
+                }
+            },
+            "version": "master"
         }
     ]
 }

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,34 +1,34 @@
 {
-    "dependencies": [
-        {
-            "name": "grafonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/grafonnet-lib",
-                    "subdir": "grafonnet"
-                }
-            },
-            "version": "master"
-        },
-        {
-            "name": "grafana-builder",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/jsonnet-libs",
-                    "subdir": "grafana-builder"
-                }
-            },
-            "version": "master"
-        },
-        {
-            "name": "slo-libsonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/metalmatze/slo-libsonnet",
-                    "subdir": "slo-libsonnet"
-                }
-            },
-            "version": "master"
+  "dependencies": [
+    {
+      "name": "grafana-builder",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs",
+          "subdir": "grafana-builder"
         }
-    ]
+      },
+      "version": "master"
+    },
+    {
+      "name": "grafonnet",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "name": "slo-libsonnet",
+      "source": {
+        "git": {
+          "remote": "https://github.com/metalmatze/slo-libsonnet",
+          "subdir": "slo-libsonnet"
+        }
+      },
+      "version": "master"
+    }
+  ]
 }


### PR DESCRIPTION
I want to start a discussion on having a SLO for the apiserver and its error rate.
By default I simply settled for 99% availability and generated all the recording rules and alerts for multi burn rate alerts.

/cc @brancz @csmarchbanks @tomwilkie @gouthamve @povilasv 

Here's the output for the generated rules as a reference.

```yaml
"groups":
- "name": "kube-apiserver-error"
  "rules":
  - "alert": "ErrorBudgetBurn"
    "annotations":
      "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn"
    "expr": |
      (
        status_class_5xx:apiserver_request_total:ratio_rate1h{job="kube-apiserver"} > (14.4*0.010000)
        and
        status_class_5xx:apiserver_request_total:ratio_rate5m{job="kube-apiserver"} > (14.4*0.010000)
      )
      or
      (
        status_class_5xx:apiserver_request_total:ratio_rate6h{job="kube-apiserver"} > (6*0.010000)
        and
        status_class_5xx:apiserver_request_total:ratio_rate30m{job="kube-apiserver"} > (6*0.010000)
      )
    "labels":
      "job": "kube-apiserver"
      "severity": "critical"
  - "alert": "ErrorBudgetBurn"
    "annotations":
      "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn"
    "expr": |
      (
        status_class_5xx:apiserver_request_total:ratio_rate1d{job="kube-apiserver"} > (3*0.010000)
        and
        status_class_5xx:apiserver_request_total:ratio_rate2h{job="kube-apiserver"} > (3*0.010000)
      )
      or
      (
        status_class_5xx:apiserver_request_total:ratio_rate3d{job="kube-apiserver"} > (0.010000)
        and
        status_class_5xx:apiserver_request_total:ratio_rate6h{job="kube-apiserver"} > (0.010000)
      )
    "labels":
      "job": "kube-apiserver"
      "severity": "warning"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[5m]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate5m"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[30m]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate30m"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[1h]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate1h"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[2h]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate2h"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[6h]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate6h"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[1d]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate1d"
  - "expr": |
      sum by (status_class) (
        label_replace(
          rate(apiserver_request_total{job="kube-apiserver"}[3d]
        ), "status_class", "${1}xx", "code", "([0-9])..")
      )
    "labels":
      "job": "kube-apiserver"
    "record": "status_class:apiserver_request_total:rate3d"
  - "expr": |
      sum(status_class:apiserver_request_total:rate5m{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate5m{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate5m"
  - "expr": |
      sum(status_class:apiserver_request_total:rate30m{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate30m{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate30m"
  - "expr": |
      sum(status_class:apiserver_request_total:rate1h{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate1h{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate1h"
  - "expr": |
      sum(status_class:apiserver_request_total:rate2h{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate2h{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate2h"
  - "expr": |
      sum(status_class:apiserver_request_total:rate6h{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate6h{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate6h"
  - "expr": |
      sum(status_class:apiserver_request_total:rate1d{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate1d{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate1d"
  - "expr": |
      sum(status_class:apiserver_request_total:rate3d{job="kube-apiserver",status_class="5xx"})
      /
      sum(status_class:apiserver_request_total:rate3d{job="kube-apiserver"})
    "labels":
      "job": "kube-apiserver"
    "record": "status_class_5xx:apiserver_request_total:ratio_rate3d"
```