### PR TITLE
dashboards/resources: include static pods for overall pod count

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -39,7 +39,7 @@ local template = grafana.template;
 
 
       local podWorkloadColumns = [
-        'count(mixin_pod_workload{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+        'sum(kube_pod_owner{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
         'count(avg(mixin_pod_workload{%(clusterLabel)s="$cluster"}) by (workload, namespace)) by (namespace)' % $._config,
       ];
 


### PR DESCRIPTION
`mixin_pod_workload` doesn't include static pods. Using `kube_pod_owner` instead renders correct numbers.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1836048