### PR TITLE
Add 'factor' label to KubeAPIErrorBudgetBurn alerts

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -31,6 +31,8 @@ local utils = import 'utils.libsonnet';
             ],
             labels: {
               severity: w.severity,
+              short: '%(short)s' % w,
+              long: '%(long)s' % w,
             },
             annotations: {
               message: 'The API server is burning too much error budget',


### PR DESCRIPTION
KubeAPIErrorBudgetBurn alerts can generate duplicate samples which would cause warnings in the Prometheus logs. For a given severity label (e.g. warning or critical), there are 2 alert rules for different burn rates but their labels sets are identical.
    
To avoid this situation, this change adds ~~a 'factor' label~~ 'short' and 'long' labels to differentiate between alerting rules.

Other options I have evaluated:
* ~~using the short and long interval of the alert.~~
* using the factor value of the alert.
* using the `for` clause.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1832819
