### PR TITLE
alerts: adjust error message accrodingly to recent change

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -220,7 +220,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than one hour to complete.',
+              message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12 hours to complete.',
             },
           },
           {


### PR DESCRIPTION
backport this change in order to allow it to be backported to older openshift versions, such as 4.5

