### PR TITLE
Add alerts for Kubelet client/server certificates

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -505,3 +505,118 @@ tests:
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
   - eval_time: 36m
     alertname: KubeDaemonSetRolloutStuck
+
+- interval: 1m
+  input_series:
+  - series: 'kubelet_certificate_manager_client_ttl_seconds{job="kubelet",namespace="monitoring",node="minikube"}'
+    values: '86400-60x1'
+  alert_rule_test:
+  - eval_time: 0m
+    alertname: KubeletClientCertificateExpiration
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet client certificate is about to expire."
+        description: 'Client certificate for Kubelet on node minikube expires in 1d 0h 0m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+  - eval_time: 1m
+    alertname: KubeletClientCertificateExpiration
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet client certificate is about to expire."
+        description: 'Client certificate for Kubelet on node minikube expires in 23h 59m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: critical
+      exp_annotations:
+        summary: "Kubelet client certificate is about to expire."
+        description: 'Client certificate for Kubelet on node minikube expires in 23h 59m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+
+- interval: 1m
+  input_series:
+  - series: 'kubelet_certificate_manager_server_ttl_seconds{job="kubelet",namespace="monitoring",node="minikube"}'
+    values: '86400-60x1'
+  alert_rule_test:
+  - eval_time: 0m
+    alertname: KubeletServerCertificateExpiration
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet server certificate is about to expire."
+        description: 'Server certificate for Kubelet on node minikube expires in 1d 0h 0m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+  - eval_time: 1m
+    alertname: KubeletServerCertificateExpiration
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet server certificate is about to expire."
+        description: 'Server certificate for Kubelet on node minikube expires in 23h 59m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: critical
+      exp_annotations:
+        summary: "Kubelet server certificate is about to expire."
+        description: 'Server certificate for Kubelet on node minikube expires in 23h 59m 0s.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+
+- interval: 1m
+  input_series:
+  - series: 'kubelet_certificate_manager_client_expiration_renew_errors{job="kubelet",namespace="monitoring",node="minikube"}'
+    values: '0+1x20'
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: KubeletClientCertificateRenewalErrors
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet has failed to renew its client certificate."
+        description: 'Kubelet on node minikube has failed to renew its client certificate (5 errors in the last 5 minutes).'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors
+
+
+- interval: 1m
+  input_series:
+  - series: 'kubelet_server_expiration_renew_errors{job="kubelet",namespace="monitoring",node="minikube"}'
+    values: '0+1x20'
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: KubeletServerCertificateRenewalErrors
+    exp_alerts:
+    - exp_labels:
+        job: kubelet
+        namespace: monitoring
+        node: minikube
+        severity: warning
+      exp_annotations:
+        summary: "Kubelet has failed to renew its server certificate."
+        description: 'Kubelet on node minikube has failed to renew its server certificate (5 errors in the last 5 minutes).'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors


### PR DESCRIPTION
This change adds alerts to monitor expirations of the kubelet's client
and server certificates as well as failures to renew the certificates.