### PR TITLE
Renamed wmi_ metrics to windows_ for Windows_exporter

### DIFF
--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -47,7 +47,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - avg(rate(wmi_cpu_time_total{mode="idle"}[1m]))')
+          g.statPanel('1 - avg(rate(windows_cpu_time_total{mode="idle"}[1m]))')
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
@@ -459,7 +459,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         template.new(
           'instance',
           '$datasource',
-          'label_values(wmi_system_system_up_time, instance)',
+          'label_values(windows_system_system_up_time, instance)',
           label='Instance',
           refresh='time',
           sort=1,
@@ -474,7 +474,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         )
         .addPanel(
           g.panel('CPU Usage Per Core') +
-          g.queryPanel('sum by (core) (irate(wmi_cpu_time_total{%(wmiExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, '{{core}}') +
+          g.queryPanel('sum by (core) (irate(windows_cpu_time_total{%(wmiExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, '{{core}}') +
           { yaxes: g.yaxes('percentunit') },
         )
       )
@@ -492,13 +492,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
           .addTarget(prometheus.target(
             |||
               max(
-                wmi_os_visible_memory_bytes{%(wmiExporterSelector)s, instance="$instance"}
-                - wmi_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"}
+                windows_os_visible_memory_bytes{%(wmiExporterSelector)s, instance="$instance"}
+                - windows_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"}
               )
             ||| % $._config, legendFormat='memory used'
           ))
           .addTarget(prometheus.target('max(node:windows_node_memory_totalCached_bytes:sum{%(wmiExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory cached'))
-          .addTarget(prometheus.target('max(wmi_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory free'))
+          .addTarget(prometheus.target('max(windows_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory free'))
         )
         .addPanel(
           g.panel('Memory Saturation (Swap I/O) Pages') +
@@ -515,9 +515,9 @@ local g = import 'grafana-builder/grafana.libsonnet';
         )
         .addPanel(
           graphPanel.new('Disk I/O',)
-          .addTarget(prometheus.target('max(rate(wmi_logical_disk_read_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='read'))
-          .addTarget(prometheus.target('max(rate(wmi_logical_disk_write_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='written'))
-          .addTarget(prometheus.target('max(rate(wmi_logical_disk_read_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]) + rate(wmi_logical_disk_write_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]))' % $._config, legendFormat='io time')) +
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='read'))
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_write_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='written'))
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]) + rate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]))' % $._config, legendFormat='io time')) +
           {
             seriesOverrides: [
               {

--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -9,7 +9,7 @@
             record: 'node:windows_node:sum',
             expr: |||
               count (
-                wmi_system_system_up_time{%(wmiExporterSelector)s}
+                windows_system_system_up_time{%(wmiExporterSelector)s}
               )
             ||| % $._config,
           },
@@ -18,7 +18,7 @@
             record: 'node:windows_node_num_cpu:sum',
             expr: |||
               count by (instance) (sum by (instance, core) (
-                wmi_cpu_time_total{%(wmiExporterSelector)s}
+                windows_cpu_time_total{%(wmiExporterSelector)s}
               ))
             ||| % $._config,
           },
@@ -26,7 +26,7 @@
             // CPU utilisation is % CPU is not idle.
             record: ':windows_node_cpu_utilisation:avg1m',
             expr: |||
-              1 - avg(rate(wmi_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m]))
+              1 - avg(rate(windows_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m]))
             ||| % $._config,
           },
           {
@@ -34,7 +34,7 @@
             record: 'node:windows_node_cpu_utilisation:avg1m',
             expr: |||
               1 - avg by (instance) (
-                rate(wmi_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m])
+                rate(windows_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m])
               )
             ||| % $._config,
           },
@@ -42,9 +42,9 @@
             record: ':windows_node_memory_utilisation:',
             expr: |||
               1 -
-              sum(wmi_memory_available_bytes{%(wmiExporterSelector)s})
+              sum(windows_memory_available_bytes{%(wmiExporterSelector)s})
               /
-              sum(wmi_os_visible_memory_bytes{%(wmiExporterSelector)s})
+              sum(windows_os_visible_memory_bytes{%(wmiExporterSelector)s})
             ||| % $._config,
           },
           // Add separate rules for Free & Total, so we can aggregate across clusters
@@ -52,19 +52,19 @@
           {
             record: ':windows_node_memory_MemFreeCached_bytes:sum',
             expr: |||
-              sum(wmi_memory_available_bytes{%(wmiExporterSelector)s} + wmi_memory_cache_bytes{%(wmiExporterSelector)s})
+              sum(windows_memory_available_bytes{%(wmiExporterSelector)s} + windows_memory_cache_bytes{%(wmiExporterSelector)s})
             ||| % $._config,
           },
           {
             record: 'node:windows_node_memory_totalCached_bytes:sum',
             expr: |||
-              (wmi_memory_cache_bytes{%(wmiExporterSelector)s} + wmi_memory_modified_page_list_bytes{%(wmiExporterSelector)s} + wmi_memory_standby_cache_core_bytes{%(wmiExporterSelector)s} + wmi_memory_standby_cache_normal_priority_bytes{%(wmiExporterSelector)s} + wmi_memory_standby_cache_reserve_bytes{%(wmiExporterSelector)s})
+              (windows_memory_cache_bytes{%(wmiExporterSelector)s} + windows_memory_modified_page_list_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_core_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_normal_priority_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_reserve_bytes{%(wmiExporterSelector)s})
             ||| % $._config,
           },
           {
             record: ':windows_node_memory_MemTotal_bytes:sum',
             expr: |||
-              sum(wmi_os_visible_memory_bytes{%(wmiExporterSelector)s})
+              sum(windows_os_visible_memory_bytes{%(wmiExporterSelector)s})
             ||| % $._config,
           },
           {
@@ -73,7 +73,7 @@
             record: 'node:windows_node_memory_bytes_available:sum',
             expr: |||
               sum by (instance) (
-                (wmi_memory_available_bytes{%(wmiExporterSelector)s})
+                (windows_memory_available_bytes{%(wmiExporterSelector)s})
               )
             ||| % $._config,
           },
