### PR TITLE
Rename Kubelet pod/container counts for Kubernetes v1.19

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -26,7 +26,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(kubelet_running_pod_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
 
       local runningContainerCount =
         singlestat.new(
@@ -35,7 +35,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(kubelet_running_container_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
 
       local actualVolumeCount =
         singlestat.new(


### PR DESCRIPTION
* Kubelet v1.19 CHANGELOG lists two metrics renames
* `kubelet_running_pod_count` --> `kubelet_running_pods`
* `kubelet_running_container_count` --> `kubelet_running_containers`

Related: https://github.com/kubernetes/kubernetes/pull/92407