### PR TITLE
dashboards: revert single row for network panels and condense/rename rows

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -178,7 +178,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Current Network Usage')
         .addPanel(
           g.panel('Current Network Usage') +
           g.tablePanel(
@@ -189,16 +189,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
@@ -207,16 +204,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Average Container Bandwidth by Namespace')
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Received') +
           g.queryPanel('avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Transmitted') +
           g.queryPanel('avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
@@ -225,16 +219,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
@@ -243,16 +234,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -187,48 +187,72 @@ local template = grafana.template;
           ) +
           { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Received') +
           g.queryPanel('avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Transmitted') +
           g.queryPanel('avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -243,36 +243,54 @@ local template = grafana.template;
           ) +
           { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -234,7 +234,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Current Network Usage')
         .addPanel(
           g.panel('Current Network Usage') +
           g.tablePanel(
@@ -245,16 +245,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
@@ -263,16 +260,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
@@ -281,16 +275,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -210,16 +210,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
@@ -228,16 +225,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
@@ -246,16 +240,13 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -217,30 +217,45 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -284,6 +284,9 @@ local template = grafana.template;
           ) +
           { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel(|||
@@ -294,6 +297,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel(|||
@@ -304,6 +310,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Workload: Received') +
           g.queryPanel(|||
@@ -314,6 +323,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Workload: Transmitted') +
           g.queryPanel(|||
@@ -324,6 +336,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel(|||
@@ -334,6 +349,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel(|||
@@ -344,6 +362,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel(|||
@@ -354,6 +375,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel(|||

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -275,7 +275,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Current Network Usage')
         .addPanel(
           g.panel('Current Network Usage') +
           g.tablePanel(
@@ -286,7 +286,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel(|||
@@ -297,9 +297,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel(|||
@@ -312,7 +309,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Average Container Bandwidth by Workload')
         .addPanel(
           g.panel('Average Container Bandwidth by Workload: Received') +
           g.queryPanel(|||
@@ -323,9 +320,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Workload: Transmitted') +
           g.queryPanel(|||
@@ -338,7 +332,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel(|||
@@ -349,9 +343,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel(|||
@@ -364,7 +355,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel(|||
@@ -375,9 +366,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel(|||

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -221,6 +221,9 @@ local template = grafana.template;
           ) +
           { interval: $._config.grafanaK8s.minimumTimeInterval },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel(|||
@@ -231,6 +234,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel(|||
@@ -241,6 +247,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Pod: Received') +
           g.queryPanel(|||
@@ -251,6 +260,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Pod: Transmitted') +
           g.queryPanel(|||
@@ -261,6 +273,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel(|||
@@ -271,6 +286,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel(|||
@@ -281,6 +299,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel(|||
@@ -291,6 +312,9 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
+      )
+      .addRow(
+        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel(|||

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -212,7 +212,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Current Network Usage')
         .addPanel(
           g.panel('Current Network Usage') +
           g.tablePanel(
@@ -223,7 +223,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
           g.queryPanel(|||
@@ -234,9 +234,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel(|||
@@ -249,7 +246,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Average Container Bandwidth by Pod')
         .addPanel(
           g.panel('Average Container Bandwidth by Pod: Received') +
           g.queryPanel(|||
@@ -260,9 +257,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Average Container Bandwidth by Pod: Transmitted') +
           g.queryPanel(|||
@@ -275,7 +269,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
           g.queryPanel(|||
@@ -286,9 +280,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel(|||
@@ -301,7 +292,7 @@ local template = grafana.template;
         )
       )
       .addRow(
-        g.row('Network')
+        g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel(|||
@@ -312,9 +303,6 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      )
-      .addRow(
-        g.row('Network')
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel(|||


### PR DESCRIPTION
This reverts fc8ed7032fee08cd25dfda4257ae48146f5be347, puts all network panels that come in a receive and a transmit flavor into the same row and renames the rows according to the panel contained.

Fixes: https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/570

The original fix of adding `gridPos` to the `addPanel` calls doesn't work for now as the `grafana.libsonnet` from github.com/grafana/jsonnet-libs/grafana-builder/ used in these dashboards doesn't support it.