### PR TITLE
dashboards: do not use `up` to count number of kubelets

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -12,12 +12,12 @@ local singlestat = grafana.singlestat;
     'kubelet.json':
       local upCount =
         singlestat.new(
-          'Up',
+          'Running Kubelets',
           datasource='$datasource',
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, metrics_path="/metrics")' % $._config));
+        .addTarget(prometheus.target('sum(kubelet_node_name{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config));
 
       local runningPodCount =
         singlestat.new(


### PR DESCRIPTION
This is a follow-up to #597 

Let's not use `up` to determine the number of kubelets as this is error-prone and heavily depends on the user setting correct `kubeletSelector`. Instead, we can get the same result using `kubelet_node_name` which doesn't require setting `kubeletSelector` to a specific value.

I also changed panel name to better align with query.

/cc @ravilr @brancz 