@@ -82,7 +82,7 @@
             record: 'node:windows_node_memory_bytes_total:sum',
             expr: |||
               sum by (instance) (
-                wmi_os_visible_memory_bytes{%(wmiExporterSelector)s}
+                windows_os_visible_memory_bytes{%(wmiExporterSelector)s}
               )
             ||| % $._config,
           },
@@ -104,15 +104,15 @@
           {
             record: 'node:windows_node_memory_swap_io_pages:irate',
             expr: |||
-              irate(wmi_memory_swap_page_operations_total{%(wmiExporterSelector)s}[5m])
+              irate(windows_memory_swap_page_operations_total{%(wmiExporterSelector)s}[5m])
             ||| % $._config,
           },
           {
             // Disk utilisation (ms spent, by rate() it's bound by 1 second)
             record: ':windows_node_disk_utilisation:avg_irate',
             expr: |||
-              avg(irate(wmi_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) + 
-                  irate(wmi_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m])
+              avg(irate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) + 
+                  irate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m])
                 )
             ||| % $._config,
           },
@@ -121,8 +121,8 @@
             record: 'node:windows_node_disk_utilisation:avg_irate',
             expr: |||
               avg by (instance) (
-                (irate(wmi_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) +
-                 irate(wmi_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m]))
+                (irate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) +
+                 irate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },
@@ -130,45 +130,45 @@
             record: 'node:windows_node_filesystem_usage:',
             expr: |||
               max by (instance,volume)(
-                (wmi_logical_disk_size_bytes{%(wmiExporterSelector)s}
-              - wmi_logical_disk_free_bytes{%(wmiExporterSelector)s})
-              / wmi_logical_disk_size_bytes{%(wmiExporterSelector)s}
+                (windows_logical_disk_size_bytes{%(wmiExporterSelector)s}
+              - windows_logical_disk_free_bytes{%(wmiExporterSelector)s})
+              / windows_logical_disk_size_bytes{%(wmiExporterSelector)s}
               )
             ||| % $._config,
           },
           {
             record: 'node:windows_node_filesystem_avail:',
             expr: |||
-              max by (instance, volume) (wmi_logical_disk_free_bytes{%(wmiExporterSelector)s} / wmi_logical_disk_size_bytes{%(wmiExporterSelector)s})
+              max by (instance, volume) (windows_logical_disk_free_bytes{%(wmiExporterSelector)s} / windows_logical_disk_size_bytes{%(wmiExporterSelector)s})
             ||| % $._config,
           },
           {
             record: ':windows_node_net_utilisation:sum_irate',
             expr: |||
-              sum(irate(wmi_net_bytes_total{%(wmiExporterSelector)s}[1m]))
+              sum(irate(windows_net_bytes_total{%(wmiExporterSelector)s}[1m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_utilisation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(wmi_net_bytes_total{%(wmiExporterSelector)s}[1m]))
+                (irate(windows_net_bytes_total{%(wmiExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },
           {
             record: ':windows_node_net_saturation:sum_irate',
             expr: |||
-              sum(irate(wmi_net_packets_received_discarded{%(wmiExporterSelector)s}[1m])) +
-              sum(irate(wmi_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
+              sum(irate(windows_net_packets_received_discarded{%(wmiExporterSelector)s}[1m])) +
+              sum(irate(windows_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_saturation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(wmi_net_packets_received_discarded{%(wmiExporterSelector)s}[1m]) +
-                irate(wmi_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
+                (irate(windows_net_packets_received_discarded{%(wmiExporterSelector)s}[1m]) +
+                irate(windows_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },
@@ -180,37 +180,37 @@
           {
             record: 'windows_container_available',
             expr: |||
-              wmi_container_available{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_available{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_total_runtime',
             expr: |||
-              wmi_container_cpu_usage_seconds_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_cpu_usage_seconds_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_memory_usage',
             expr: |||
-              wmi_container_memory_usage_commit_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_commit_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_private_working_set_usage',
             expr: |||
-              wmi_container_memory_usage_private_working_set_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_private_working_set_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_receive_bytes_total',
             expr: |||
-              wmi_container_network_receive_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_receive_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_transmit_bytes_total',
             expr: |||
-              wmi_container_network_transmit_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_transmit_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
Wmi_exporter has been renamed to windows_exporter and all the metrics prefix from wmi_ has been changed to windows_
This PR fix by updating the metrics prefixes.

https://github.com/prometheus-community/windows_exporter/releases/tag/v0.13.0