### PR TITLE
Do not alert mismatch replicas during rolling updates

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -53,9 +53,15 @@
           },
           {
             expr: |||
-              kube_deployment_spec_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-                !=
-              kube_deployment_status_replicas_available{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              (
+                kube_deployment_spec_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                  !=
+                kube_deployment_status_replicas_available{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              ) and (
+                changes(kube_deployment_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m])
+                  ==
+                0
+              )
             ||| % $._config,
             labels: {
               severity: 'critical',
@@ -68,9 +74,15 @@
           },
           {
             expr: |||
-              kube_statefulset_status_replicas_ready{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-                !=
-              kube_statefulset_status_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              (
+                kube_statefulset_status_replicas_ready{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                  !=
+                kube_statefulset_status_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              ) and (
+                changes(kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m])
+                  ==
+                0
+              )
             ||| % $._config,
             labels: {
               severity: 'critical',


### PR DESCRIPTION
We have some services (ie. Cortex ingesters) whose deployment takes a long time in a large clusters and cause the `KubeDeploymentReplicasMismatch` or `KubeStatefulSetReplicasMismatch` to trigger.

A solution we've found working for our use case is to change these alerts to not trigger until there's some progress during rolling updates. In this PR I'm proposing to upstream this change.