### PR TITLE
alerts: improve recovery for KubePodCrashLooping alert

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -13,6 +13,8 @@
           {
             expr: |||
               increase(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) > 0
+              and
+              sum without (phase) (kube_pod_status_phase{phase!="Running",%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} == 1)
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
If a pod is running the alert should stop firing. This should improve recovery from the alert condition and prevent false-positives.