### PR TITLE
Fix "instance" template var in kubelet dashboard

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -359,7 +359,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(kubelet_runtime_operations{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, instance)' % $._config,
+          'label_values(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, instance)' % $._config,
           refresh='time',
           includeAll=true,
           sort=1,


### PR DESCRIPTION
Fixes #335
- `kubelet_runtime_operations` is deprecated
- replace with `kubelet_runtime_operations_total`