### PR TITLE
dashboards/statefulset: Fix usage of duplicate cAdvisor time-series

### DIFF
--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -14,7 +14,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local cpuStat =
         numbersinglestat.new(
           'CPU',
-          'sum(rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$statefulset.*"}[3m]))' % $._config,
+          'sum(rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", container!="", namespace="$namespace", pod=~"$statefulset.*"}[3m]))' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('cores')
@@ -23,7 +23,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local memoryStat =
         numbersinglestat.new(
           'Memory',
-          'sum(container_memory_usage_bytes{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$statefulset.*"}) / 1024^3' % $._config,
+          'sum(container_memory_usage_bytes{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", container!="", namespace="$namespace", pod=~"$statefulset.*"}) / 1024^3' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('GB')
@@ -32,7 +32,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local networkStat =
         numbersinglestat.new(
           'Network',
-          'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$statefulset.*"}[3m])) + sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace="$namespace",pod=~"$statefulset.*"}[3m]))' % $._config,
+          'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$statefulset.*"}[3m])) + sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace",pod=~"$statefulset.*"}[3m]))' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('Bps')


### PR DESCRIPTION
Same as my previous PR (#456), partial fix for #136.

Currently, Kubelet cAdvisor exports metrics for the parent cgroup as
well as for each container. This leads to having "duplicate metrics" and
especially lead to strange or wrong visualizations.

Filtering by `container!=""` exclude metrics from the parent cgroup.
This patch avoids having two time-series in the CPU Throttling panel.

Unlike my previous PR, `container="POD"` is not removed from these panels but its value is always 0 AFAIK.

Sorry for the lack of screenshot.
**Before the PR:** values for CPU usage and Memory usage in the Statefulset dashboard are twice the real usage
**After the PR:** values match real usage

**Note:** I also added a missing cadvisorSelector for `container_network_receive_bytes_total`