### PR TITLE
Kubernetes/Compute Resources/Pod: Fix resource label

### DIFF
--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -54,8 +54,8 @@ local template = grafana.template;
       ||| % $._config;
 
       local cpuLimitsQuery = std.strReplace(cpuRequestsQuery, 'requests', 'limits');
-      local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu_cores', 'memory_bytes');
-      local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu_cores', 'memory_bytes');
+      local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
+      local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
 
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Pod' % $._config.grafanaK8s,


### PR DESCRIPTION
In the Memory Usage panel the requests and limits query specified the
cpu resource. Seems like this was overlooked in the move to
kube-state-metrics v2.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>