### PR TITLE
fix table headers in network graph

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -26,7 +26,6 @@ local gauge = promgrafonnet.gauge;
         link=false,
         linkTooltip='Drill down',
         linkUrl='',
-        pattern='',
         thresholds=[],
         type='number',
         unit='short'
@@ -39,7 +38,6 @@ local gauge = promgrafonnet.gauge;
         link: link,
         linkTooltip: linkTooltip,
         linkUrl: linkUrl,
-        pattern: pattern,
         thresholds: thresholds,
         type: type,
         unit: unit,
@@ -147,82 +145,72 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
         )
         .addColumn(
-          field='',
+          field='Time',
           style=newStyle(
             alias='Time',
-            type='hidden',
-            pattern='Time',
+            type='hidden'
           )
         )
         .addColumn(
-          field='',
+          field='Value #A',
           style=newStyle(
             alias='Current Bandwidth Received',
-            pattern='Value #A',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #B',
           style=newStyle(
             alias='Current Bandwidth Transmitted',
-            pattern='Value #B',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #C',
           style=newStyle(
             alias='Average Bandwidth Received',
-            pattern='Value #C',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #D',
           style=newStyle(
             alias='Average Bandwidth Transmitted',
-            pattern='Value #D',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #E',
           style=newStyle(
             alias='Rate of Received Packets',
-            pattern='Value #E',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #F',
           style=newStyle(
             alias='Rate of Transmitted Packets',
-            pattern='Value #F',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #G',
           style=newStyle(
             alias='Rate of Received Packets Dropped',
-            pattern='Value #G',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #H',
           style=newStyle(
             alias='Rate of Transmitted Packets Dropped',
-            pattern='Value #H',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='namespace',
           style=newStyle(
             alias='Namespace',
-            pattern='namespace',
             link=true,
             linkUrl='d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=$__cell',
           ),

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -26,7 +26,6 @@ local gauge = promgrafonnet.gauge;
         link=false,
         linkTooltip='Drill down',
         linkUrl='',
-        pattern='',
         thresholds=[],
         type='number',
         unit='short'
@@ -39,7 +38,6 @@ local gauge = promgrafonnet.gauge;
         link: link,
         linkTooltip: linkTooltip,
         linkUrl: linkUrl,
-        pattern: pattern,
         thresholds: thresholds,
         type: type,
         unit: unit,
@@ -160,66 +158,58 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
         )
         .addColumn(
-          field='',
+          field='Time',
           style=newStyle(
             alias='Time',
             type='hidden',
-            pattern='Time',
           )
         )
         .addColumn(
-          field='',
+          field='Value #A',
           style=newStyle(
             alias='Bandwidth Received',
-            pattern='Value #A',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #B',
           style=newStyle(
             alias='Bandwidth Transmitted',
-            pattern='Value #B',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #C',
           style=newStyle(
             alias='Rate of Received Packets',
-            pattern='Value #C',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #D',
           style=newStyle(
             alias='Rate of Transmitted Packets',
-            pattern='Value #D',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #E',
           style=newStyle(
             alias='Rate of Received Packets Dropped',
-            pattern='Value #E',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #F',
           style=newStyle(
             alias='Rate of Transmitted Packets Dropped',
-            pattern='Value #F',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='pod',
           style=newStyle(
             alias='Pod',
-            pattern='pod',
             link=true,
             linkUrl='d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell'
           ),

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -26,7 +26,6 @@ local gauge = promgrafonnet.gauge;
         link=false,
         linkTooltip='Drill down',
         linkUrl='',
-        pattern='',
         thresholds=[],
         type='number',
         unit='short'
@@ -39,7 +38,6 @@ local gauge = promgrafonnet.gauge;
         link: link,
         linkTooltip: linkTooltip,
         linkUrl: linkUrl,
-        pattern: pattern,
         thresholds: thresholds,
         type: type,
         unit: unit,
@@ -139,82 +137,72 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
         )
         .addColumn(
-          field='',
+          field='Time',
           style=newStyle(
             alias='Time',
-            type='hidden',
-            pattern='Time',
+            type='hidden'
           )
         )
         .addColumn(
-          field='',
+          field='Value #A',
           style=newStyle(
             alias='Current Bandwidth Received',
-            pattern='Value #A',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #B',
           style=newStyle(
             alias='Current Bandwidth Transmitted',
-            pattern='Value #B',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #C',
           style=newStyle(
             alias='Average Bandwidth Received',
-            pattern='Value #C',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #D',
           style=newStyle(
             alias='Average Bandwidth Transmitted',
-            pattern='Value #D',
             unit='Bps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #E',
           style=newStyle(
             alias='Rate of Received Packets',
-            pattern='Value #E',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #F',
           style=newStyle(
             alias='Rate of Transmitted Packets',
-            pattern='Value #F',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #G',
           style=newStyle(
             alias='Rate of Received Packets Dropped',
-            pattern='Value #G',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='Value #H',
           style=newStyle(
             alias='Rate of Transmitted Packets Dropped',
-            pattern='Value #H',
             unit='pps',
           ),
         )
         .addColumn(
-          field='',
+          field='workload',
           style=newStyle(
             alias='Workload',
-            pattern='workload',
             link=true,
             linkUrl='d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell'
           ),


### PR DESCRIPTION
The table headers on the network tables are not working:
![image](https://user-images.githubusercontent.com/6730584/71447824-380b3100-273c-11ea-9581-65b9e8530237.png)
Looking at the generated dashboard JSON, the `pattern` field of each column was empty. When I looked at the code for `table_panel.libsonnet`, I noticed it take the `pattern` from `field`:
```jsonnet
    addColumn(field, style):: self {
      local style_ = style { pattern: field },
      local column_ = { text: field, value: field },
      styles+: [style_],
      columns+: [column_],
    },
```
So I simply set the `field` to be the right name of the template to fix the bug:
![image](https://user-images.githubusercontent.com/6730584/71447852-acde6b00-273c-11ea-8c9b-2aaedfa5f893.png)

