### PR TITLE
alerts: be explicit how to proceed when KubeJobFailed is firing

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -258,7 +258,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.',
+              description: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete. Removing failed job after investigation should clear this alert.',
               summary: 'Job failed to complete.',
             },
           },

--- a/tests.yaml
+++ b/tests.yaml
@@ -638,5 +638,5 @@ tests:
         job: kube-state-metrics
       exp_annotations:
         summary: "Job failed to complete."
-        description: "Job ns1/job-1597623120 failed to complete."
+        description: "Job ns1/job-1597623120 failed to complete. Removing failed job after investigation should clear this alert."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"


### PR DESCRIPTION
For some it is unclear how to proceed when this alert fires and mostly how to clear it even after failed job was investigated.


/cc @wking