### PR TITLE
Add New Alert to notify on APIServer Terminated Request

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -103,6 +103,20 @@ local utils = import 'utils.libsonnet';
             componentName:: 'KubeAPI',
             selector:: $._config.kubeApiserverSelector,
           },
+          {
+            alert: 'KubeAPITerminatedRequests',
+            expr: |||
+              sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m]))  / (  sum(rate(apiserver_request_total{%(kubeApiserverSelector)s}[10m])) + sum(rate(apiserver_request_terminations_total{%(kubeApiserverSelector)s}[10m])) ) > 0.20
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'The apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.',
+              summary: 'The apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.',
+            },
+            'for': '5m',
+          },
         ],
       },
     ],

--- a/runbook.md
+++ b/runbook.md
@@ -118,6 +118,10 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeClientCertificateExpiration"
 + *Message*: `A client certificate used to authenticate to the apiserver is expiring in less than 1 day.`
 + *Severity*: critical
+##### Alert Name: "KubeAPITerminatedRequests"
++ *Message*: `The apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.`
++ *Severity*: warning
++ *Action*: Use the `apiserver_flowcontrol_rejected_requests_total` metric to determine which flow schema is throttling the traffic to the API Server. The flow schema also provides information on the affected resources and subjects.
 
 ## Other Kubernetes Runbooks and troubleshooting
 + [Troubleshoot Clusters ](https://kubernetes.io/docs/tasks/debug-application-cluster/debug-cluster/)

--- a/tests.yaml
+++ b/tests.yaml
@@ -640,3 +640,22 @@ tests:
         summary: "Job failed to complete."
         description: "Job ns1/job-1597623120 failed to complete. Removing failed job after investigation should clear this alert."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
+
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_terminations_total{job="kube-apiserver",apiserver="kube-apiserver"}'
+    values: '1+1x10'
+  - series: 'apiserver_request_total{job="kube-apiserver",apiserver="kube-apiserver"}'
+    values: '1+2x10'
+  alert_rule_test:
+  - eval_time: 5m    # alert hasn't fired
+    alertname: KubeAPITerminatedRequests
+  - eval_time: 10m   # alert fired
+    alertname: KubeAPITerminatedRequests
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        summary: "The apiserver has terminated 33.33% of its incoming requests."
+        description: "The apiserver has terminated 33.33% of its incoming requests."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"


### PR DESCRIPTION
This PR adds a new alert that fires when the number of inbound requests 
terminated by the APIServer exceeds 30% of the total inbound requests. 
Requests can be terminated due to timeout or throttling caused by the 
[API Priority and Fairness ](https://v1-19.docs.kubernetes.io/docs/concepts/cluster-administration/flow-control) policies.

This alert helps platform owners to surface request failures such as those
described in [BZ 1905235](https://bugzilla.redhat.com/show_bug.cgi?id=1905235).

The alert condition is defined as the ratio of the total terminated requests to
the total requests, using the `apiserver_request_terminations_total` and
`apiserver_request_total` metrics.The total inbound request is determined 
by the summation of the two metrics because the `apiserver_request_total` 
time series doesn't account for terminated requests.

### Testing

Using a simple test controller to simulate the APF throttling effect, the following 
chart shows the expected increasing trend in the ratio of the terminated requests 
to the total requests:

![apf_apiserver_request_terminations_ratio_60m](https://user-images.githubusercontent.com/1330522/103177725-ce7fa000-4831-11eb-8720-1b18b48a7597.png)

The next chart shows the expected decreasing trend during recovery:

![apf_apiserver_request_terminations_ratio_drop](https://user-images.githubusercontent.com/1330522/103177729-d3dcea80-4831-11eb-8798-5621fa413672.png)

Signed-off-by: Ivan Sim <isim@redhat.com>