### PR TITLE
dashboards/network-usage: don't collapse rows by default

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -310,7 +310,6 @@ local singlestat = grafana.singlestat;
       local averageBandwidthRow =
         row.new(
           title='Average Bandwidth',
-          collapse=true,
         );
 
       //#####  Bandwidth History Row ######
@@ -320,19 +319,15 @@ local singlestat = grafana.singlestat;
         );
 
       //##### Packet  Row ######
-      // collapsed, so row must include panels
       local packetRow =
         row.new(
           title='Packets',
-          collapse=true,
         );
 
       //##### Error Row ######
-      // collapsed, so row must include panels
       local errorRow =
         row.new(
           title='Errors',
-          collapse=true,
         );
       local clusterTemplate =
         template.new(

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -330,19 +330,15 @@ local singlestat = grafana.singlestat;
         );
 
       //##### Packet  Row ######
-      // collapsed, so row must include panels
       local packetRow =
         row.new(
           title='Packets',
-          collapse=true,
         );
 
       //##### Error Row ######
-      // collapsed, so row must include panels
       local errorRow =
         row.new(
           title='Errors',
-          collapse=true,
         );
 
       dashboard.new(

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -348,7 +348,6 @@ local singlestat = grafana.singlestat;
       local averageBandwidthRow =
         row.new(
           title='Average Bandwidth',
-          collapse=true,
         );
 
       //#####  Bandwidth History Row ######
@@ -359,19 +358,15 @@ local singlestat = grafana.singlestat;
         );
 
       //##### Packet  Row ######
-      // collapsed, so row must include panels
       local packetRow =
         row.new(
           title='Packets',
-          collapse=true,
         );
 
       //##### Error Row ######
-      // collapsed, so row must include panels
       local errorRow =
         row.new(
           title='Errors',
-          collapse=true,
         );
 
       dashboard.new(

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -229,19 +229,15 @@ local singlestat = grafana.singlestat;
         );
 
       //##### Packet  Row ######
-      // collapsed, so row must include panels
       local packetRow =
         row.new(
           title='Packets',
-          collapse=true,
         );
 
       //##### Error Row ######
-      // collapsed, so row must include panels
       local errorRow =
         row.new(
           title='Errors',
-          collapse=true,
         );
 
       dashboard.new(

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -232,7 +232,6 @@ local singlestat = grafana.singlestat;
       local averageBandwidthRow =
         row.new(
           title='Average Bandwidth',
-          collapse=true,
         );
 
       //#####  Bandwidth History Row ######
@@ -243,19 +242,15 @@ local singlestat = grafana.singlestat;
         );
 
       //##### Packet  Row ######
-      // collapsed, so row must include panels
       local packetRow =
         row.new(
           title='Packets',
-          collapse=true,
         );
 
       //##### Error Row ######
-      // collapsed, so row must include panels
       local errorRow =
         row.new(
           title='Errors',
-          collapse=true,
         );
 
       dashboard.new(


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

Had a report about collapsed rows being unexpected.
I fail to come up with an argument for collapsing some rows, hence this proposal.