### PR TITLE
Update AggregatedAPIErrors after Kubernetes 1.19 changes

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -75,7 +75,7 @@ local utils = import 'utils.libsonnet';
           {
             alert: 'AggregatedAPIErrors',
             expr: |||
-              sum by(name, namespace)(increase(aggregator_unavailable_apiservice_count[10m])) > 4
+              sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
In Kubernetes 1.19, the aggregator_unavailable_apiservice_count metric
was renamed to aggregator_unavailable_apiservice_total. Thus, the
AggregatedAPIErrors alert needs to be updated to use the new metric.

cf. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#other-cleanup-or-flake-5