### PR TITLE
Split the alerts for quota usage reached and exceeded

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -100,7 +100,7 @@
               kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}
                 / ignoring(instance, job, type)
               (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
-                = 1
+                == 1
             ||| % $._config,
             'for': '15m',
             labels: {

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -100,7 +100,7 @@
               kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}
                 / ignoring(instance, job, type)
               (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
-                >= 1
+                = 1
             ||| % $._config,
             'for': '15m',
             labels: {
@@ -109,6 +109,23 @@
             annotations: {
               description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.',
               summary: 'Namespace quota is fully used.',
+            },
+          },
+          {
+            alert: 'KubeQuotaExceeded',
+            expr: |||
+              kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}
+                / ignoring(instance, job, type)
+              (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
+                > 1
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.',
+              summary: 'Namespace quota has exceeded the limits.',
             },
           },
           {

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -95,6 +95,23 @@
             'for': '5m',
           },
           {
+            alert: 'KubeQuotaAlmostFull',
+            expr: |||
+              kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}
+                / ignoring(instance, job, type)
+              (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
+                > 0.9 < 1
+            ||| % $._config,
+            'for': '15m',
+            labels: {
+              severity: 'info',
+            },
+            annotations: {
+              description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.',
+              summary: 'Namespace quota is going to be full.',
+            },
+          },
+          {
             alert: 'KubeQuotaFullyUsed',
             expr: |||
               kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="used"}

--- a/runbook.md
+++ b/runbook.md
@@ -83,6 +83,9 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeQuotaFullyUsed"
 + *Message*: `{{ $value | humanizePercentage }} usage of {{ $labels.resource }} in namespace {{ $labels.namespace }}.`
 + *Severity*: info
+##### Alert Name: "KubeQuotaExceeded"
++ *Message*: `{{ $value | humanizePercentage }} usage of {{ $labels.resource }} in namespace {{ $labels.namespace }}.`
++ *Severity*: warning
 ### Group Name: "kubernetes-storage"
 ##### Alert Name: "KubePersistentVolumeFillingUp"
 + *Message*: `The persistent volume claimed by {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} has {{ $value | humanizePercentage }} free.`

--- a/runbook.md
+++ b/runbook.md
@@ -80,6 +80,9 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeMemOvercommit"
 + *Message*: `Overcommited Memory resource request quota on Namespaces.`
 + *Severity*: warning
+##### Alert Name: "KubeQuotaAlmostFull"
++ *Message*: `{{ $value | humanizePercentage }} usage of {{ $labels.resource }} in namespace {{ $labels.namespace }}.`
++ *Severity*: info
 ##### Alert Name: "KubeQuotaFullyUsed"
 + *Message*: `{{ $value | humanizePercentage }} usage of {{ $labels.resource }} in namespace {{ $labels.namespace }}.`
 + *Severity*: info


### PR DESCRIPTION
Add alert for KubeQuotaExceeded only when the quota exceeded and split the condition where 
the quota is reached `= 1` and quota is exceeded `> 1`.

As the quota being fully used should totally be ok. And no one will complain about this. 
So just inform the user in case they see any issue based on that. Like the application failed to be created.

And when the quota is over-committed, administrator or user should be alerted and take action on that.

cc @RiRa12621 @NautiluX 