### PR TITLE
Skip unreachable alert for nodes subject to deletion

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -24,7 +24,7 @@
           },
           {
             expr: |||
-              kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+              kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="node.kubernetes.io/unreachable",effect="NoSchedule"} - kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="ToBeDeletedByClusterAutoscaler",effect="NoSchedule"} == 1
             ||| % $._config,
             'for': '2m',
             labels: {


### PR DESCRIPTION
I'm running on GKE cluster with autoscaling enabled, and reached this through prometheus-operator chart. What I see is that an alert gets raised during a few minutes before the node gets actually removed by the autoscaler. This change accounts for that fact and avoids those false positives.