### PR TITLE
OWNERS: add povilasv and paulfantom

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,8 @@ approvers:
 - metalmatze
 - tomwilkie
 - s-urbaniak
+- povilasv
+- paulfantom
 
 reviewers:
 - brancz
@@ -13,3 +15,5 @@ reviewers:
 - metalmatze
 - tomwilkie
 - s-urbaniak
+- povilasv
+- paulfantom


### PR DESCRIPTION
As discussed in Kubernetes Slack, I kindly suggest to add @paulfantom to the list of maintainers (approvers and reviewers) for this repository :-)

This also adds @povilasv to the OWNERS file as his alias was missing.

cc @brancz @povilasv @tomwilkie @csmarchbanks @metalmatze @paulfantom 

side note: I do not have permissions to add @paulfantom to the github team member list, so I kindly ask an owner to do this. Thank you!