### PR TITLE
Use non-overlapping rule name

### DIFF
--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -160,7 +160,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         template.new(
           'namespace',
           '$datasource',
-          'label_values(windows_container_available, namespace)',
+          'label_values(windows_pod_container_available, namespace)',
           label='Namespace',
           refresh='time',
           sort=1,
@@ -253,7 +253,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         template.new(
           'namespace',
           '$datasource',
-          'label_values(windows_container_available, namespace)',
+          'label_values(windows_pod_container_available, namespace)',
           label='Namespace',
           refresh='time',
           sort=1,
@@ -263,7 +263,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         template.new(
           'pod',
           '$datasource',
-          'label_values(windows_container_available{namespace="$namespace"}, pod)',
+          'label_values(windows_pod_container_available{namespace="$namespace"}, pod)',
           label='Pod',
           refresh='time',
           sort=1,

--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -178,7 +178,7 @@
         name: 'windows.pod.rules',
         rules: [
           {
-            record: 'windows_container_available',
+            record: 'windows_pod_container_available',
             expr: |||
               windows_container_available{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
             ||| % $._config,
@@ -216,25 +216,25 @@
           {
             record: 'kube_pod_windows_container_resource_memory_request',
             expr: |||
-              kube_pod_container_resource_requests_memory_bytes {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_container_available)
+              kube_pod_container_resource_requests_memory_bytes {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
             ||| % $._config,
           },
           {
             record: 'kube_pod_windows_container_resource_memory_limit',
             expr: |||
-              kube_pod_container_resource_limits_memory_bytes {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_container_available)
+              kube_pod_container_resource_limits_memory_bytes {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
             ||| % $._config,
           },
           {
             record: 'kube_pod_windows_container_resource_cpu_cores_request',
             expr: |||
-              kube_pod_container_resource_requests_cpu_cores  {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_container_available)
+              kube_pod_container_resource_requests_cpu_cores  {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
             ||| % $._config,
           },
           {
             record: 'kube_pod_windows_container_resource_cpu_cores_limit',
             expr: |||
-              kube_pod_container_resource_limits_cpu_cores  {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_container_available)
+              kube_pod_container_resource_limits_cpu_cores  {%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
When running the windows dashboard I found that the rules where failing and no data was being shown on the graphana dashboards.  This PR updates the windows metric to be uniquely named and not overlap with the metric exported by [windows_exporter](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.container.md).

```
record:windows_container_available
expr:windows_container_available{job="windows-exporter"} * on(container_id) group_left(container, pod, namespace) max by(container, container_id, pod, namespace) (kube_pod_container_info{job="kube-state-metrics"})
```

![Screenshot from 2021-02-02 11-59-08](https://user-images.githubusercontent.com/648372/106655363-1939b980-654e-11eb-9341-c8d3694cb543.png)


and
 
```
found duplicate series for the match group {} on the right hand-side of the operation: [{__name__="windows_container_available", 
container_id="containerd://455087011e72a8503085b2417c8759199bc343f3e8c630a1e43d9ea4917b2532", 
instance="10.240.0.65:5000", job="windows-exporter"}, {__name__="windows_container_available", 
container_id="containerd://130d82553c53d017649b7115a4e58a8007eef0641ce8804bfb6eb7dcc70ef18b", 
instance="10.240.0.65:5000", job="windows-exporter"}];many-to-many matching not allowed: matching labels must be unique on 
one side
```

![Screenshot from 2021-02-02 11-57-39](https://user-images.githubusercontent.com/648372/106655209-ea234800-654d-11eb-84da-b3bc5f1dd86c.png)


