### PR TITLE
KubeHpaMaxedOut should not alert for minReplicas == maxReplicas

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -285,6 +285,10 @@
               kube_hpa_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 ==
               kube_hpa_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                and
+              kube_hpa_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                !=
+              kube_hpa_spec_min_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
When horizontal pod autoscaler has minReplicas == maxReplicas, the
KubeHpaMaxedOut alert fires all the time. Since such configuration is
valid, this commit modified the alert to be fired only when max and
current replicas can actually be different.