### PR TITLE
Add a flag for managed K8s clusters

### DIFF
--- a/alerts/kube_controller_manager.libsonnet
+++ b/alerts/kube_controller_manager.libsonnet
@@ -3,7 +3,7 @@
     kubeControllerManagerSelector: error 'must provide selector for kube-controller-manager',
   },
 
-  prometheusAlerts+:: {
+  prometheusAlerts+:: if !$._config.managedCluster then {
     groups+: [
       {
         name: 'kubernetes-system-controller-manager',
@@ -15,5 +15,5 @@
         ],
       },
     ],
-  },
+  } else {},
 }

--- a/alerts/kube_scheduler.libsonnet
+++ b/alerts/kube_scheduler.libsonnet
@@ -3,7 +3,7 @@
     kubeSchedulerSelector: 'job="kube-scheduler"',
   },
 
-  prometheusAlerts+:: {
+  prometheusAlerts+:: if !$._config.managedCluster then {
     groups+: [
       {
         name: 'kubernetes-system-scheduler',
@@ -15,5 +15,5 @@
         ],
       },
     ],
-  },
+  } else {},
 }

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -76,6 +76,10 @@
       minimumTimeInterval: '1m',
     },
 
+    // Removes alerting rules and dashboards of components which
+    // are managed by a service(GKE, AKS, EKS).
+    managedCluster: false,
+
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
     clusterLabel: 'cluster',

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -7,7 +7,7 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
-  grafanaDashboards+:: {
+  grafanaDashboards+:: if !$._config.managedCluster then {
     'controller-manager.json':
       local upCount =
         singlestat.new(
@@ -181,5 +181,5 @@ local singlestat = grafana.singlestat;
         .addPanel(cpu)
         .addPanel(goroutines)
       ) + { refresh: $._config.grafanaK8s.refresh },
-  },
+  } else {},
 }

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -7,7 +7,7 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
-  grafanaDashboards+:: {
+  grafanaDashboards+:: if !$._config.managedCluster then {
     'scheduler.json':
       local upCount =
         singlestat.new(
@@ -171,5 +171,5 @@ local singlestat = grafana.singlestat;
         .addPanel(cpu)
         .addPanel(goroutines)
       ) + { refresh: $._config.grafanaK8s.refresh },
-  },
+  } else {},
 }

--- a/rules/kube_scheduler.libsonnet
+++ b/rules/kube_scheduler.libsonnet
@@ -4,7 +4,7 @@
     podLabel: 'pod',
   },
 
-  prometheusRules+:: {
+  prometheusRules+:: if !$._config.managedCluster then {
     groups+: [
       {
         name: 'kube-scheduler.rules',
@@ -27,5 +27,5 @@
         ],
       },
     ],
-  },
+  } else {},
 }


### PR DESCRIPTION
On managed Kubernetes clusters some of the control plane components are not exposed to customers. This adds a flag reflecting that, which removes the alerts/dashboards if enabled.

A feature I'd prefer instead of doing this: https://github.com/prometheus-operator/kube-prometheus/blob/main/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet#L12-L22