### PR TITLE
Add KubeletPodStartUpLatencyHigh alert

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -74,6 +74,19 @@
               message: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.',
             },
           },
+          {
+            alert: 'KubeletPodStartUpLatencyHigh',
+            expr: |||
+              histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{%(kubeletSelector)s}[5m])) by (instance, le)) * on(instance) group_left(node) kubelet_node_name  > 5
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Kubelet Pod startup 99th percentile latency is {{ $value }} seconds on node {{ $labels.node }}.',
+            },
+          },
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'Kubelet',
             selector:: $._config.kubeletSelector,


### PR DESCRIPTION
This is more for discussion, feel free not to merge :)

I had an issue with kubelet taking long time to spin up pods, turns out there was a cronjob which had created cronjob with 700 image pull back off jobs, which made kubelet slow down on pod creation for other things.

So in general I think maybe it's worthwhile to monitor pod start up latency 