### PR TITLE
Fix rate time for PodCrashLoopbackoff alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -12,7 +12,7 @@
         rules: [
           {
             expr: |||
-              rate(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) * 60 * 5 > 0
+              increase(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
Hello,

Following the PR #531 , the time multiplier was not changed correctly.

Hence currently:
```
rate(kube_pod_container_status_restarts_total{..}[10m]) * 60 * 5
```
give us the number of restart per 5 minutes and not 10 minutes as the message annotation is saying..

This quick fix set it to be the number per 10 minutes.

Note: the PromQL could also be replaced with
```
increase(kube_pod_container_status_restarts_total{..}[10m])
```
which is equivalent and maybe more readable ?