### PR TITLE
Fix dependency for grafana-builder

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -14,7 +14,7 @@
             "name": "grafana-builder",
             "source": {
                 "git": {
-                    "remote": "https://github.com/kausalco/public",
+                    "remote": "https://github.com/grafana/jsonnet-libs",
                     "subdir": "grafana-builder"
                 }
             },


### PR DESCRIPTION
Use `grafana/jsonnet-libs` instead of `kausalco/public` which silently redirects to former.

/cc @brancz @s-urbaniak 