### PR TITLE
Fix KubeletTooManyPods on fargate nodes

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -37,6 +37,8 @@
           },
           {
             alert: 'KubeletTooManyPods',
+            // Some node has a capacity of 1 like AWS's Fargate and only exists while a pod is running on it.
+            // We have to ignore this special node in the KubeletTooManyPods alert.
             expr: |||
               max(max(kubelet_running_pod_count{%(kubeletSelector)s}) by(instance) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) by(node) / max(kube_node_status_capacity_pods{%(kubeStateMetricsSelector)s} != 1) by(node) > 0.95
             ||| % $._config,

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -38,7 +38,7 @@
           {
             alert: 'KubeletTooManyPods',
             expr: |||
-              max(max(kubelet_running_pod_count{%(kubeletSelector)s}) by(instance) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) by(node) / max(kube_node_status_capacity_pods{%(kubeStateMetricsSelector)s}) by(node) > 0.95
+              max(max(kubelet_running_pod_count{%(kubeletSelector)s}) by(instance) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s}) by(node) / max(kube_node_status_capacity_pods{%(kubeStateMetricsSelector)s} != 1) by(node) > 0.95
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
Some node has a capacity of 1 like AWS's Fargate and only exists while a pod is running on it.
We have to ignore this special node in the KubeletTooManyPods alert.