### PR TITLE
[apps_alerts] - Fix err msg "found duplicate series for the match group"

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -25,7 +25,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job",job="kube-state-metrics"}) > 0
+              sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -25,7 +25,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job"}) > 0
+              sum by (namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"} * on(namespace, pod) group_left(owner_kind) kube_pod_owner{owner_kind!="Job",job="kube-state-metrics"}) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
Fix err msg found duplicate series for the match group for KubePodNotReady alert. Here is my stack trace:
`Error executing query: found duplicate series for the match group {namespace="default", pod="nginx-dbddb74b8-vks5q"} on the right hand-side of the operation: [{__name__="kube_pod_owner", endpoint="http", instance="X.X.X.X:8080", job="kube-state-metrics", namespace="default", owner_is_controller="true", owner_kind="ReplicaSet", owner_name="nginx-dbddb74b8", pod="nginx-dbddb74b8-vks5q", service="prometheus-operator-kube-state-metrics"}, {__name__="kube_pod_owner", app_kubernetes_io_instance="prometheus-operator", app_kubernetes_io_managed_by="Tiller", app_kubernetes_io_name="kube-state-metrics", helm_sh_chart="kube-state-metrics-2.4.1", instance="X.X.X.X:8080", job="kubernetes-service-endpoints", kubernetes_name="prometheus-operator-kube-state-metrics", kubernetes_namespace="prometheus-operator", kubernetes_node="XXXXXX-b6b5a477-zq60", namespace="default", owner_is_controller="true", owner_kind="ReplicaSet", owner_name="nginx-dbddb74b8", pod="nginx-dbddb74b8-vks5q"}];many-to-many matching not allowed: matching labels must be unique on one side`

Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

I previously create my PR [here](https://github.com/helm/charts/pull/18736) but this repo is the source.

cc @vsliouniaev @bismarck