### PR TITLE
Make `AggregatedAPIDown` even less noisy

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -88,14 +88,14 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'AggregatedAPIDown',
             expr: |||
-              (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[5m]))) * 100 < 90
+              (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
             ||| % $._config,
             'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              description: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 5m.',
+              description: 'An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 10m.',
               summary: 'An aggregated API is down.',
             },
           },


### PR DESCRIPTION
With the current setting, very few individual scrapes reporting the
API as unavailable can trigger the alert. Even with a scrape interval
of only 15s, the 5m range contains only 20 scrapes, and three scrapes
reporting the API as down will trigger the alert. With 30s scrape
interval, two scrapes will trigger. With 60s, even a single scrape is
enough.

With the suggested change, two scrape are needed with 60s interval,
four scrapes with 30s, and seven with 15s. Note that a consistently
down API will still trigger the alert after only 2m (plus the 5m from
the `for` clause). Response time is therefore not a problem. However,
if the availability is hovering around 90% all the time, the alert
will never fire. I'm assuming for now that that's not a problem to
alert on anyway, but it is, we need a second alert with a much longer
range, that would alert on long-term insufficiont availability.

Signed-off-by: beorn7 <beorn@grafana.com>