### PR TITLE
Updated rules using deprecated metrics with new versions.

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -2,6 +2,10 @@
   _config+:: {
     cadvisorSelector: 'job="cadvisor"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
+    memorySelector: 'resource="memory"',
+    cpuSelector: 'resource="cpu"',
+    byteSelector: 'unit="byte"',
+    coreSelector: 'unit="core"'
   },
 
   prometheusRules+:: {
@@ -64,7 +68,7 @@
               sum by (namespace) (
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
-                          kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s}
+                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(memorySelector)s, %(byteSelector)s}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                           kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
@@ -78,7 +82,7 @@
               sum by (namespace) (
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
-                          kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}
+                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, $(cpuSelector)s, %(coreSelector)s}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -2,10 +2,6 @@
   _config+:: {
     cadvisorSelector: 'job="cadvisor"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
-    memorySelector: 'resource="memory"',
-    cpuSelector: 'resource="cpu"',
-    byteSelector: 'unit="byte"',
-    coreSelector: 'unit="core"'
   },
 
   prometheusRules+:: {
@@ -68,7 +64,7 @@
               sum by (namespace) (
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
-                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(memorySelector)s, %(byteSelector)s}
+                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory", unit="byte"}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                           kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
@@ -82,7 +78,7 @@
               sum by (namespace) (
                   sum by (namespace, pod) (
                       max by (namespace, pod, container) (
-                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, $(cpuSelector)s, %(coreSelector)s}
+                          kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu", unit="core"}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )

--- a/tests.yaml
+++ b/tests.yaml
@@ -112,17 +112,17 @@ tests:
 
 - interval: 1m
   input_series:
-  - series: 'kube_pod_container_resource_requests_cpu_cores{container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="cpu",unit="core",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
     values: '0.15+0x10'
-  - series: 'kube_pod_container_resource_requests_cpu_cores{container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="cpu",unit="core",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm"}'
     values: '0.15+0x10'
-  - series: 'kube_pod_container_resource_requests_cpu_cores{container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="cpu",unit="core",container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
     values: '0.1+0x10'
-  - series: 'kube_pod_container_resource_requests_memory_bytes{container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="memory",unit="byte",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
     values: '1E9+0x10'
-  - series: 'kube_pod_container_resource_requests_memory_bytes{container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="memory",unit="byte",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm"}'
     values: '1E9+0x10'
-  - series: 'kube_pod_container_resource_requests_memory_bytes{container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
+  - series: 'kube_pod_container_resource_requests{resource="memory",unit="byte",container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm"}'
     values: '0.5E9+0x10'
   # Duplicate kube_pod_status_phase timeseries for the same pod.
   - series: 'kube_pod_status_phase{endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",phase="Running",pod="pod-1",service="ksm"}'


### PR DESCRIPTION
Refer this changelog: https://github.com/kubernetes/kube-state-metrics/blob/33db2356bf1f0a1f51ddaaeb165bce04ab5aa0df/CHANGELOG.md#v200-alpha--2020-09-16

`kube_pod_container_resource_requests_cpu_cores` and `kube_pod_container_resource_requests_memory_bytes` are deprecated.