### PR TITLE
set background color for CPU and memory single stat

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -127,7 +127,11 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[1m]))' % $._config)
+          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[1m]))' % $._config) + 
+          {
+            colorBackground: true,
+            thresholds: "60,80",
+          },
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
@@ -139,7 +143,11 @@ local template = grafana.template;
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_memory_bytes{%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_memory_bytes{%(clusterLabel)s="$cluster"})' % $._config)+ 
+          {
+            colorBackground: true,
+            thresholds: "70,85",
+          },
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +


### PR DESCRIPTION
Add background color for those metrics, so if CPU or memory utilization becomes high the stats background will be yellow/green:
![image](https://user-images.githubusercontent.com/6730584/71447349-d8aa2280-2735-11ea-8d31-65445380b827.png)
