### PR TITLE
dashboard/kubelet: Migrate to statPanel

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -5,64 +5,58 @@ local prometheus = grafana.prometheus;
 local template = grafana.template;
 local graphPanel = grafana.graphPanel;
 local tablePanel = grafana.tablePanel;
-local singlestat = grafana.singlestat;
+local statPanel = grafana.statPanel;
 
 {
   grafanaDashboards+:: {
     'kubelet.json':
       local upCount =
-        singlestat.new(
+        statPanel.new(
           'Running Kubelets',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         .addTarget(prometheus.target('sum(kubelet_node_name{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config));
 
       local runningPodCount =
-        singlestat.new(
+        statPanel.new(
           'Running Pods',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
         .addTarget(prometheus.target('sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_pod_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
 
       local runningContainerCount =
-        singlestat.new(
+        statPanel.new(
           'Running Container',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
         .addTarget(prometheus.target('sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_container_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
 
       local actualVolumeCount =
-        singlestat.new(
+        statPanel.new(
           'Actual Volume Count',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance", state="actual_state_of_world"})' % $._config, legendFormat='{{instance}}'));
 
       local desiredVolumeCount =
-        singlestat.new(
+        statPanel.new(
           'Desired Volume Count',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance",state="desired_state_of_world"})' % $._config, legendFormat='{{instance}}'));
 
       local configErrorCount =
-        singlestat.new(
+        statPanel.new(
           'Config Error Count',
           datasource='$datasource',
-          span=2,
-          valueName='min',
+          reducerFunction='min',
         )
         .addTarget(prometheus.target('sum(rate(kubelet_node_config_error{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='{{instance}}'));
 
@@ -70,7 +64,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Operation Rate',
           datasource='$datasource',
-          span=6,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -84,8 +77,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Operation Error Rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -99,7 +90,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Operation duration 99th quantile',
           datasource='$datasource',
-          span=12,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -113,8 +103,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Pod Start Rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -129,8 +117,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Pod Start Duration',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -145,8 +131,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Storage Operation Rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -162,8 +146,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Storage Operation Error Rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -180,8 +162,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Storage Operation Duration 99th quantile',
           datasource='$datasource',
-          span=12,
-          min=0,
           format='s',
           legend_values=true,
           legend_current=true,
@@ -196,8 +176,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Cgroup manager operation rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='ops',
           legend_show=true,
           legend_values=true,
@@ -211,8 +189,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Cgroup manager 99th quantile',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -226,8 +202,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'PLEG relist rate',
           datasource='$datasource',
-          span=6,
-          min=0,
           description='Pod lifecycle event generator',
           format='ops',
           legend_show=true,
@@ -242,8 +216,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'PLEG relist duration',
           datasource='$datasource',
-          span=12,
-          min=0,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -257,8 +229,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'PLEG relist interval',
           datasource='$datasource',
-          span=6,
-          min=0,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -272,8 +242,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'RPC Rate',
           datasource='$datasource',
-          span=12,
-          min=0,
           format='ops',
         )
         .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % $._config, legendFormat='2xx'))
@@ -285,8 +253,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Request duration 99th quantile',
           datasource='$datasource',
-          span=12,
-          min=0,
           format='s',
           legend_show=true,
           legend_values=true,
@@ -300,7 +266,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Memory',
           datasource='$datasource',
-          span=4,
           format='bytes',
         )
         .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
@@ -309,9 +274,7 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'CPU usage',
           datasource='$datasource',
-          span=4,
           format='short',
-          min=0,
         )
         .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])' % $._config, legendFormat='{{instance}}'));
 
@@ -319,7 +282,6 @@ local singlestat = grafana.singlestat;
         graphPanel.new(
           'Goroutines',
           datasource='$datasource',
-          span=4,
           format='short',
         )
         .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
@@ -367,54 +329,30 @@ local singlestat = grafana.singlestat;
           sort=1,
         )
       )
-      .addRow(
-        row.new()
-        .addPanel(upCount)
-        .addPanel(runningPodCount)
-        .addPanel(runningContainerCount)
-        .addPanel(actualVolumeCount)
-        .addPanel(desiredVolumeCount)
-        .addPanel(configErrorCount)
-      ).addRow(
-        row.new()
-        .addPanel(operationRate)
-        .addPanel(operationErrorRate)
-      ).addRow(
-        row.new()
-        .addPanel(operationLatency)
-      ).addRow(
-        row.new()
-        .addPanel(podStartRate)
-        .addPanel(podStartLatency)
-      ).addRow(
-        row.new()
-        .addPanel(storageOperationRate)
-        .addPanel(storageOperationErrorRate)
-      ).addRow(
-        row.new()
-        .addPanel(storageOperationLatency)
-      ).addRow(
-        row.new()
-        .addPanel(cgroupManagerRate)
-        .addPanel(cgroupManagerDuration)
-      ).addRow(
-        row.new()
-        .addPanel(plegRelistRate)
-        .addPanel(plegRelistInterval)
-      ).addRow(
-        row.new()
-        .addPanel(plegRelistDuration)
-      ).addRow(
-        row.new()
-        .addPanel(rpcRate)
-      ).addRow(
-        row.new()
-        .addPanel(requestDuration)
-      ).addRow(
-        row.new()
-        .addPanel(memory)
-        .addPanel(cpu)
-        .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      .addPanel(upCount, gridPos={ h: 7, w: 4, x: 0, y: 0 })
+      .addPanel(runningPodCount, gridPos={ h: 7, w: 4, x: 4, y: 0 })
+      .addPanel(runningContainerCount, gridPos={ h: 7, w: 4, x: 8, y: 0 })
+      .addPanel(actualVolumeCount, gridPos={ h: 7, w: 4, x: 12, y: 0 })
+      .addPanel(desiredVolumeCount, gridPos={ h: 7, w: 4, x: 16, y: 0 })
+      .addPanel(configErrorCount, gridPos={ h: 7, w: 4, x: 20, y: 0 })
+      .addPanel(operationRate, gridPos={ h: 7, w: 12, x: 0, y: 7 })
+      .addPanel(operationErrorRate, gridPos={ h: 7, w: 12, x: 12, y: 7 })
+      .addPanel(operationLatency, gridPos={ h: 7, w: 24, x: 0, y: 14 })
+      .addPanel(podStartRate, gridPos={ h: 7, w: 12, x: 0, y: 21 })
+      .addPanel(podStartLatency, gridPos={ h: 7, w: 12, x: 12, y: 21 })
+      .addPanel(storageOperationRate, gridPos={ h: 7, w: 12, x: 0, y: 28 })
+      .addPanel(storageOperationErrorRate, gridPos={ h: 7, w: 12, x: 12, y: 28 })
+      .addPanel(storageOperationLatency, gridPos={ h: 7, w: 24, x: 0, y: 35 })
+      .addPanel(cgroupManagerRate, gridPos={ h: 7, w: 12, x: 0, y: 42 })
+      .addPanel(cgroupManagerDuration, gridPos={ h: 7, w: 12, x: 12, y: 42 })
+      .addPanel(plegRelistRate, gridPos={ h: 7, w: 12, x: 0, y: 49 })
+      .addPanel(plegRelistInterval, gridPos={ h: 7, w: 12, x: 12, y: 49 })
+      .addPanel(plegRelistDuration, gridPos={ h: 7, w: 24, x: 0, y: 56 })
+      .addPanel(rpcRate, gridPos={ h: 7, w: 24, x: 0, y: 63 })
+      .addPanel(requestDuration, gridPos={ h: 7, w: 24, x: 0, y: 70 })
+      .addPanel(memory, gridPos={ h: 7, w: 8, x: 0, y: 77 })
+      .addPanel(cpu, gridPos={ h: 7, w: 8, x: 8, y: 77 })
+      .addPanel(goroutines, gridPos={ h: 7, w: 8, x: 16, y: 77 })
+      + { refresh: $._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -14,7 +14,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Running Kubelets',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         .addTarget(prometheus.target('sum(kubelet_node_name{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config));
 
@@ -22,7 +22,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Running Pods',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
         .addTarget(prometheus.target('sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_pod_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
@@ -31,7 +31,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Running Container',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
         .addTarget(prometheus.target('sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_container_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
@@ -40,7 +40,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Actual Volume Count',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance", state="actual_state_of_world"})' % $._config, legendFormat='{{instance}}'));
 
@@ -48,7 +48,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Desired Volume Count',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance",state="desired_state_of_world"})' % $._config, legendFormat='{{instance}}'));
 
@@ -56,7 +56,7 @@ local statPanel = grafana.statPanel;
         statPanel.new(
           'Config Error Count',
           datasource='$datasource',
-          reducerFunction='min',
+          reducerFunction='lastNotNull',
         )
         .addTarget(prometheus.target('sum(rate(kubelet_node_config_error{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='{{instance}}'));
 


### PR DESCRIPTION
Singlestat panels are deprecated. 

Statpanels do not support spans so I changed all panels to use gridPos (had issues aligning panels when only statpanels made use of gridPos).

Change reducer function to `lastNotNull` to fetch the last value and not the min one.

Should not change any dashboard UI except the singlestat->statpanel change.

![image](https://user-images.githubusercontent.com/12065867/119663024-4a5a3480-be32-11eb-9adf-96a81e45113b.png)