### PR TITLE
Fix AggregatedAPIDown alert

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -84,14 +84,14 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'AggregatedAPIDown',
             expr: |||
-              sum by(name, namespace)(sum_over_time(aggregator_unavailable_apiservice[5m])) > 0
+              (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[5m]))) * 100 < 90
             ||| % $._config,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} is down. It has not been available at least for the past five minutes.',
+              message: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 5m.',
             },
           },
           (import '../lib/absent_alert.libsonnet') {


### PR DESCRIPTION
In the current form, the alert fires if
`aggregator_unavailable_apiservice` is 1 in only a single scrape. As
hinted in the message, that's probably not the intention of the alert.

Rather than requiren 5m complete downtime, however, I think it's best
to measure the availability over the last 5m and alert on that, still
guarded by a `for: 5m` clause to avoid firing if the metrics just
starts to come in for a new instance and happens to start with a
failure.

Signed-off-by: beorn7 <beorn@grafana.com>