### PR TITLE
Preserve runbook urls

### DIFF
--- a/alerts/add-runbook-links.libsonnet
+++ b/alerts/add-runbook-links.libsonnet
@@ -15,7 +15,7 @@ local lower(x) =
 
   prometheusAlerts+::
     local addRunbookURL(rule) = rule {
-      [if 'alert' in rule then 'annotations']+: {
+      [if 'alert' in rule && !('runbook_url' in rule.annotations) then 'annotations']+: {
         runbook_url: $._config.runbookURLPattern % lower(rule.alert),
       },
     };


### PR DESCRIPTION
The `addRunbookURL` method overwrites this annotation on all of our alerts.  Adding a check to not add the rule if one already exists.