### PR TITLE
dashboards: Default dashboards to UTC

### DIFF
--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -6,7 +6,7 @@
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
-      timezone: '',
+      timezone: 'UTC',
 
       // Modify tooltip to only show a single value
       rows: [


### PR DESCRIPTION
Various tools in the SRE space use UTC as the default to make it
effortless during incidents to not have to calculate between timezones.
Just an example, both Prometheus and Thanos default to this behavior as
well. People can still override this in downstream usage, but I think we
should be promoting best practices.

@povilasv @metalmatze @s-urbaniak @lilic 