### PR TITLE
Use correct metric names for windows network traffic

### DIFF
--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -159,16 +159,16 @@
           {
             record: ':windows_node_net_saturation:sum_irate',
             expr: |||
-              sum(irate(windows_net_packets_received_discarded{%(wmiExporterSelector)s}[1m])) +
-              sum(irate(windows_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
+              sum(irate(windows_net_packets_received_discarded_total{%(wmiExporterSelector)s}[1m])) +
+              sum(irate(windows_net_packets_outbound_discarded_total{%(wmiExporterSelector)s}[1m]))
             ||| % $._config,
           },
           {
             record: 'node:windows_node_net_saturation:sum_irate',
             expr: |||
               sum by (instance) (
-                (irate(windows_net_packets_received_discarded{%(wmiExporterSelector)s}[1m]) +
-                irate(windows_net_packets_outbound_discarded{%(wmiExporterSelector)s}[1m]))
+                (irate(windows_net_packets_received_discarded_total{%(wmiExporterSelector)s}[1m]) +
+                irate(windows_net_packets_outbound_discarded_total{%(wmiExporterSelector)s}[1m]))
               )
             ||| % $._config,
           },


### PR DESCRIPTION
This rule was using the wrong metric names for calculation and was return nothing.  According to the `net` [collector](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.net.md) for the windows_exporter the values are:

```
windows_net_packets_received_discarded_total
windows_net_packets_outbound_discarded_total
```






