### PR TITLE
Increased replicas mismatch alert tolerance

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -71,7 +71,7 @@
                   !=
                 kube_deployment_status_replicas_available{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
               ) and (
-                changes(kube_deployment_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m])
+                changes(kube_deployment_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m])
                   ==
                 0
               )
@@ -93,7 +93,7 @@
                   !=
                 kube_statefulset_status_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
               ) and (
-                changes(kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m])
+                changes(kube_statefulset_status_replicas_updated{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m])
                   ==
                 0
               )


### PR DESCRIPTION
During deployments and statefulsets rolling updates we frequently experience the alerts `KubeDeploymentReplicasMismatch` and `KubeStatefulSetReplicasMismatch` firing because some of our applications do stuff on shutdown / startup (eg. transfer state, replay WAL, ..) which slow down the rollout. 

What's the sentiment if we increase the tolerance on changes from 5m to 10m?