### PR TITLE
README: cut release-0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 | release-0.3  | v1.17 and before   | v2.11.0+  |
 | release-0.4  | v1.18              | v2.11.0+  |
 | release-0.5  | v1.19              | v2.11.0+  |
-| master       | v1.19              | v2.11.0+  |
+| release-0.6  | v1.19+             | v2.11.0+  |
+| master       | v1.19+             | v2.11.0+  |
 
 In Kubernetes 1.14 there was a major [metrics overhaul](https://github.com/kubernetes/enhancements/issues/1206) implemented.
 Therefore v0.1.x of this repository is the last release to support Kubernetes 1.13 and previous version on a best effort basis.


### PR DESCRIPTION
Note: technically we do plan to use release-0.6 in k8s 1.20, so tentatively setting `1.19+` in the compatibility matrix but since it is not released yet.

Please let me know if this ok from the maintainers perspective. We can also bump to `1.20`.

Signed-off-by: Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>