### PR TITLE
alerts: prevent firing KubeJobCompletion and KubeJobFailed at the same time

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -215,7 +215,7 @@
             expr: |||
               kube_job_spec_completions{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_job_status_succeeded{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
             ||| % $._config,
-            'for': '1h',
+            'for': '12h',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
backport this change in order to allow it to be backported to older openshift versions