### PR TITLE
dashboards/resources: use one datasource for calculating memory consumption

### DIFF
--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -36,7 +36,7 @@ local template = grafana.template;
           )
           .addPanel(
             g.panel('Memory Utilisation') +
-            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(kube_node_status_allocatable{resource="memory"})')
+            g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(node_memory_MemTotal_bytes)')
           )
           .addPanel(
             g.panel('Memory Requests Commitment') +


### PR DESCRIPTION
Right now query for memory consumption in multi-cluster dashboard mixes node memory usage with kube allocatable memory. This can lead to negative values if there are other applications running outside of the cluster, but on nodes. Plus kubelet has memory reservation which is not counted towards allocatable memory for the cluster.

It might be good to expand this "headline" row and add `Pod CPU usage` as well as `Pod Memory usage`. This would give a clear distinction of how much memory is used in a cluster and how much is used by the nodes in total. If there is a need for it, I'll open an issue and possibly later - PR.