### PR TITLE
Separate kube-apiserver-availability.rules into own group (w/ 3min interval)

### DIFF
--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -20,7 +20,7 @@ local singlestat = grafana.singlestat;
           span=4,
           format='percentunit',
           decimals=3,
-          description='How many percent of requests (both read and write) in %d days have been answered successfully and fast enough?' % 100 * $._config.SLOs.apiserver.days,
+          description='How many percent of requests (both read and write) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
         )
         .addTarget(prometheus.target('apiserver_request:availability%dd{verb="all"}' % $._config.SLOs.apiserver.days));
 

--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -15,21 +15,24 @@ local singlestat = grafana.singlestat;
     'apiserver.json':
       local availability1d =
         singlestat.new(
-          'Availability (%dd) > %.3f' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
+          'Availability (%dd) > %.3f%%' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
           datasource='$datasource',
           span=4,
           format='percentunit',
           decimals=3,
+          description='How many percent of requests (both read and write) in %d days have been answered successfully and fast enough?' % 100 * $._config.SLOs.apiserver.days,
         )
         .addTarget(prometheus.target('apiserver_request:availability%dd{verb="all"}' % $._config.SLOs.apiserver.days));
 
       local errorBudget =
         graphPanel.new(
-          'ErrorBudget (%dd) > %.3f' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
+          'ErrorBudget (%dd) > %.3f%%' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
           datasource='$datasource',
           span=8,
           format='percentunit',
           decimals=3,
+          fill=10,
+          description='How much error budget is left looking at our %.3f%% availability gurantees?' % $._config.SLOs.apiserver.target,
         )
         .addTarget(prometheus.target('100 * (apiserver_request:availability%dd{verb="all"} - %f)' % [$._config.SLOs.apiserver.days, $._config.SLOs.apiserver.target], legendFormat='errorbudget'));
 
@@ -40,6 +43,7 @@ local singlestat = grafana.singlestat;
           span=3,
           format='percentunit',
           decimals=3,
+          description='How many percent of read requests (LIST,GET) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
         )
         .addTarget(prometheus.target('apiserver_request:availability%dd{verb="read"}' % $._config.SLOs.apiserver.days));
 
@@ -49,15 +53,24 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           span=3,
           format='reqps',
+          stack=true,
+          fill=10,
+          description='How many read requests (LIST,GET) per second do the apiservers get by code?',
         )
-        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{verb="read"})'));
+        .addSeriesOverride({ alias: '/2../i', color: '#56A64B' })
+        .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
+        .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
+        .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
+        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="read"})', legendFormat='{{ code }}'));
 
       local readErrors =
         graphPanel.new(
           'Read SLI - Errors',
           datasource='$datasource',
+          min=0,
           span=3,
           format='percentunit',
+          description='How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?',
         )
         .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read",code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read"})', legendFormat='{{ resource }}'));
 
@@ -67,6 +80,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           span=3,
           format='s',
+          description='How many seconds is the 99th percentile for reading (LIST|GET) a given resource?',
         )
         .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="read"}', legendFormat='{{ resource }}'));
 
@@ -77,6 +91,7 @@ local singlestat = grafana.singlestat;
           span=3,
           format='percentunit',
           decimals=3,
+          description='How many percent of write requests (POST|PUT|PATCH|DELETE) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
         )
         .addTarget(prometheus.target('apiserver_request:availability%dd{verb="write"}' % $._config.SLOs.apiserver.days));
 
@@ -86,15 +101,24 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           span=3,
           format='reqps',
+          stack=true,
+          fill=10,
+          description='How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?',
         )
-        .addTarget(prometheus.target('sum(code_resource:apiserver_request_total:rate5m{verb="write"})'));
+        .addSeriesOverride({ alias: '/2../i', color: '#56A64B' })
+        .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
+        .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
+        .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
+        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="write"})', legendFormat='{{ code }}'));
 
       local writeErrors =
         graphPanel.new(
           'Write SLI - Errors',
           datasource='$datasource',
+          min=0,
           span=3,
           format='percentunit',
+          description='How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?',
         )
         .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write",code=~"5.."}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write"})', legendFormat='{{ resource }}'));
 
@@ -104,6 +128,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           span=3,
           format='s',
+          description='How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?',
         )
         .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="write"}', legendFormat='{{ resource }}'));
 
@@ -146,7 +171,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Add Rate',
           datasource='$datasource',
-          span=6,
+          span=4,
           format='ops',
           legend_show=false,
           min=0,
@@ -157,7 +182,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Depth',
           datasource='$datasource',
-          span=6,
+          span=4,
           format='short',
           legend_show=false,
           min=0,
@@ -169,7 +194,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Latency',
           datasource='$datasource',
-          span=12,
+          span=4,
           format='s',
           legend_show=true,
           legend_values=true,

--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -132,41 +132,6 @@ local singlestat = grafana.singlestat;
         )
         .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="write"}', legendFormat='{{ resource }}'));
 
