### PR TITLE
dashboards: fix number of kubelets being up

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -17,7 +17,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config));
+        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, metrics_path="/metrics")' % $._config));
 
       local runningPodCount =
         singlestat.new(


### PR DESCRIPTION
Kubelet is exposing data on at least 4 different URIs. This leads to duplication of `up` metrics and causes incorrect sum presented in the dashboard.  