### PR TITLE
revert failed pod marked as NotReady

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -25,7 +25,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Failed|Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+              sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
This cherry-picks #296 into https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/release-0.2

cc @metalmatze @brancz @LiliC @paulfantom 