### PR TITLE
alerts: adjust error message accrodingly to recent change

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -213,7 +213,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.',
+              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12 hours to complete.',
             },
           },
           {


### PR DESCRIPTION
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/473 was introducing a change to the timeframe for which a jobs doesn't complete.
This PR adjusts the error message accordingly