### PR TITLE
ignore aws-node-termination-handler/spot-itn

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -5,6 +5,7 @@
     kubeNodeUnreachableIgnoreKeys: [
       'ToBeDeletedByClusterAutoscaler',
       'cloud.google.com/impending-node-termination',
+      'aws-node-termination-handler/spot-itn',
     ],
   },
 


### PR DESCRIPTION
For KubeNodeUnreachable, this can be ignored too.

Origin:
https://github.com/aws/aws-node-termination-handler/blob/f5f8766609022dd8c2df18367089205e3a8ce92e/pkg/node/node.go#L48-L49

Refs: #459, #460