### PR TITLE
ignore placeholder namespaces

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -22,7 +22,7 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(placeholdersNamespaceSelector)s},)
+              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(placeholdersNamespaceSelector)s})
                 /
               sum(kube_node_status_allocatable_cpu_cores)
                 >

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -11,7 +11,7 @@
     namespaceOvercommitFactor: 1.5,
     cpuThrottlingPercent: 25,
     cpuThrottlingSelector: '',
-    placeholdersNamespaceSelector: null,
+    placeholdersNamespaceSelector: '',
   },
 
   prometheusAlerts+:: {

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -11,7 +11,10 @@
     namespaceOvercommitFactor: 1.5,
     cpuThrottlingPercent: 25,
     cpuThrottlingSelector: '',
-    placeholdersNamespaceSelector: '',
+    // Set this selector for seleting namespaces that contains resources used for overprovision
+    // See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler
+    // for more details.
+    ignoringOverprovisionedWorkloadSelector: '',
   },
 
   prometheusAlerts+:: {
@@ -22,7 +25,7 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(placeholdersNamespaceSelector)s})
+              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(ignoringOverprovisionedWorkloadSelector)s})
                 /
               sum(kube_node_status_allocatable_cpu_cores)
                 >
@@ -39,7 +42,7 @@
           {
             alert: 'KubeMemOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(placeholdersNamespaceSelector)s})
+              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(ignoringOverprovisionedWorkloadSelector)s})
                 /
               sum(kube_node_status_allocatable_memory_bytes)
                 >

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -11,6 +11,7 @@
     namespaceOvercommitFactor: 1.5,
     cpuThrottlingPercent: 25,
     cpuThrottlingSelector: '',
+    placeholdersNamespaceSelector: null,
   },
 
   prometheusAlerts+:: {
@@ -21,7 +22,7 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum)
+              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(placeholdersNamespaceSelector)s},)
                 /
               sum(kube_node_status_allocatable_cpu_cores)
                 >
@@ -38,7 +39,7 @@
           {
             alert: 'KubeMemOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum)
+              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(placeholdersNamespaceSelector)s})
                 /
               sum(kube_node_status_allocatable_memory_bytes)
                 >


### PR DESCRIPTION
When using cluster autoscaler, it is common to have a deployment that keeps a few nodes "empty" - this is how you can achieve [over provisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler). The CPU/memory overcommit alert should ignore those deployments because they there just to keep the node - and can be evicted any time a real pod need scheduling. I added a new property, `placeholdersNamespaceSelector` that can be set to ignore them.