### PR TITLE
[release-0.3] config.libsonnet: add dasd devices for IBM Z systems

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -77,7 +77,7 @@ local slo = import 'slo-libsonnet/slo.libsonnet';
     fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
 
     // This list of disk device names is referenced in various expressions.
-    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+'],
+    diskDevices: ['nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
     diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
   },
 }


### PR DESCRIPTION
support metrics for dasd disk devices which are used by most IBM Z systems

This is needed in releases 0.3 and 0.2 so that it can be incorporated in the cluster monitoring operator for the current release and release-4.3 to fix https://bugzilla.redhat.com/show_bug.cgi?id=1794934

(cherry picked from commit aaaefb771c25f3e6f49a5303966675bde8039f66)