### PR TITLE
dashboards/pod: Fix usage of duplicate cAdvisor time-series

### DIFF
--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -103,7 +103,7 @@ local template = grafana.template;
         g.row('CPU Throttling')
         .addPanel(
           g.panel('CPU Throttling') +
-          g.queryPanel('sum(increase(container_cpu_cfs_throttled_periods_total{namespace="$namespace", pod="$pod", container!="POD", %(clusterLabel)s="$cluster"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{namespace="$namespace", pod="$pod", container!="POD", %(clusterLabel)s="$cluster"}[5m])) by (container)' % $._config, '{{container}}') +
+          g.queryPanel('sum(increase(container_cpu_cfs_throttled_periods_total{namespace="$namespace", pod="$pod", container!="POD", container!="", %(clusterLabel)s="$cluster"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{namespace="$namespace", pod="$pod", container!="POD", container!="", %(clusterLabel)s="$cluster"}[5m])) by (container)' % $._config, '{{container}}') +
           g.stack
           + {
             yaxes: g.yaxes({ format: 'percentunit', max: 1 }),


### PR DESCRIPTION
Currently, Kubelet cAdvisor exports metrics for the parent cgroup as
well as for each container. This leads to having "duplicate metrics" and
espacially lead to strange or wrong visualisations.

Filtering by `container!=""` exclude metrics from the parent cgroup.
This patch avoids having two time-series in the CPU Throttling panel.

Related to #136 

Metrics from `container="POD"` are already removed from the current panel.

Before the patch:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/22404472/86602249-e87eab00-bf91-11ea-8e71-f0498aede521.png">

After the patch:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/22404472/86602280-f3394000-bf91-11ea-8439-8b99d648c68c.png">