### PR TITLE
repair empty box when using multicluster

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -77,7 +77,7 @@
             expr: |||
               sum by (namespace, cluster) (
                   sum by (namespace, pod, cluster) (
-                      max by (namespace, pod, container,cluster) (
+                      max by (namespace, pod, container, cluster) (
                           kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -61,9 +61,9 @@
           {
             record: 'namespace:kube_pod_container_resource_requests_memory_bytes:sum',
             expr: |||
-              sum by (namespace) (
-                  sum by (namespace, pod) (
-                      max by (namespace, pod, container) (
+              sum by (namespace, cluster) (
+                  sum by (namespace, pod, cluster) (
+                      max by (namespace, pod, container, cluster) (
                           kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                           kube_pod_status_phase{phase=~"Pending|Running"} == 1
@@ -75,9 +75,9 @@
           {
             record: 'namespace:kube_pod_container_resource_requests_cpu_cores:sum',
             expr: |||
-              sum by (namespace) (
-                  sum by (namespace, pod) (
-                      max by (namespace, pod, container) (
+              sum by (namespace, cluster) (
+                  sum by (namespace, pod, cluster) (
+                      max by (namespace, pod, container,cluster) (
                           kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}
                       ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1


### PR DESCRIPTION
Problem:

![Capture d’écran de 2021-03-03 15-52-40](https://user-images.githubusercontent.com/58891894/109823821-91bc9480-7c38-11eb-9462-8bec08627012.png)
![Capture d’écran de 2021-03-03 15-52-34](https://user-images.githubusercontent.com/58891894/109823837-941eee80-7c38-11eb-9c22-023fac342d42.png)

When we use MultiCluster flag, in the "cluster" dashboard (in resource), some boxes does not properly show datas.


These two faulty box are feeded by record rules:

`sum﻿(﻿namespace:kube_pod_container_resource_requests_cpu_cores:sum﻿{﻿cluster﻿=﻿"$cluster"﻿}﻿)﻿ / ﻿sum﻿(﻿kube_node_status_allocatable_cpu_cores﻿{﻿cluster﻿=﻿"$cluster"﻿}﻿)`

```
namespace:kube_pod_container_resource_requests_memory_bytes
namespace:kube_pod_container_resource_requests_cpu_cores

g.statPanel('sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_memory_bytes{%(clusterLabel)s="$cluster"})' % $._config)

g.statPanel('sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable_cpu_cores{%(clusterLabel)s="$cluster"})' % $._config)
```

Details of the record rules:

```
          {
            record: 'namespace:kube_pod_container_resource_requests_memory_bytes:sum',
            expr: |||
              sum by (namespace) (
                  sum by (namespace, pod) (
                      max by (namespace, pod, container) (
                          kube_pod_container_resource_requests_memory_bytes{%(kubeStateMetricsSelector)s}
                      ) * on(namespace, pod) group_left() max by (namespace, pod) (
                          kube_pod_status_phase{phase=~"Pending|Running"} == 1
                      )
                  )
              )
            ||| % $._config,
          },
          {
            record: 'namespace:kube_pod_container_resource_requests_cpu_cores:sum',
            expr: |||
              sum by (namespacer) (
                  sum by (namespace, pod) (
                      max by (namespace, pod, container) (
                          kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s}
                      ) * on(namespace, pod) group_left() max by (namespace, pod) (
                        kube_pod_status_phase{phase=~"Pending|Running"} == 1
                      )
                  )
              )
            ||| % $._config,
          },

```

It cannot properly work because of the non availability of the label "cluster" in the expression

This PR just add availability of the label to be able to filter it from grafana POV.