### PR TITLE
remove KubeCronJobRunning alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -204,19 +204,6 @@
             'for': '15m',
           },
           {
-            alert: 'KubeCronJobRunning',
-            expr: |||
-              time() - kube_cronjob_next_schedule_time{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 3600
-            ||| % $._config,
-            'for': '1h',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.',
-            },
-          },
-          {
             alert: 'KubeJobCompletion',
             expr: |||
               kube_job_spec_completions{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_job_status_succeeded{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0

--- a/runbook.md
+++ b/runbook.md
@@ -57,11 +57,6 @@ This page collects this repositories alerts and begins the process of describing
 + *Message*: `A number of pods of daemonset {{$labels.namespace}}/{{$labels.daemonset}} are running where they are not supposed to run.`
 + *Severity*: warning
 
-##### Alert Name: "KubeCronJobRunning"
-+ *Message*: `CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.`
-+ *Severity*: warning
-+ *Action*: Check the cronjob using `kubectl describe cronjob <cronjob>` and look at the pod logs using `kubectl logs <pod>` for further information.
-
 ##### Alert Name: "KubeJobCompletion"
 + *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 1h to complete.`
 + *Severity*: warning


### PR DESCRIPTION
Alert is redundant with KubeJobCompletion, both provide the same information and fire in the same situation.

From my observations, `KubeJobCompletion` is better due to relying on more stable metrics. `KubeCronJobRunning` can cause false positives when kube-state-metrics doesn't properly update `kube_cronjob_next_schedule_time` metric (which in itself is kind of predicion type of metric).