### PR TITLE
config.libsonnet: add dasd devices for IBM Z systems

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -77,7 +77,7 @@ local slo = import 'slo-libsonnet/slo.libsonnet';
     fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
 
     // This list of disk device names is referenced in various expressions.
-    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
+    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
     diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
   },
 }


### PR DESCRIPTION
support metrics for dasd disk devices which are used by most IBM Z systems