### PR TITLE
Double Cluster template in cluster dashboard with multi cluster enabled.

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -87,7 +87,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
-      ).addTemplate('cluster', 'node_cpu_seconds_total', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      )
       .addRow(
         (g.row('Headlines') +
          {


### PR DESCRIPTION
Template was added twice in this dashboard when `showMultiCluster: true` was set.