### PR TITLE
Remove recording rules which are used in neither dashboards nor alerts

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -10,12 +10,6 @@
         name: 'k8s.rules',
         rules: [
           {
-            record: 'namespace:container_cpu_usage_seconds_total:sum_rate',
-            expr: |||
-              sum(rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, image!="", container!="POD"}[5m])) by (namespace)
-            ||| % $._config,
-          },
-          {
             // Reduces cardinality of this timeseries by #cores, which makes it
             // more useable in dashboards.  Also, allows us to do things like
             // quantile_over_time(...) which would otherwise not be possible.
@@ -62,12 +56,6 @@
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
-          },
-          {
-            record: 'namespace:container_memory_usage_bytes:sum',
-            expr: |||
-              sum(container_memory_usage_bytes{%(cadvisorSelector)s, image!="", container!="POD"}) by (namespace)
             ||| % $._config,
           },
           {

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -118,15 +118,6 @@
           for verb in verbs
         ] + [
           {
-            record: 'cluster:apiserver_request_duration_seconds:mean5m',
-            expr: |||
-              sum(rate(apiserver_request_duration_seconds_sum{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s)
-              /
-              sum(rate(apiserver_request_duration_seconds_count{subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s)
-            ||| % ($._config),
-          },
-        ] + [
-          {
             record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
             expr: |||
               histogram_quantile(%(quantile)s, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s))

--- a/rules/node.libsonnet
+++ b/rules/node.libsonnet
@@ -11,14 +11,6 @@
         name: 'node.rules',
         rules: [
           {
-            // Number of nodes in the cluster
-            // SINCE 2018-02-08
-            record: ':kube_pod_info_node_count:',
-            expr: |||
-              sum(min(kube_pod_info{node!=""}) by (%(clusterLabel)s, node))
-            ||| % $._config,
-          },
-          {
             // This rule results in the tuples (node, namespace, instance) => 1.
             // It is used to calculate per-node metrics, given namespace & instance.
             // We use the topk() aggregator to ensure that each (namespace,


### PR DESCRIPTION
As in title.

Additionally, all rules from [kube_scheduler.libsonnet](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/rules/kube_scheduler.libsonnet) are unused, should we remove them?