### PR TITLE
feat: Adding cluster dimension to all aggregating alerting rules

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -26,15 +26,15 @@
           },
           {
             // We wrap kube_pod_owner with the topk() aggregator to ensure that
-            // every (namespace, pod) tuple is unique even if the "owner_kind"
+            // every (cluster, namespace, pod) tuple is unique even if the "owner_kind"
             // label exists for 2 values. This avoids "many-to-many matching
             // not allowed" errors when joining with kube_pod_status_phase.
             expr: |||
-              sum by (namespace, pod) (
-                max by(namespace, pod) (
+              sum by (cluster, namespace, pod) (
+                max by(cluster, namespace, pod) (
                   kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}
-                ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
-                  1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+                ) * on(cluster, namespace, pod) group_left(owner_kind) topk by(cluster, namespace, pod) (
+                  1, max by(cluster, namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
                 )
               ) > 0
             ||| % $._config,
@@ -192,7 +192,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
+              sum by (cluster, namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -30,11 +30,11 @@
             // label exists for 2 values. This avoids "many-to-many matching
             // not allowed" errors when joining with kube_pod_status_phase.
             expr: |||
-              sum by (cluster, namespace, pod) (
-                max by(cluster, namespace, pod) (
+              sum by (%(clusterLabel)s, namespace, pod) (
+                max by(%(clusterLabel)s, namespace, pod) (
                   kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}
-                ) * on(cluster, namespace, pod) group_left(owner_kind) topk by(cluster, namespace, pod) (
-                  1, max by(cluster, namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+                ) * on(%(clusterLabel)s, namespace, pod) group_left(owner_kind) topk by(%(clusterLabel)s, namespace, pod) (
+                  1, max by(%(clusterLabel)s, namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
                 )
               ) > 0
             ||| % $._config,
@@ -192,7 +192,7 @@
           },
           {
             expr: |||
-              sum by (cluster, namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
+              sum by (%(clusterLabel)s, namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -52,11 +52,11 @@
             // Some node has a capacity of 1 like AWS's Fargate and only exists while a pod is running on it.
             // We have to ignore this special node in the KubeletTooManyPods alert.
             expr: |||
-              count by(node) (
-                (kube_pod_status_phase{%(kubeStateMetricsSelector)s,phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{%(kubeStateMetricsSelector)s})
+              count by(cluster, node) (
+                (kube_pod_status_phase{%(kubeStateMetricsSelector)s,phase="Running"} == 1) * on(instance,pod,namespace) group_left(cluster, node) topk by(instance,pod,namespace) (1, kube_pod_info{%(kubeStateMetricsSelector)s})
               )
               /
-              max by(node) (
+              max by(cluster, node) (
                 kube_node_status_capacity_pods{%(kubeStateMetricsSelector)s} != 1
               ) > 0.95
             ||| % $._config,
@@ -72,7 +72,7 @@
           {
             alert: 'KubeNodeReadinessFlapping',
             expr: |||
-              sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (node) > 2
+              sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (cluster, node) > 2
             ||| % $._config,
             'for': '15m',
             labels: {
@@ -100,7 +100,7 @@
           {
             alert: 'KubeletPodStartUpLatencyHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{%(kubeletSelector)s}[5m])) by (instance, le)) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s} > 60
+              histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{%(kubeletSelector)s}[5m])) by (instance, le)) * on(instance) group_left(cluster, node) kubelet_node_name{%(kubeletSelector)s} > 60
             ||| % $._config,
             'for': '15m',
             labels: {

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -25,11 +25,11 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(ignoringOverprovisionedWorkloadSelector)s})
+              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (cluster)
                 /
-              sum(kube_node_status_allocatable_cpu_cores)
+              sum(kube_node_status_allocatable_cpu_cores) by (cluster)
                 >
-              (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
+              (count(kube_node_status_allocatable_cpu_cores) by (cluster) - 1) / count(kube_node_status_allocatable_cpu_cores) by (cluster)
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -43,13 +43,13 @@
           {
             alert: 'KubeMemoryOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(ignoringOverprovisionedWorkloadSelector)s})
+              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (cluster)
                 /
-              sum(kube_node_status_allocatable_memory_bytes)
+              sum(kube_node_status_allocatable_memory_bytes) by (cluster)
                 >
-              (count(kube_node_status_allocatable_memory_bytes)-1)
+              (count(kube_node_status_allocatable_memory_bytes) by (cluster) -1)
                 /
-              count(kube_node_status_allocatable_memory_bytes)
+              count(kube_node_status_allocatable_memory_bytes) by (cluster)
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -63,9 +63,9 @@
           {
             alert: 'KubeCPUQuotaOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="cpu"})
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="cpu"}) by (cluster)
                 /
-              sum(kube_node_status_allocatable_cpu_cores)
+              sum(kube_node_status_allocatable_cpu_cores) by (cluster)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -80,9 +80,9 @@
           {
             alert: 'KubeMemoryQuotaOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"})
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"}) by (cluster)
                 /
-              sum(kube_node_status_allocatable_memory_bytes{%(kubeStateMetricsSelector)s})
+              sum(kube_node_status_allocatable_memory_bytes{%(kubeStateMetricsSelector)s}) by (cluster)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -148,9 +148,9 @@
           {
             alert: 'CPUThrottlingHigh',
             expr: |||
-              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)
+              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, cluster)
                 /
-              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)
+              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, cluster)
                 > ( %(cpuThrottlingPercent)s / 100 )
             ||| % $._config,
             'for': '15m',

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -25,11 +25,11 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (cluster)
+              sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (%(clusterLabel)s)
                 /
-              sum(kube_node_status_allocatable_cpu_cores) by (cluster)
+              sum(kube_node_status_allocatable_cpu_cores) by (%(clusterLabel)s)
                 >
-              (count(kube_node_status_allocatable_cpu_cores) by (cluster) - 1) / count(kube_node_status_allocatable_cpu_cores) by (cluster)
+              (count(kube_node_status_allocatable_cpu_cores) by (%(clusterLabel)s) - 1) / count(kube_node_status_allocatable_cpu_cores) by (%(clusterLabel)s)
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -43,13 +43,13 @@
           {
             alert: 'KubeMemoryOvercommit',
             expr: |||
-              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (cluster)
+              sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (%(clusterLabel)s)
                 /
-              sum(kube_node_status_allocatable_memory_bytes) by (cluster)
+              sum(kube_node_status_allocatable_memory_bytes) by (%(clusterLabel)s)
                 >
-              (count(kube_node_status_allocatable_memory_bytes) by (cluster) -1)
+              (count(kube_node_status_allocatable_memory_bytes) by (%(clusterLabel)s) -1)
                 /
-              count(kube_node_status_allocatable_memory_bytes) by (cluster)
+              count(kube_node_status_allocatable_memory_bytes) by (%(clusterLabel)s)
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -63,9 +63,9 @@
           {
             alert: 'KubeCPUQuotaOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="cpu"}) by (cluster)
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="cpu"}) by (%(clusterLabel)s)
                 /
-              sum(kube_node_status_allocatable_cpu_cores) by (cluster)
+              sum(kube_node_status_allocatable_cpu_cores) by (%(clusterLabel)s)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -80,9 +80,9 @@
           {
             alert: 'KubeMemoryQuotaOvercommit',
             expr: |||
-              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"}) by (cluster)
+              sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"}) by (%(clusterLabel)s)
                 /
-              sum(kube_node_status_allocatable_memory_bytes{%(kubeStateMetricsSelector)s}) by (cluster)
+              sum(kube_node_status_allocatable_memory_bytes{%(kubeStateMetricsSelector)s}) by (%(clusterLabel)s)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -148,9 +148,9 @@
           {
             alert: 'CPUThrottlingHigh',
             expr: |||
-              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, cluster)
+              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, %(clusterLabel)s)
                 /
-              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, cluster)
+              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, %(clusterLabel)s)
                 > ( %(cpuThrottlingPercent)s / 100 )
             ||| % $._config,
             'for': '15m',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -32,7 +32,7 @@
                 /
               sum(rate(rest_client_requests_total[5m])) by (%(clusterLabel)s, instance, job))
               > 0.01
-            |||,
+            ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -11,7 +11,7 @@
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count by (cluster) (count by (cluster, gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))) > 1
+              count by (%(clusterLabel)s) (count by (%(clusterLabel)s, gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))) > 1
             ||| % $._config,
             'for': '15m',
             labels: {
@@ -28,9 +28,9 @@
             // this is normal and an expected error, therefore it should be
             // ignored in this alert.
             expr: |||
-              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
+              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (%(clusterLabel)s, instance, job)
                 /
-              sum(rate(rest_client_requests_total[5m])) by (instance, job))
+              sum(rate(rest_client_requests_total[5m])) by (%(clusterLabel)s, instance, job))
               > 0.01
             |||,
             'for': '15m',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -11,7 +11,7 @@
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))) > 1
+              count by (cluster) (count by (cluster, gitVersion) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))) > 1
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
This is indeed a very nice collection of both alerting and recording rules as well as dashboards. However, while the dashboards are indeed prepared to be run on something like Cortex assuming timeseries from multiple clusters the alert rules did not all have multi-cluster support.

I have gone through the alerting rules to make sure the label defined in the configuration `clusterLabel` is present on all alerts. So if alerts are evaluated in a setup with data from multiple clusters the alert will carry a label identifying the cluster triggering the alert - could be used for routing in Alertmanager etc. 