### PR TITLE
chore/dash-var-refresh: change default refresh to 2(time range)

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -340,7 +340,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
           hide=if $._config.showMultiCluster then '' else '2',
-          refresh=1
+          refresh=2
         );
 
       dashboard.new(

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -233,7 +233,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
           hide=if $._config.showMultiCluster then '' else '2',
-          refresh=1
+          refresh=2
         );
 
       local namespaceTemplate =
@@ -244,7 +244,7 @@ local singlestat = grafana.singlestat;
           allValues='.+',
           current='kube-system',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=true,
           sort=1
         ) + {

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -237,7 +237,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
           hide=if $._config.showMultiCluster then '' else '2',
-          refresh=1
+          refresh=2
         );
 
       local namespaceTemplate =
@@ -247,7 +247,7 @@ local singlestat = grafana.singlestat;
           query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
           current='kube-system',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=false,
           sort=1
         ) + {
@@ -265,7 +265,7 @@ local singlestat = grafana.singlestat;
           query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config,
           current='deployment',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=false,
           sort=0
         ) + {

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -112,7 +112,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
           hide=if $._config.showMultiCluster then '' else '2',
-          refresh=1
+          refresh=2
         );
 
 
@@ -124,7 +124,7 @@ local singlestat = grafana.singlestat;
           allValues='.+',
           current='kube-system',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=true,
           sort=1
         ) + {
@@ -143,7 +143,7 @@ local singlestat = grafana.singlestat;
           allValues='.+',
           current='',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=false,
           sort=1
         ) + {

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -102,7 +102,7 @@ local singlestat = grafana.singlestat;
           datasource='$datasource',
           query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
           hide=if $._config.showMultiCluster then '' else '2',
-          refresh=1
+          refresh=2
         );
 
       local namespaceTemplate =
@@ -113,7 +113,7 @@ local singlestat = grafana.singlestat;
           allValues='.+',
           current='kube-system',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=true,
           sort=1
         ) + {
@@ -131,7 +131,7 @@ local singlestat = grafana.singlestat;
           query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace"}, workload)' % $._config,
           current='',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=false,
           sort=1
         ) + {
@@ -149,7 +149,7 @@ local singlestat = grafana.singlestat;
           query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload"}, workload_type)' % $._config,
           current='deployment',
           hide='',
-          refresh=1,
+          refresh=2,
           includeAll=false,
           sort=0
         ) + {

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -11,7 +11,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -23,7 +23,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -11,7 +11,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -23,7 +23,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, node)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         multi=true,
         sort=1

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -11,7 +11,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -23,7 +23,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -12,7 +12,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -24,7 +24,7 @@ local template = grafana.template;
         query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config.clusterLabel,
         current='deployment',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=0
       ) + {
@@ -42,7 +42,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -11,7 +11,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -23,7 +23,7 @@ local template = grafana.template;
         query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -35,7 +35,7 @@ local template = grafana.template;
         query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),
@@ -47,7 +47,7 @@ local template = grafana.template;
         query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload"}, workload_type)' % $._config.clusterLabel,
         current='',
         hide='',
-        refresh=1,
+        refresh=2,
         includeAll=false,
         sort=1
       ),


### PR DESCRIPTION
Change the default variable refresh behavior from "On Dashboard Reload" to "On Time Range Change" on Grafana dashboards.

That is quite useful when navigating to old data, avoiding refresh the dashboards every new time range change.

https://github.com/openshift/cluster-monitoring-operator/pull/1097