### PR TITLE
Backport #414

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -12,7 +12,7 @@
         rules: [
           {
             expr: |||
-              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) * 60 * 5 > 0
+              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m]) * 60 * 5 > 0
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Backporting #414 to fix the issue on 1.18 Kubernetes environments.


According to [support matrix](https://github.com/kubernetes-monitoring/kubernetes-mixin#releases), `release-0.4` is the branch responsible for k8s 1.18).