### PR TITLE
Replace piecharts with Bar plots

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -7,7 +7,6 @@ local graphPanel = grafana.graphPanel;
 local tablePanel = grafana.tablePanel;
 local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
-local piechart = grafana.pieChartPanel;
 local promgrafonnet = import '../lib/promgrafonnet/promgrafonnet.libsonnet';
 local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;
@@ -43,42 +42,52 @@ local gauge = promgrafonnet.gauge;
         unit: unit,
       };
 
-      local newPieChartPanel(pieChartTitle, pieChartQuery) =
+      local newBarplotPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
         local target =
           prometheus.target(
-            pieChartQuery
+            graphQuery
           ) + {
-            instant: null,
             intervalFactor: 1,
-            legendFormat: '{{namespace}}',
+            legendFormat: legendFormat,
+            step: 10,
           };
 
-        piechart.new(
-          title=pieChartTitle,
+        graphPanel.new(
+          title=graphTitle,
+          span=24,
           datasource='$datasource',
-          pieType='donut',
+          fill=2,
+          min_span=24,
+          format=graphFormat,
+          min=0,
+          max=null,
+          show_xaxis=false,
+          x_axis_mode='series',
+          x_axis_values='current',
+          lines=false,
+          bars=true,
+          stack=false,
+          legend_show=true,
+          legend_values=true,
+          legend_min=false,
+          legend_max=false,
+          legend_current=true,
+          legend_avg=false,
+          legend_alignAsTable=true,
+          legend_rightSide=true,
+          legend_sort='current',
+          legend_sortDesc=true,
+          nullPointMode='null'
         ).addTarget(target) + {
-          breakpoint: '50%',
-          cacheTimeout: null,
-          combine: {
-            label: 'Others',
-            threshold: 0,
+          legend+: {
+            hideEmpty: true,
+            hideZero: true,
           },
-          fontSize: '80%',
-          format: 'Bps',
-          interval: null,
-          legend: {
-            percentage: true,
-            percentageDecimals: null,
-            show: true,
-            values: true,
+          paceLength: 10,
+          tooltip+: {
+            sort: 2,
           },
-          legendType: 'Right side',
-          maxDataPoints: 3,
-          nullPointMode: 'connected',
-          valueName: 'current',
         };
-
 
       local newGraphPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
         local target =
@@ -361,16 +370,16 @@ local gauge = promgrafonnet.gauge;
         },
       )
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Received',
-          pieChartQuery='sort_desc(sum(irate(container_network_receive_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Received',
+          graphQuery='sort_desc(sum(irate(container_network_receive_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Transmitted',
-          pieChartQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Transmitted',
+          graphQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -393,16 +402,16 @@ local gauge = promgrafonnet.gauge;
       .addPanel(
         averageBandwidthRow
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Received',
-            pieChartQuery='sort_desc(avg(irate(container_network_receive_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Received',
+            graphQuery='sort_desc(avg(irate(container_network_receive_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 11 }
         )
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Transmitted',
-            pieChartQuery='sort_desc(avg(irate(container_network_transmit_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Transmitted',
+            graphQuery='sort_desc(avg(irate(container_network_transmit_bytes_total{namespace=~".+"}[$interval:$resolution])) by (namespace))',
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 11 }
         ),

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -7,7 +7,6 @@ local graphPanel = grafana.graphPanel;
 local tablePanel = grafana.tablePanel;
 local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
-local piechart = grafana.pieChartPanel;
 local promgrafonnet = import '../lib/promgrafonnet/promgrafonnet.libsonnet';
 local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -7,7 +7,6 @@ local graphPanel = grafana.graphPanel;
 local tablePanel = grafana.tablePanel;
 local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
-local piechart = grafana.pieChartPanel;
 local promgrafonnet = import '../lib/promgrafonnet/promgrafonnet.libsonnet';
 local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;
@@ -43,40 +42,51 @@ local gauge = promgrafonnet.gauge;
         unit: unit,
       };
 
-      local newPieChartPanel(pieChartTitle, pieChartQuery) =
+      local newBarplotPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
         local target =
           prometheus.target(
-            pieChartQuery
+            graphQuery
           ) + {
-            instant: null,
             intervalFactor: 1,
-            legendFormat: '{{workload}}',
+            legendFormat: legendFormat,
+            step: 10,
           };
 
