### PR TITLE
Fix groupname is repeated in the same file error

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -14,7 +14,7 @@ local utils = import 'utils.libsonnet';
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'kube-apiserver-error',
+        name: 'kube-apiserver-error-alerts',
         rules:
           $._config.SLOs.apiserver.errors.alerts,
       },


### PR DESCRIPTION
#351  broke my prometheus rules:

```
level=error ts=2020-02-12T07:16:47.307Z caller=manager.go:832 component="rule manager" msg="loading groups failed" err="/etc/prometheus/rules/prometheus-k8s-rulefiles-0/monitoring-prometheus-k8s-rules.yaml: groupname: \"kube-apiserver-error\" is repeated in the same file"
```