### PR TITLE
Do not fire KubeStatefulSetUpdateNotRolledOut while a statefulset is rolling out

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -120,16 +120,22 @@
           },
           {
             expr: |||
-              max without (revision) (
-                kube_statefulset_status_current_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-                  unless
-                kube_statefulset_status_update_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-              )
-                *
               (
-                kube_statefulset_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-                  !=
-                kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                max without (revision) (
+                  kube_statefulset_status_current_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                    unless
+                  kube_statefulset_status_update_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                )
+                  *
+                (
+                  kube_statefulset_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                    !=
+                  kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                )
+              )  and (
+                changes(kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m])
+                  ==
+                0
               )
             ||| % $._config,
             labels: {


### PR DESCRIPTION
I've noticed the `KubeStatefulSetUpdateNotRolledOut` fires every time a statefulset rollout takes more than 15m. In this PR I'm proposing to fix it using the same technique we used in the `KubeStatefulSetReplicasMismatch` and having the alert not alerting if the statefulset rollout is progressing.