### PR TITLE
revert failed pod marked as NotReady

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -25,7 +25,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+              sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
This issue
https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/215
turned a "Failed" pod into a "PodNotReady". The creator of the PR wanted this for his evicted pods. I believe this is not correct. I would suggest looking at 
```
kube_pod_container_status_terminated_reason{reason!="Completed"}
OR
kube_pod_container_status_terminated
```
to build a metric if people need it. Why are we reverting? Because any failed pod will now trigger this alert, since [pods stay in the API for quite a long time](https://stackoverflow.com/questions/51234378/why-do-pods-with-completed-status-still-show-up-in-kubctl-get-pods) and therefore any failed pod == PodNotReady.

Failed pods occur all the time. Build systems, batch processing, etc.
