### PR TITLE
alerts: prevent KubeJobCompletion and KubeJobFailed firing at the same time

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -208,7 +208,7 @@
             expr: |||
               kube_job_spec_completions{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_job_status_succeeded{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
             ||| % $._config,
-            'for': '1h',
+            'for': '12h',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
In most cases when KubeJobFailed is triggered, KubeJobCompletion follows and can cause alert fatigue. To solve this I propose to increase `for` statement in KubeJobCompletion. This way failing cron jobs would already be covered by `KubeJobFailed` and alerting on jobs entering infinite loop would be done after an extended period.

Additionally, it solves a problem of unnecessary alerting on longer running jobs (like backups).

Another approach would be to completely remove `KubeJobCompletion` alert or provide a customizable timeout.