### PR TITLE
alerts: do not include completed pods in KubeTooManyPods alert

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -78,12 +78,20 @@ tests:
 
 - interval: 1m
   input_series:
-  - series: 'kubelet_running_pod_count{endpoint="https-metrics",instance="10.0.2.15:10250",job="kubelet",namespace="kube-system",node="minikube",service="kubelet"}'
-    values: '110 110 110 110 110 110 110 110 110 110 110 110 110 110 108 108'
-  - series: 'kubelet_node_name{endpoint="https-metrics",instance="10.0.2.15:10250",job="kubelet",namespace="kube-system",node="minikube",service="kubelet"}'
-    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
-  - series: 'kube_node_status_capacity_pods{instance="172.17.0.5:8443",node="minikube", job="kube-state-metrics"}'
-    values: '110 110 110 110 110 110 110 110 110 110 110 110 110 110 110 110'
+  - series: 'kube_node_status_capacity_pods{instance="172.17.0.5:8443",node="minikube",job="kube-state-metrics", namespace="kube-system"}'
+    values: '3x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-1",service="kube-state-metrics"}'
+    values: '1x15'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-1",service="kube-state-metrics"}'
+    values: '1x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-2",service="kube-state-metrics"}'
+    values: '1x15'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-2",service="kube-state-metrics"}'
+    values: '1x15'
+  - series: 'kube_pod_info{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",node="minikube",pod="pod-3",service="kube-state-metrics"}'
+    values: '1x15'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="172.17.0.5:8443",job="kube-state-metrics",namespace="kube-system",phase="Running",pod="pod-3",service="kube-state-metrics"}'
+    values: '1x15'
   alert_rule_test:
   - eval_time: 10m
     alertname: KubeletTooManyPods
@@ -94,7 +102,7 @@ tests:
         node: minikube
         severity: warning
       exp_annotations:
-        message: "Kubelet 'minikube' is running at 98.18% of its Pod capacity."
+        message: "Kubelet 'minikube' is running at 100% of its Pod capacity."
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
 
 - interval: 1m


### PR DESCRIPTION
Currently, `kubelet_running_pod_count` includes `Completed` pods, which
is incorrect from the point of `KubeTooManyPods` alert. Since every pod needs to have `container_memory_rss` exposed, we can leverage it to find the actual number
of pods running on a node.

Workaround fix #442 