### PR TITLE
Revert "Remove AggregatedAPIDown alert from 0.4-release"

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -121,6 +121,19 @@ local utils = import 'utils.libsonnet';
               message: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. The number of errors have increased for it in the past five minutes. High values indicate that the availability of the service changes too often.',
             },
           },
+          {
+            alert: 'AggregatedAPIDown',
+            expr: |||
+              sum by(name, namespace)(sum_over_time(aggregator_unavailable_apiservice[5m])) > 0
+            ||| % $._config,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} is down. It has not been available at least for the past five minutes.',
+            },
+          },
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeAPI',
             selector:: $._config.kubeApiserverSelector,


### PR DESCRIPTION
Reverts kubernetes-monitoring/kubernetes-mixin#407

Kubernetes 1.18 has the fix for this alert, so 0.4 should include this alert. (RE: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/358#issuecomment-593328376)

@povilasv @lilic 