### PR TITLE
Fix for Alert KubeHpaReplicasMismatch

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -276,7 +276,7 @@
                 <
               kube_hpa_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
                 and
-              changes(kube_hpa_status_current_replicas[15m]) == 0
+              changes(kube_hpa_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) == 0
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
added missing selectors for kube_hpa_status_current_replicas