### PR TITLE
prevent KubeNodeUnreachable from firing when cluster is autoscaled down

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -24,9 +24,8 @@
           },
           {
             expr: |||
-              kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+              (kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{%(kubeStateMetricsSelector)s,key="ToBeDeletedByClusterAutoscaler"}) == 1
             ||| % $._config,
-            'for': '2m',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
This is result of testing queries listed in comments in #300 on autoscaled cluster.

`for: 2m` is no longer necessary as autoscaler decision is taken into consideration during evaluation of alerting rule.

Fixes #300 
Different approach to #400 

