### PR TITLE
fix(dashboard): fix cluster memory utilization in cluster dashboard

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -109,7 +109,7 @@ local template = grafana.template;
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(node_memory_MemTotal_bytes{resource="memory",%(clusterLabel)s="$cluster""})' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +


### PR DESCRIPTION
This fixes the cluster memory utilization panel in the `Kubernetes / Compute Resources / Cluster` dashboard .

Before:     
![image](https://user-images.githubusercontent.com/17493763/113362961-ee05f780-934f-11eb-834f-50525fee7413.png)

After:     
![image](https://user-images.githubusercontent.com/17493763/113363004-0b3ac600-9350-11eb-8736-fd17d6e8aa12.png)