-      local upCount =
-        singlestat.new(
-          'Up',
-          datasource='$datasource',
-          span=2,
-          valueName='min',
-        )
-        .addTarget(prometheus.target('sum(up{%(kubeApiserverSelector)s, %(clusterLabel)s="$cluster"})' % $._config));
-
-      local rpcRate =
-        graphPanel.new(
-          'RPC Rate',
-          datasource='$datasource',
-          span=5,
-          format='ops',
-        )
-        .addTarget(prometheus.target('sum(rate(apiserver_request_total{%(kubeApiserverSelector)s, instance=~"$instance",code=~"2..", %(clusterLabel)s="$cluster"}[5m]))' % $._config, legendFormat='2xx'))
-        .addTarget(prometheus.target('sum(rate(apiserver_request_total{%(kubeApiserverSelector)s, instance=~"$instance",code=~"3..", %(clusterLabel)s="$cluster"}[5m]))' % $._config, legendFormat='3xx'))
-        .addTarget(prometheus.target('sum(rate(apiserver_request_total{%(kubeApiserverSelector)s, instance=~"$instance",code=~"4..", %(clusterLabel)s="$cluster"}[5m]))' % $._config, legendFormat='4xx'))
-        .addTarget(prometheus.target('sum(rate(apiserver_request_total{%(kubeApiserverSelector)s, instance=~"$instance",code=~"5..", %(clusterLabel)s="$cluster"}[5m]))' % $._config, legendFormat='5xx'));
-
-      local requestDuration =
-        graphPanel.new(
-          'Request duration 99th quantile',
-          datasource='$datasource',
-          span=5,
-          format='s',
-          legend_show=true,
-          legend_values=true,
-          legend_current=true,
-          legend_alignAsTable=true,
-          legend_rightSide=true,
-        )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s, instance=~"$instance", verb!="WATCH", %(clusterLabel)s="$cluster"}[5m])) by (verb, le))' % $._config, legendFormat='{{verb}}'));
-
       local workQueueAddRate =
         graphPanel.new(
           'Work Queue Add Rate',
@@ -325,12 +290,6 @@ local singlestat = grafana.singlestat;
         .addPanel(writeRequests)
         .addPanel(writeErrors)
         .addPanel(writeDuration)
-      )
-      .addRow(
-        row.new()
-        .addPanel(upCount)
-        .addPanel(rpcRate)
-        .addPanel(requestDuration)
       ).addRow(
         row.new()
         .addPanel(workQueueAddRate)

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -6,16 +6,17 @@
     kubeApiserverWriteSelector: 'verb=~"POST|PUT|PATCH|DELETE"',
   },
 
+
   prometheusRules+:: {
+    local SLODays = $._config.SLOs.apiserver.days + 'd',
+    local SLOTarget = $._config.SLOs.apiserver.target,
+    local verbs = [
+      { type: 'read', selector: $._config.kubeApiserverReadSelector },
+      { type: 'write', selector: $._config.kubeApiserverWriteSelector },
+    ],
+
     groups+: [
       {
-        local SLODays = $._config.SLOs.apiserver.days + 'd',
-        local SLOTarget = $._config.SLOs.apiserver.target,
-        local verbs = [
-          { type: 'read', selector: $._config.kubeApiserverReadSelector },
-          { type: 'write', selector: $._config.kubeApiserverWriteSelector },
-        ],
-
         name: 'kube-apiserver.rules',
         rules: [
           {
@@ -27,7 +28,7 @@
                   sum(rate(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(window)s]))
                   -
                   (
-                    sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(window)s])) +
+                    sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(window)s])) +
                     sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(window)s])) +
                     sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(window)s]))
                   )
@@ -88,98 +89,6 @@
           ])
         ] + [
           {
-            record: 'apiserver_request:availability%s' % SLODays,
-            expr: |||
-              1 - (
-                (
-                  # write too slow
-                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
-                  -
-                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
-                ) +
-                (
-                  # read too slow
-                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverReadSelector)s}[%(SLODays)s]))
-                  -
-                  (
-                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(SLODays)s])) +
-                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
-                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
-                  )
-                ) +
-                # errors
-                sum(code:apiserver_request_total:increase%(SLODays)s{code=~"5.."})
-              )
-              /
-              sum(code:apiserver_request_total:increase%(SLODays)s)
-            ||| % ($._config { SLODays: SLODays }),
-            labels: {
-              verb: 'all',
-            },
-          },
-          {
-            record: 'apiserver_request:availability%s' % SLODays,
-            expr: |||
-              1 - (
-                sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(SLODays)s]))
-                -
-                (
-                  # too slow
-                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="resource",le="0.1"}[%(SLODays)s])) +
-                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
-                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
-                )
-                +
-                # errors
-                sum(code:apiserver_request_total:increase%(SLODays)s{verb="read",code=~"5.."})
-              )
-              /
-              sum(code:apiserver_request_total:increase%(SLODays)s{verb="read"})
-            ||| % ($._config { SLODays: SLODays }),
-            labels: {
-              verb: 'read',
-            },
-          },
-          {
-            record: 'apiserver_request:availability%s' % SLODays,
-            expr: |||
-              1 - (
-                (
-                  # too slow
-                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
-                  -
-                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
-                )
-                +
-                # errors
-                sum(code:apiserver_request_total:increase%(SLODays)s{verb="write",code=~"5.."})
-              )
-              /
-              sum(code:apiserver_request_total:increase%(SLODays)s{verb="write"})
-            ||| % ($._config { SLODays: SLODays }),
-            labels: {
-              verb: 'write',
-            },
-          },
-          {
-            record: 'code_verb:apiserver_request_total:increase%s' % SLODays,
-            expr: |||
-              sum by (code, verb) (increase(apiserver_request_total{%s}[%s]))
-            ||| % [$._config.kubeApiserverSelector, SLODays],
-          },
-        ] + [
-          {
-            record: 'code:apiserver_request_total:increase%s' % SLODays,
-            expr: |||
-              sum by (code) (code_verb:apiserver_request_total:increase%s{%s})
-            ||| % [SLODays, verb.selector],
-            labels: {
-              verb: verb.type,
-            },
-          }
-          for verb in verbs
-        ] + [
-          {
             record: 'code_resource:apiserver_request_total:rate5m',
             expr: |||
               sum by (code,resource) (rate(apiserver_request_total{%s}[5m]))
@@ -221,6 +130,106 @@
             },
           }
           for quantile in ['0.99', '0.9', '0.5']
