### PR TITLE
change back span length for some panels in apiserver dashboard

### DIFF
--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -136,7 +136,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Add Rate',
           datasource='$datasource',
-          span=4,
+          span=6,
           format='ops',
           legend_show=false,
           min=0,
@@ -147,7 +147,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Depth',
           datasource='$datasource',
-          span=4,
+          span=6,
           format='short',
           legend_show=false,
           min=0,
@@ -159,7 +159,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Work Queue Latency',
           datasource='$datasource',
-          span=4,
+          span=12,
           format='s',
           legend_show=true,
           legend_values=true,


### PR DESCRIPTION
- revert back span length changes for workqueue metrics panels from https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/403

with span=4, workQueueLatency panel doesn't show the graph properly, legend data takes up the entire panel, due to the legend_show=true:

<img width="1603" alt="image" src="https://user-images.githubusercontent.com/3928411/87907752-04fef680-ca1a-11ea-83a7-5debfcdb30f8.png">


cc @metalmatze since he authored the original change.