### PR TITLE
fix panels with no data due to no minimal interval

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -69,6 +69,7 @@
 
       // The default refresh time for all dashboards, default to 10s
       refresh: '10s',
+      minimumTimeInterval: '1m',
     },
 
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -96,7 +96,8 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[$__interval]))' % $._config)
+          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[$__interval]))' % $._config) +
+          { interval: '1m' },
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
@@ -183,7 +184,8 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ),
+          ) +
+          { interval: '1m' },
         )
       )
       .addRow(

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -97,7 +97,7 @@ local template = grafana.template;
         .addPanel(
           g.panel('CPU Utilisation') +
           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[$__interval]))' % $._config) +
-          { interval: '1m' },
+          { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
@@ -185,7 +185,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: '1m' },
+          { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -237,7 +237,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: '1m' },
+          { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -236,7 +236,8 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ),
+          ) +
+          { interval: '1m' },
         )
       )
       .addRow(

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -215,7 +215,7 @@ local template = grafana.template;
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       )
       .addRow(
@@ -224,7 +224,7 @@ local template = grafana.template;
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       )
       .addRow(
@@ -233,7 +233,7 @@ local template = grafana.template;
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       )
       .addRow(
@@ -242,7 +242,7 @@ local template = grafana.template;
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       )
       .addRow(
@@ -251,7 +251,7 @@ local template = grafana.template;
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       )
       .addRow(
@@ -260,7 +260,7 @@ local template = grafana.template;
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps') },
+          { yaxes: g.yaxes('Bps'), interval: '1m' },
         )
       ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, podTemplate] }, refresh: $._config.grafanaK8s.refresh },
   },

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -215,7 +215,7 @@ local template = grafana.template;
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -224,7 +224,7 @@ local template = grafana.template;
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -233,7 +233,7 @@ local template = grafana.template;
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -242,7 +242,7 @@ local template = grafana.template;
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -251,7 +251,7 @@ local template = grafana.template;
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -260,7 +260,7 @@ local template = grafana.template;
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{namespace=~"$namespace", pod=~"$pod"}[$__interval])) by (pod)', '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: '1m' },
+          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, podTemplate] }, refresh: $._config.grafanaK8s.refresh },
   },

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -276,7 +276,8 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ),
+          ) +
+          { interval: '1m' },
         )
       )
       .addRow(
@@ -376,7 +377,7 @@ local template = grafana.template;
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel(|||
             (sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[$__interval])
-            * on (namespace,pod) 
+            * on (namespace,pod)
             group_left(workload,workload_type) mixin_pod_workload{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
           ||| % $._config, '{{workload}}') +
           g.stack +

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -277,7 +277,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: '1m' },
+          { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -219,7 +219,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: '1m' },
+          { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -218,7 +218,8 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ),
+          ) +
+          { interval: '1m' },
         )
       )
       .addRow(


### PR DESCRIPTION
fixes #429 

I went through all the `kubernetes-mixin` dashboard that had `No Data` / `N/A` errors and applied an interval to fix it.