+        ],
+      },
+      {
+        name: 'kube-apiserver-availability.rules',
+        interval: '3m',
+        rules: [
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                (
+                  # write too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
+                ) +
+                (
+                  # read too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverReadSelector)s}[%(SLODays)s]))
+                  -
+                  (
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(SLODays)s])) +
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
+                    sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
+                  )
+                ) +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s)
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'all',
+            },
+          },
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(SLODays)s]))
+                -
+                (
+                  # too slow
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(SLODays)s])) +
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s])) +
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="cluster",le="5"}[%(SLODays)s]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{verb="read",code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s{verb="read"})
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'read',
+            },
+          },
+          {
+            record: 'apiserver_request:availability%s' % SLODays,
+            expr: |||
+              1 - (
+                (
+                  # too slow
+                  sum(increase(apiserver_request_duration_seconds_count{%(kubeApiserverWriteSelector)s}[%(SLODays)s]))
+                  -
+                  sum(increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverWriteSelector)s,le="1"}[%(SLODays)s]))
+                )
+                +
+                # errors
+                sum(code:apiserver_request_total:increase%(SLODays)s{verb="write",code=~"5.."} or vector(0))
+              )
+              /
+              sum(code:apiserver_request_total:increase%(SLODays)s{verb="write"})
+            ||| % ($._config { SLODays: SLODays }),
+            labels: {
+              verb: 'write',
+            },
+          },
+        ] + [
+          {
+            record: 'code_verb:apiserver_request_total:increase%s' % SLODays,
+            expr: |||
+              sum by (code, verb) (increase(apiserver_request_total{%s,verb="%s",code=~"%s"}[%s]))
+            ||| % [$._config.kubeApiserverSelector, verb, code, SLODays],
+          }
+          for code in ['2..', '3..', '4..', '5..']
+          for verb in ['LIST', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+        ] + [
+          {
+            record: 'code:apiserver_request_total:increase%s' % SLODays,
+            expr: |||
+              sum by (code) (code_verb:apiserver_request_total:increase%s{%s})
+            ||| % [SLODays, verb.selector],
+            labels: {
+              verb: verb.type,
+            },
+          }
+          for verb in verbs
         ],
       },
     ],


### PR DESCRIPTION
## Recording Rules

First, I've added a more explicit `code_verb:apiserver_request_total:increase30d` recording rule for which we now iterate over `for code in ['2..', '3..', '4..', '5..']` and `for verb in ['LIST', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE']` evaluating these individual combinations on their own. This will add 24 more recording rules, but nicely split those up :)

![photo_2020-04-26_17-06-38](https://user-images.githubusercontent.com/872251/80360956-6c286700-8880-11ea-921f-09b6ed0eab6f.jpg)

The 3min evaluation interval has the nice side effect of really saving some CPU again (as reported by others resulting in higher usage, hi @smoke)

![Screenshot from 2020-04-27 10-25-14](https://user-images.githubusercontent.com/872251/80361125-b3aef300-8880-11ea-8322-1b51536abe39.png)

Additionally, I also had to fix the `scope=~"resource|"` for Kubernetes 1.18+, as the `scope="resource"` doesn't seem to exist anymore. 

---

## Dashboard

The dashboard need some cleaning up and I put a bit time into it:
![Screenshot from 2020-04-27 12-17-03](https://user-images.githubusercontent.com/872251/80361329-09839b00-8881-11ea-86da-4ba82ac44ba2.png)

The biggest change here would be that both Read and Write SLI - Requests panels now show the requests `by (code)`. I've deleted a few older and now duplicate panels too.
Each panel now has a description explaining a bit about what they show. 

/cc @brancz @povilasv @jamie-34254 @smoke @anyname2 @ekeih @billimek 

Closes https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/394 https://github.com/coreos/kube-prometheus/issues/503 https://github.com/helm/charts/pull/22003