### PR TITLE
Use `default` as a picker value for datasource variable

### DIFF
--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -154,8 +154,8 @@ local singlestat = grafana.singlestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -135,8 +135,8 @@ local singlestat = grafana.singlestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -331,8 +331,8 @@ local singlestat = grafana.singlestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -359,8 +359,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -363,8 +363,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -382,8 +382,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -250,8 +250,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -254,8 +254,8 @@ local gauge = promgrafonnet.gauge;
       .addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -113,8 +113,8 @@ local gauge = promgrafonnet.gauge;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -131,8 +131,8 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -142,8 +142,8 @@ local singlestat = grafana.singlestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -130,8 +130,8 @@ local singlestat = grafana.singlestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -109,8 +109,8 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -26,8 +26,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,
@@ -143,8 +143,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,
@@ -236,8 +236,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,
@@ -357,8 +357,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,
@@ -442,8 +442,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
       ).addTemplate(
         {
           current: {
-            text: 'Prometheus',
-            value: 'Prometheus',
+            text: 'default',
+            value: 'default',
           },
           hide: 0,
           label: null,


### PR DESCRIPTION
There can be multiple  datasources of `type: prometheus` available (i.e.
Prometheus and Thanos) and a datasource can be marked as a `default`
which makes any dashboard using the `default` as a datasource
automatically use the one chosen by the user.

This PR makes the selector on the dashboards use the value of `default`.

The rendered files look OK and I tried a couple on a live server and that works for me. I have one issue: `kubernetes-mixin/dashboards_out/k8s-resources-cluster.json` still contains the `Prometheus`  for the selector and I don't see any more mentions of `Prometheus` anywhere in code. How does that file get that value?