### PR TITLE
apply simple anomaly detectionto KubeAPILatencyHigh alert

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -20,18 +20,18 @@ local utils = import 'utils.libsonnet';
             alert: 'KubeAPILatencyHigh',
             expr: |||
               (
-                cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"}
+                cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s}
                 >
                 on (verb) group_left()
                 (
-                  avg by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"} >= 0)
+                  avg by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s} >= 0)
                   +
-                  2*stddev by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"} >= 0)
+                  2*stddev by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s} >= 0)
                 )
               ) > on (verb) group_left()
-              1.2 * avg by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"} >= 0)
+              1.2 * avg by (verb) (cluster:apiserver_request_duration_seconds:mean5m{%(kubeApiserverSelector)s} >= 0)
               and on (verb,resource)
-              cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"}
+              cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99"}
               >
               %(kubeAPILatencyWarningSeconds)s
             ||| % $._config,
@@ -46,7 +46,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'KubeAPILatencyHigh',
             expr: |||
-              cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"} > %(kubeAPILatencyCriticalSeconds)s
+              cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{%(kubeApiserverSelector)s,quantile="0.99"} > %(kubeAPILatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -10,6 +10,15 @@
         name: 'kube-apiserver.rules',
         rules: [
           {
+            record: 'cluster:apiserver_request_duration_seconds:mean5m',
+            expr: |||
+              sum(rate(apiserver_request_duration_seconds_sum[5m])) without(instance, %(podLabel)s)
+              /
+              sum(rate(apiserver_request_duration_seconds_count[5m])) without(instance, %(podLabel)s)
+            ||| % ($._config),
+          },
+        ] + [
+          {
             record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
             expr: |||
               histogram_quantile(%(quantile)s, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s}[5m])) without(instance, %(podLabel)s))

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -12,16 +12,16 @@
           {
             record: 'cluster:apiserver_request_duration_seconds:mean5m',
             expr: |||
-              sum(rate(apiserver_request_duration_seconds_sum[5m])) without(instance, %(podLabel)s)
+              sum(rate(apiserver_request_duration_seconds_sum{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s)
               /
-              sum(rate(apiserver_request_duration_seconds_count[5m])) without(instance, %(podLabel)s)
+              sum(rate(apiserver_request_duration_seconds_count{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s)
             ||| % ($._config),
           },
         ] + [
           {
             record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
             expr: |||
-              histogram_quantile(%(quantile)s, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s}[5m])) without(instance, %(podLabel)s))
+              histogram_quantile(%(quantile)s, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s))
             ||| % ({ quantile: quantile } + $._config),
             labels: {
               quantile: quantile,


### PR DESCRIPTION
We can apply simple anomaly detection based on average and standard
deviantion of metrics for each type of request hitting apiserver.

This should limit reliance on static threshold value which can vary a
lot in different situations.

This is largely based on @brian-brazil article from https://prometheus.io/blog/2015/06/18/practical-anomaly-detection/

/cc @brancz @s-urbaniak 