### PR TITLE
kausal/public -> grafana/jsonnet-libs for v0.1

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -14,7 +14,7 @@
             "name": "grafana-builder",
             "source": {
                 "git": {
-                    "remote": "https://github.com/kausalco/public",
+                    "remote": "https://github.com/grafana/jsonnet-libs",
                     "subdir": "grafana-builder"
                 }
             },


### PR DESCRIPTION
It's an old release, I know, but still used and installing using `jb v0.3` yields:

```
WARN: cannot link 'github.com/grafana/jsonnet-libs/grafana-builder' to 'vendor/grafana-builder', because package 'github.com/kausalco/public/grafana-builder' already uses that name. The absolute import still works
```