### PR TITLE
Fix `code_verb:apiserver_request_total:increase30d` loading too many samples

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -228,12 +228,18 @@
               verb: 'write',
             },
           },
-        ] + [
           {
             record: 'code_verb:apiserver_request_total:increase%s' % SLODays,
             expr: |||
-              sum by (code, verb) (increase(apiserver_request_total{%s,verb="%s",code=~"%s"}[%s]))
-            ||| % [$._config.kubeApiserverSelector, verb, code, SLODays],
+              avg_over_time(code_verb:apiserver_request_total:increase1h[%s]) * 24 * %d
+            ||| % [SLODays, $._config.SLOs.apiserver.days],
+          },
+        ] + [
+          {
+            record: 'code_verb:apiserver_request_total:increase1h',
+            expr: |||
+              sum by (code, verb) (increase(apiserver_request_total{%s,verb="%s",code=~"%s"}[1h]))
+            ||| % [$._config.kubeApiserverSelector, verb, code],
           }
           for code in ['2..', '3..', '4..', '5..']
           for verb in ['LIST', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE']


### PR DESCRIPTION
This PR applies the following suggestion from @beorn7 https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/411#issuecomment-641238064, to fix Prometheus evaluation errors reporting that the `code_verb:apiserver_request_total:increase30d` recording rule can't be evaluated because it's loading too many samples.

After experimenting with the suggested recording rule https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/411#issuecomment-748167633, it was concluded that the new lightweight approach is precise enough to replace the existing one.

Fixes #411 