-        piechart.new(
-          title=pieChartTitle,
+        graphPanel.new(
+          title=graphTitle,
+          span=24,
           datasource='$datasource',
-          pieType='donut',
+          fill=2,
+          min_span=24,
+          format=graphFormat,
+          min=0,
+          max=null,
+          show_xaxis=false,
+          x_axis_mode='series',
+          x_axis_values='current',
+          lines=false,
+          bars=true,
+          stack=false,
+          legend_show=true,
+          legend_values=true,
+          legend_min=false,
+          legend_max=false,
+          legend_current=true,
+          legend_avg=false,
+          legend_alignAsTable=true,
+          legend_rightSide=true,
+          legend_sort='current',
+          legend_sortDesc=true,
+          nullPointMode='null'
         ).addTarget(target) + {
-          breakpoint: '50%',
-          cacheTimeout: null,
-          combine: {
-            label: 'Others',
-            threshold: 0,
+          legend+: {
+            hideEmpty: true,
+            hideZero: true,
           },
-          fontSize: '80%',
-          format: 'Bps',
-          interval: null,
-          legend: {
-            percentage: true,
-            percentageDecimals: null,
-            show: true,
-            values: true,
+          paceLength: 10,
+          tooltip+: {
+            sort: 2,
           },
-          legendType: 'Right side',
-          maxDataPoints: 3,
-          nullPointMode: 'connected',
-          valueName: 'current',
         };
 
       local newGraphPanel(graphTitle, graphQuery, graphFormat='Bps') =
@@ -390,9 +400,9 @@ local gauge = promgrafonnet.gauge;
       .addAnnotation(annotation.default)
       .addPanel(currentBandwidthRow, gridPos={ h: 1, w: 24, x: 0, y: 0 })
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Received',
-          pieChartQuery=|||
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Received',
+          graphQuery=|||
             sort_desc(sum(irate(container_network_receive_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
@@ -401,9 +411,9 @@ local gauge = promgrafonnet.gauge;
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Transmitted',
-          pieChartQuery=|||
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Transmitted',
+          graphQuery=|||
             sort_desc(sum(irate(container_network_transmit_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
@@ -462,9 +472,9 @@ local gauge = promgrafonnet.gauge;
       .addPanel(
         averageBandwidthRow
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Received',
-            pieChartQuery=|||
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Received',
+            graphQuery=|||
               sort_desc(avg(irate(container_network_receive_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
@@ -473,9 +483,9 @@ local gauge = promgrafonnet.gauge;
           gridPos={ h: 9, w: 12, x: 0, y: 20 }
         )
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Transmitted',
-            pieChartQuery=|||
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Transmitted',
+            graphQuery=|||
               sort_desc(avg(irate(container_network_transmit_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -407,6 +407,7 @@ local gauge = promgrafonnet.gauge;
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
           |||,
+          legendFormat='{{ workload }}',
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
@@ -418,6 +419,7 @@ local gauge = promgrafonnet.gauge;
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
           |||,
+          legendFormat='{{ workload }}',
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -479,6 +481,7 @@ local gauge = promgrafonnet.gauge;
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
             |||,
+            legendFormat='{{ workload }}',
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 20 }
         )
@@ -490,6 +493,7 @@ local gauge = promgrafonnet.gauge;
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
             |||,
+            legendFormat='{{ workload }}',
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 20 }
         ),

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -6,7 +6,6 @@ local template = grafana.template;
 local graphPanel = grafana.graphPanel;
 local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
-local piechart = grafana.pieChartPanel;
 local promgrafonnet = import '../lib/promgrafonnet/promgrafonnet.libsonnet';
 local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -6,7 +6,6 @@ local template = grafana.template;
 local graphPanel = grafana.graphPanel;
 local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
-local piechart = grafana.pieChartPanel;
 local promgrafonnet = import '../lib/promgrafonnet/promgrafonnet.libsonnet';
 local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;
@@ -16,40 +15,51 @@ local gauge = promgrafonnet.gauge;
 
     'workload-total.json':
 
-      local newPieChartPanel(pieChartTitle, pieChartQuery) =
+      local newBarplotPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
         local target =
           prometheus.target(
-            pieChartQuery
+            graphQuery
           ) + {
-            instant: null,
             intervalFactor: 1,
-            legendFormat: '{{pod}}',
+            legendFormat: legendFormat,
+            step: 10,
           };
 
-        piechart.new(
-          title=pieChartTitle,
+        graphPanel.new(
+          title=graphTitle,
+          span=24,
           datasource='$datasource',
-          pieType='donut',
+          fill=2,
+          min_span=24,
+          format=graphFormat,
+          min=0,
+          max=null,
+          show_xaxis=false,
+          x_axis_mode='series',
+          x_axis_values='current',
+          lines=false,
+          bars=true,
+          stack=false,
+          legend_show=true,
+          legend_values=true,
+          legend_min=false,
+          legend_max=false,
+          legend_current=true,
+          legend_avg=false,
+          legend_alignAsTable=true,
+          legend_rightSide=true,
+          legend_sort='current',
+          legend_sortDesc=true,
+          nullPointMode='null'
         ).addTarget(target) + {
-          breakpoint: '50%',
-          cacheTimeout: null,
-          combine: {
-            label: 'Others',
-            threshold: 0,
+          legend+: {
+            hideEmpty: true,
+            hideZero: true,
           },
-          fontSize: '80%',
-          format: 'Bps',
-          interval: null,
-          legend: {
-            percentage: true,
-            percentageDecimals: null,
-            show: true,
-            values: true,
+          paceLength: 10,
+          tooltip+: {
+            sort: 2,
           },
-          legendType: 'Right side',
-          maxDataPoints: 3,
-          nullPointMode: 'connected',
-          valueName: 'current',
         };
 
       local newGraphPanel(graphTitle, graphQuery, graphFormat='Bps') =
@@ -275,9 +285,9 @@ local gauge = promgrafonnet.gauge;
       .addAnnotation(annotation.default)
       .addPanel(currentBandwidthRow, gridPos={ h: 1, w: 24, x: 0, y: 0 })
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Received',
-          pieChartQuery=|||
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Received',
+          graphQuery=|||
             sort_desc(sum(irate(container_network_receive_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
@@ -286,9 +296,9 @@ local gauge = promgrafonnet.gauge;
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
-        newPieChartPanel(
-          pieChartTitle='Current Rate of Bytes Transmitted',
-          pieChartQuery=|||
+        newBarplotPanel(
+          graphTitle='Current Rate of Bytes Transmitted',
+          graphQuery=|||
             sort_desc(sum(irate(container_network_transmit_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
@@ -299,9 +309,9 @@ local gauge = promgrafonnet.gauge;
       .addPanel(
         averageBandwidthRow
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Received',
-            pieChartQuery=|||
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Received',
+            graphQuery=|||
               sort_desc(avg(irate(container_network_receive_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
@@ -310,9 +320,9 @@ local gauge = promgrafonnet.gauge;
           gridPos={ h: 9, w: 12, x: 0, y: 11 }
         )
         .addPanel(
-          newPieChartPanel(
-            pieChartTitle='Average Rate of Bytes Transmitted',
-            pieChartQuery=|||
+          newBarplotPanel(
+            graphTitle='Average Rate of Bytes Transmitted',
+            graphQuery=|||
               sort_desc(avg(irate(container_network_transmit_bytes_total{namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -292,6 +292,7 @@ local gauge = promgrafonnet.gauge;
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
           |||,
+          legendFormat='{{ pod }}',
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
@@ -303,6 +304,7 @@ local gauge = promgrafonnet.gauge;
             * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
           |||,
+          legendFormat='{{ pod }}',
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -316,6 +318,7 @@ local gauge = promgrafonnet.gauge;
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
             |||,
+            legendFormat='{{ pod }}',
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 11 }
         )
@@ -327,6 +330,7 @@ local gauge = promgrafonnet.gauge;
               * on (namespace,pod)
               group_left(workload,workload_type) mixin_pod_workload{namespace=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
             |||,
+            legendFormat='{{ pod }}',
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 11 }
         ),


### PR DESCRIPTION
The reasoning behind this PR is in https://github.com/coreos/kube-prometheus/issues/305#issuecomment-554664859. TL;DR: Pie charts are bad.

In second commit I fixed some inconsistencies in legends where it showed entries only as "namespace" text. Replaced it with pod name or workload name (like in the second screenshot).

Effect of this PR can be seen in the attached screenshots:
![01_cluster](https://user-images.githubusercontent.com/3531758/73180390-89308b00-4115-11ea-8d83-618f0f607f4e.png)
![02_workload](https://user-images.githubusercontent.com/3531758/73180391-89c92180-4115-11ea-83c1-43b43fd1287c.png)
![03_namespace_workload](https://user-images.githubusercontent.com/3531758/73180392-89c92180-4115-11ea-87bd-00c2c45ab902.png)


/cc: @brancz @s-urbaniak 