### PR TITLE
adjust time window for `KubePodCrashLooping` alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -12,7 +12,7 @@
         rules: [
           {
             expr: |||
-              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) * 60 * 5 > 0
+              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m]) * 60 * 5 > 0
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Currently this alarm fires when a pod was `CrashLooping` during the last 5 minutes and not like mentioned in the message in the last 5 minutes.

Signed-off-by: Guus van Weelden <guus.vanweelden@moia.io>