### PR TITLE
Add APIServer SLOs based on community guidelines

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -14,6 +14,32 @@ local utils = import 'utils.libsonnet';
   prometheusAlerts+:: {
     groups+: [
       {
+        name: 'kube-apiserver-slos',
+        rules: [
+          {
+            alert: 'KubeAPIErrorBudgetBurn',
+            expr: |||
+              sum(apiserver_request:burnrate%s) > (%.2f * %.5f)
+              and
+              sum(apiserver_request:burnrate%s) > (%.2f * %.5f)
+            ||| % [
+              w.long,
+              w.factor,
+              (1 - $._config.SLOs.apiserver.target),
+              w.short,
+              w.factor,
+              (1 - $._config.SLOs.apiserver.target),
+            ],
+            labels: {
+              severity: w.severity,
+            },
+            annotations: {
+              message: 'The API server is burning too much error budget',
+            },
+            'for': '%(for)s' % w,
+          }
+          for w in $._config.SLOs.apiserver.windows
+        ],
       },
       {
         name: 'kubernetes-system-apiserver',

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -14,9 +14,6 @@ local utils = import 'utils.libsonnet';
   prometheusAlerts+:: {
     groups+: [
       {
-        name: 'kube-apiserver-error-alerts',
-        rules:
-          $._config.SLOs.apiserver.errors.alerts,
       },
       {
         name: 'kubernetes-system-apiserver',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -4,14 +4,6 @@ local slo = import 'slo-libsonnet/slo.libsonnet';
   _config+:: {
     SLOs: {
       apiserver: {
-        // This is templating a Multiple Burn Rate Alerts for Kubernetes Apiservers.
-        // We will alert on burning too much error budget over 30 days.
-        // By default we have 99% availability (1% unavailability = 7h12m in 30d).
-        errors: slo.errorburn({
-          metric: 'apiserver_request_total',
-          selectors: [$._config.kubeApiserverSelector],
-          errorBudget: 1 - 0.99,
-        }),
       },
     },
 

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -4,16 +4,17 @@ local slo = import 'slo-libsonnet/slo.libsonnet';
   _config+:: {
     SLOs: {
       apiserver: {
-        days: 7,  // The number of days we alert on burning too much error budget for.
-        target: 0.99, // The target percentage of availability between 0-1. (0.99 = 99%, 0.999 = 99.9%)
+        days: 30,  // The number of days we alert on burning too much error budget for.
+        target: 0.99,  // The target percentage of availability between 0-1. (0.99 = 99%, 0.999 = 99.9%)
 
         // Only change these windows when you really understand multi burn rate errors.
-        // Otherwise change days and target above to make high-level changes.
+        // Even though you can change the days above (which will change availability calculations)
+        // these windows will alert on a 30 days sliding window. We're looking into basing these windows on the given days too.
         windows: [
-          { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 2 * (24 * $._config.SLOs.apiserver.days) / 100 },
-          { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 1 * (24 * $._config.SLOs.apiserver.days) / 100 },
-          { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 0.5 * (24 * $._config.SLOs.apiserver.days) / 100 },
-          { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 0.1 * (24 * $._config.SLOs.apiserver.days) / 100 },
+          { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 14.4 },
+          { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 6 },
+          { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 3 },
+          { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 1 },
         ],
       },
     },

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -4,6 +4,17 @@ local slo = import 'slo-libsonnet/slo.libsonnet';
   _config+:: {
     SLOs: {
       apiserver: {
+        days: 7,  // The number of days we alert on burning too much error budget for.
+        target: 0.99, // The target percentage of availability between 0-1. (0.99 = 99%, 0.999 = 99.9%)
+
+        // Only change these windows when you really understand multi burn rate errors.
+        // Otherwise change days and target above to make high-level changes.
+        windows: [
+          { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 2 * (24 * $._config.SLOs.apiserver.days) / 100 },
+          { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 1 * (24 * $._config.SLOs.apiserver.days) / 100 },
+          { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 0.5 * (24 * $._config.SLOs.apiserver.days) / 100 },
+          { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 0.1 * (24 * $._config.SLOs.apiserver.days) / 100 },
+        ],
       },
     },
 

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -19,6 +19,6 @@
         }
       },
       "version": "master"
-    },
+    }
   ]
 }

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -20,15 +20,5 @@
       },
       "version": "master"
     },
-    {
-      "name": "slo-libsonnet",
-      "source": {
-        "git": {
-          "remote": "https://github.com/metalmatze/slo-libsonnet",
-          "subdir": "slo-libsonnet"
-        }
-      },
-      "version": "master"
-    }
   ]
 }

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -7,11 +7,6 @@
   prometheusRules+:: {
     groups+: [
       {
-        name: 'kube-apiserver-error',
-        rules:
-          $._config.SLOs.apiserver.errors.recordingrules,
-      },
-      {
         name: 'kube-apiserver.rules',
         rules: [
           {

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -2,13 +2,200 @@
   _config+:: {
     kubeApiserverSelector: 'job="kube-apiserver"',
     podLabel: 'pod',
+    kubeApiserverReadSelector: 'verb=~"LIST|GET"',
+    kubeApiserverWriteSelector: 'verb=~"POST|PUT|PATCH|DELETE"',
   },
 
   prometheusRules+:: {
     groups+: [
       {
+        local SLODays = $._config.SLOs.apiserver.days + 'd',
+        local SLOTarget = $._config.SLOs.apiserver.target,
+        local verbs = [
+          { type: 'read', selector: $._config.kubeApiserverReadSelector },
+          { type: 'write', selector: $._config.kubeApiserverWriteSelector },
+        ],
+
         name: 'kube-apiserver.rules',
         rules: [
+          {
+            record: 'apiserver_request:burnrate%(window)s' % w,
+            expr: |||
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(window)s]))
+                  -
+                  (
+                    sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(window)s])) +
+                    sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(window)s])) +
+                    sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(window)s]))
+                  )
+                )
+                +
+                # errors
+                sum(rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,code=~"5.."}[%(window)s]))
+              )
+              /
+              sum(rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(window)s]))
+            ||| % {
+              window: w,
+              kubeApiserverSelector: $._config.kubeApiserverSelector,
+              kubeApiserverReadSelector: $._config.kubeApiserverReadSelector,
+            },
+            labels: {
+              verb: 'read',
+            },
+          }
+          for w in std.set([  // Get the unique array of short and long window rates
+            w.short
+            for w in $._config.SLOs.apiserver.windows
+          ] + [
+            w.long
+            for w in $._config.SLOs.apiserver.windows
+          ])
+        ] + [
+          {
+            record: 'apiserver_request:burnrate%(window)s' % w,
+            expr: |||
+              (
+                (
+                  # too slow
+                  sum(rate(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s}[%(window)s]))
+                  -
+                  sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,le="1"}[%(window)s]))
+                )
+                +
+                sum(rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,code=~"5.."}[%(window)s]))
+              )
+              /
+              sum(rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s}[%(window)s]))
+            ||| % {
+              window: w,
+              kubeApiserverSelector: $._config.kubeApiserverSelector,
+              kubeApiserverWriteSelector: $._config.kubeApiserverWriteSelector,
+            },
+            labels: {
+              verb: 'write',
+            },
+          }
+          for w in std.set([  // Get the unique array of short and long window rates
+            w.short
+            for w in $._config.SLOs.apiserver.windows
+          ] + [
+            w.long
+            for w in $._config.SLOs.apiserver.windows
+          ])
+        ] + [
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                (
+                  # write too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
+                ) +
+                (
+                  # read too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverReadSelector)s}[%(SLODays)s]))
+                  -
+                  (
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(SLODays)s])) +
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
+                  )
+                ) +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{code=~"5.."})
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s)
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'all',
+            },
+          },
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(SLODays)s]))
+                -
+                (
+                  # too slow
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(SLODays)s])) +
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{verb="read",code=~"5.."})
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s{verb="read"})
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'read',
+            },
+          },
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                (
+                  # too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{verb="write",code=~"5.."})
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s{verb="write"})
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'write',
+            },
+          },
+        ] + [
+          {
+            record: 'code:apiserver_request_total:increase%s' % SLODays,
+            expr: |||
+              sum by (code) (increase(apiserver_request_total{%s}[%s]))
+            ||| % [std.join(',', [$._config.kubeApiserverSelector, verb.selector]), SLODays],
+            labels: {
+              verb: verb.type,
+            },
+          }
+          for verb in verbs
+        ] + [
+          {
+            record: 'code_resource:apiserver_request_total:rate5m',
+            expr: |||
+              sum by (code,resource) (rate(apiserver_request_total{%s}[5m]))
+            ||| % std.join(',', [$._config.kubeApiserverSelector, verb.selector]),
+            labels: {
+              verb: verb.type,
+            },
+          }
+          for verb in verbs
+        ] + [
+          {
+            record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
+            expr: |||
+              histogram_quantile(0.99, sum by (le, resource) (rate(apiserver_request_duration_seconds_bucket{%s}[5m]))) > 0
+            ||| % std.join(',', [$._config.kubeApiserverSelector, verb.selector]),
+            labels: {
+              verb: verb.type,
+              quantile: '0.99',
+            },
+          }
+          for verb in verbs
+        ] + [
           {
             record: 'cluster:apiserver_request_duration_seconds:mean5m',
             expr: |||


### PR DESCRIPTION
SIG Scalability has some documents around SLOs for the APIServer. The make a difference between mutating, what I called _write_ (with verbs `verb=~"POST|PUT|PATCH|DELETE"`), and non-streaming read-only API calls, what I called _read_ (with verbs  `verb=~"LIST|GET"`).

This PR adds recording rules for multi error burn rate alerts and some general rules that compute the availability of the APIServer. Next to that I also added some singlestat showing the overall availability of the APIServer, a graph with the remaining error budget. In the 2 rows below I've added the SLIs for reading and writing. It's basically a RED dashboard row with the availability for read and write at the beginning.

As a user of the project, the only real decision I need to make are:
1. For what time span do I want to measure my availability - in days. 7 days by default.
1. What's the availability target I want to guarantee. 99% by default which is `0.99` as percentage is given as [0-1].

![Screenshot from 2020-03-19 11-44-05](https://user-images.githubusercontent.com/872251/77059281-fb677280-69d6-11ea-8dc3-1299463b1013.png)

/cc @brancz @beorn7 @krasi-georgiev @csmarchbanks @tomwilkie @omerlh @squat @lilic @s-urbaniak (sorry I missed more people)