### PR TITLE
Re-add group_left in namespace resource requests metrics. Fixes: #308

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -67,7 +67,7 @@
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
                           kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod) max by (namespace, pod) (
+                      ) * on(namespace, pod) group_left() max by (namespace, pod) (
                           kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )
@@ -81,7 +81,7 @@
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
                           kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod) max by (namespace, pod) (
+                      ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )


### PR DESCRIPTION
Sometimes the left side of these queries has more than one matching vector for
a given vector on the right side, such as when the pod has two containers. This
caused the namespace:kube_pod_container_resource_requests_memory_bytes:sum and
namespace:kube_pod_container_resource_requests_cpu_cores:sum rules to fail
evaluation with the following error:

    Error executing query: multiple matches for labels: many-to-one matching
    must be explicit (group_left/group_right)"

This commit reverts a recent change where `group_left` was removed:

https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/306#pullrequestreview-327321333