### PR TITLE
Fix dashboard regressions in 'Multi-Cluster' and 'Cluster'

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -109,7 +109,7 @@ local template = grafana.template;
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster""})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -28,23 +28,23 @@ local template = grafana.template;
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"}')
+            g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"})')
           )
           .addPanel(
             g.panel('CPU Limits Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"}')
+            g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"})')
           )
           .addPanel(
             g.panel('Memory Utilisation') +
-            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource="memory"}')
+            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource="memory"})')
           )
           .addPanel(
             g.panel('Memory Requests Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"}')
+            g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"})')
           )
           .addPanel(
             g.panel('Memory Limits Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"}')
+            g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"})')
           )
         )
         .addRow(

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -28,23 +28,23 @@ local template = grafana.template;
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"))' % $._config)
+            g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"}')
           )
           .addPanel(
             g.panel('CPU Limits Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"))' % $._config)
+            g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(kube_node_status_allocatable{resource="cpu"}')
           )
           .addPanel(
             g.panel('Memory Utilisation') +
-            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"))' % $._config)
+            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource="memory"}')
           )
           .addPanel(
             g.panel('Memory Requests Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"))' % $._config)
+            g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"}')
           )
           .addPanel(
             g.panel('Memory Limits Commitment') +
-            g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"))' % $._config)
+            g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(kube_node_status_allocatable{resource="memory"}')
           )
         )
         .addRow(


### PR DESCRIPTION
This PR removes the `%(clusterLabel)s="$cluster"` label matcher from the multi-cluster dashboard.

This matcher does not make sense to include in the context of the headlines section, since we are aggregating across all clusters in the context of those queries (and not _by_ cluster). The queries themselves were also broken due to missing a `}` after the `$cluster` label matchers, and have also been fixed.

Finally, a typo has been fixed in the 'Memory Utilisation' section of the cluster dashboard.