### PR TITLE
alerts: prevent hpa false positive alerts

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -268,6 +268,14 @@
                 !=
               kube_hpa_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
                 and
+              (kube_hpa_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                >
+              kube_hpa_spec_min_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
+                and
+              (kube_hpa_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                <
+              kube_hpa_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
+                and
               changes(kube_hpa_status_current_replicas[15m]) == 0
             ||| % $._config,
             labels: {


### PR DESCRIPTION
When an HPA desired replicas count is outside of the specified min and max replicas count, an alert is firing. This can be annoying, for example, when the desired count is 0 but the min replicas count is 1.