### PR TITLE
Add intermediate recording rule for APIServer availability

### DIFF
--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -41,7 +41,7 @@ local singlestat = grafana.singlestat;
           format='percentunit',
           decimals=3,
         )
-        .addTarget(prometheus.target('apiserver_request:availability7d{verb="read"}'));
+        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="read"}' % $._config.SLOs.apiserver.days));
 
       local readRequests =
         graphPanel.new(
@@ -78,7 +78,7 @@ local singlestat = grafana.singlestat;
           format='percentunit',
           decimals=3,
         )
-        .addTarget(prometheus.target('apiserver_request:availability7d{verb="write"}'));
+        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="write"}' % $._config.SLOs.apiserver.days));
 
       local writeRequests =
         graphPanel.new(

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -161,12 +161,18 @@
               verb: 'write',
             },
           },
+          {
+            record: 'code_verb:apiserver_request_total:increase%s' % SLODays,
+            expr: |||
+              sum by (code, verb) (increase(apiserver_request_total{%s}[%s]))
+            ||| % [$._config.kubeApiserverSelector, SLODays],
+          },
         ] + [
           {
             record: 'code:apiserver_request_total:increase%s' % SLODays,
             expr: |||
-              sum by (code) (increase(apiserver_request_total{%s}[%s]))
-            ||| % [std.join(',', [$._config.kubeApiserverSelector, verb.selector]), SLODays],
+              sum by (code) (code_verb:apiserver_request_total:increase%s{%s})
+            ||| % [SLODays, verb.selector],
             labels: {
               verb: verb.type,
             },


### PR DESCRIPTION
After getting  a few reports (one for the previous implementation) I decided to split up the recording rule that calculates availability over 30d.

```
level=warn ts=2020-04-07T14:44:41.760Z caller=manager.go:525 component="rule manager" group=kube-apiserver.rules msg="Evaluating rule failed" rule="record: code:apiserver_request_total:increase30d\nexpr: sum by(code) (increase(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[30d]))\nlabels:\n  verb: write\n" err="query processing would load too many samples into memory in query execution"
```

Instead of calculating `sum by (code) (increase(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30d]))` directly, we now create the recording rule `code_verb:apiserver_request_total:increase30d` and then use those to do `sum by (code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})`. In the end we get the same results and I've verified that in the last 12 hours on my own cluster.

Thanks for reporting @johannwillgrubs, I hope this helps!