### PR TITLE
*: Replace all usage of `$.` with a local reference

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
     namespaceSelector: null,
@@ -13,7 +15,7 @@
           {
             expr: |||
               increase(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -37,7 +39,7 @@
                   1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
                 )
               ) > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -53,7 +55,7 @@
               kube_deployment_status_observed_generation{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 !=
               kube_deployment_metadata_generation{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -75,7 +77,7 @@
                   ==
                 0
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -97,7 +99,7 @@
                   ==
                 0
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -113,7 +115,7 @@
               kube_statefulset_status_observed_generation{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 !=
               kube_statefulset_metadata_generation{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -143,7 +145,7 @@
                   ==
                 0
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -180,7 +182,7 @@
                   ==
                 0
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -193,7 +195,7 @@
           {
             expr: |||
               sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -210,7 +212,7 @@
               kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 -
               kube_daemonset_status_current_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -224,7 +226,7 @@
             alert: 'KubeDaemonSetMisScheduled',
             expr: |||
               kube_daemonset_status_number_misscheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -238,7 +240,7 @@
             alert: 'KubeJobCompletion',
             expr: |||
               kube_job_spec_completions{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_job_status_succeeded{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '12h',
             labels: {
               severity: 'warning',
@@ -252,7 +254,7 @@
             alert: 'KubeJobFailed',
             expr: |||
               kube_job_failed{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'warning',
@@ -277,7 +279,7 @@
               kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
                 and
               changes(kube_horizontalpodautoscaler_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[15m]) == 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -293,7 +295,7 @@
               kube_horizontalpodautoscaler_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 ==
               kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },

--- a/alerts/kube_controller_manager.libsonnet
+++ b/alerts/kube_controller_manager.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeControllerManagerSelector: error 'must provide selector for kube-controller-manager',
   },
@@ -10,7 +12,7 @@
         rules: [
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeControllerManager',
-            selector:: $._config.kubeControllerManagerSelector,
+            selector:: kubernetesMixin._config.kubeControllerManagerSelector,
           },
         ],
       },

--- a/alerts/kube_scheduler.libsonnet
+++ b/alerts/kube_scheduler.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeSchedulerSelector: 'job="kube-scheduler"',
   },
@@ -10,7 +12,7 @@
         rules: [
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeScheduler',
-            selector:: $._config.kubeSchedulerSelector,
+            selector:: kubernetesMixin._config.kubeSchedulerSelector,
           },
         ],
       },

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
     nodeExporterSelector: error 'must provide selector for node-exporter',
@@ -30,7 +32,7 @@
               sum(kube_node_status_allocatable{resource="cpu"})
                 >
               ((count(kube_node_status_allocatable{resource="cpu"}) > 1) - 1) / count(kube_node_status_allocatable{resource="cpu"})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -50,7 +52,7 @@
               ((count(kube_node_status_allocatable{resource="memory"}) > 1) - 1)
                 /
               count(kube_node_status_allocatable{resource="memory"})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -67,7 +69,7 @@
                 /
               sum(kube_node_status_allocatable{resource="cpu"})
                 > %(namespaceOvercommitFactor)s
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -84,7 +86,7 @@
                 /
               sum(kube_node_status_allocatable{resource="memory",%(kubeStateMetricsSelector)s})
                 > %(namespaceOvercommitFactor)s
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               severity: 'warning',
             },
@@ -101,7 +103,7 @@
                 / ignoring(instance, job, type)
               (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
                 > 0.9 < 1
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'info',
@@ -118,7 +120,7 @@
                 / ignoring(instance, job, type)
               (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
                 == 1
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'info',
@@ -135,7 +137,7 @@
                 / ignoring(instance, job, type)
               (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard"} > 0)
                 > 1
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'warning',
@@ -152,7 +154,7 @@
                 /
               sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)
                 > ( %(cpuThrottlingPercent)s / 100 )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'info',

--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeStateMetricsSelector: error 'must provide selector for kube-state-metrics',
     kubeletSelector: error 'must provide selector for kubelet',
@@ -23,7 +25,7 @@
                 /
               kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
                 < 0.03
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '1m',
             labels: {
               severity: 'critical',
@@ -43,7 +45,7 @@
               ) < 0.15
               and
               predict_linear(kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}[%(volumeFullPredictionSampleTime)s], 4 * 24 * 3600) < 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '1h',
             labels: {
               severity: 'warning',
@@ -57,7 +59,7 @@
             alert: 'KubePersistentVolumeErrors',
             expr: |||
               kube_persistentvolume_status_phase{phase=~"Failed|Pending",%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '5m',
             labels: {
               severity: 'critical',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     notKubeDnsCoreDnsSelector: 'job!~"kube-dns|coredns"',
   },
@@ -12,7 +14,7 @@
             alert: 'KubeVersionMismatch',
             expr: |||
               count(count by (git_version) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -7,6 +7,8 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeApiserverSelector: 'job="kube-apiserver"',
   },
@@ -15,37 +17,37 @@ local singlestat = grafana.singlestat;
     'apiserver.json':
       local availability1d =
         singlestat.new(
-          'Availability (%dd) > %.3f%%' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
+          'Availability (%dd) > %.3f%%' % [kubernetesMixin._config.SLOs.apiserver.days, 100 * kubernetesMixin._config.SLOs.apiserver.target],
           datasource='$datasource',
           span=4,
           format='percentunit',
           decimals=3,
-          description='How many percent of requests (both read and write) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
+          description='How many percent of requests (both read and write) in %d days have been answered successfully and fast enough?' % kubernetesMixin._config.SLOs.apiserver.days,
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="all", %(clusterLabel)s="$cluster"}' % [$._config.SLOs.apiserver.days, $._config.clusterLabel]));
+        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="all", %(clusterLabel)s="$cluster"}' % [kubernetesMixin._config.SLOs.apiserver.days, kubernetesMixin._config.clusterLabel]));
 
       local errorBudget =
         graphPanel.new(
-          'ErrorBudget (%dd) > %.3f%%' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],
+          'ErrorBudget (%dd) > %.3f%%' % [kubernetesMixin._config.SLOs.apiserver.days, 100 * kubernetesMixin._config.SLOs.apiserver.target],
           datasource='$datasource',
           span=8,
           format='percentunit',
           decimals=3,
           fill=10,
-          description='How much error budget is left looking at our %.3f%% availability guarantees?' % $._config.SLOs.apiserver.target,
+          description='How much error budget is left looking at our %.3f%% availability guarantees?' % kubernetesMixin._config.SLOs.apiserver.target,
         )
-        .addTarget(prometheus.target('100 * (apiserver_request:availability%dd{verb="all", %(clusterLabel)s="$cluster"} - %f)' % [$._config.SLOs.apiserver.days, $._config.clusterLabel, $._config.SLOs.apiserver.target], legendFormat='errorbudget'));
+        .addTarget(prometheus.target('100 * (apiserver_request:availability%dd{verb="all", %(clusterLabel)s="$cluster"} - %f)' % [kubernetesMixin._config.SLOs.apiserver.days, kubernetesMixin._config.clusterLabel, kubernetesMixin._config.SLOs.apiserver.target], legendFormat='errorbudget'));
 
       local readAvailability =
         singlestat.new(
-          'Read Availability (%dd)' % $._config.SLOs.apiserver.days,
+          'Read Availability (%dd)' % kubernetesMixin._config.SLOs.apiserver.days,
           datasource='$datasource',
           span=3,
           format='percentunit',
           decimals=3,
-          description='How many percent of read requests (LIST,GET) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
+          description='How many percent of read requests (LIST,GET) in %d days have been answered successfully and fast enough?' % kubernetesMixin._config.SLOs.apiserver.days,
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="read", %(clusterLabel)s="$cluster"}' % [$._config.SLOs.apiserver.days, $._config.clusterLabel]));
+        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="read", %(clusterLabel)s="$cluster"}' % [kubernetesMixin._config.SLOs.apiserver.days, kubernetesMixin._config.clusterLabel]));
 
       local readRequests =
         graphPanel.new(
@@ -61,7 +63,7 @@ local singlestat = grafana.singlestat;
         .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
         .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
         .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
-        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="read", %(clusterLabel)s="$cluster"})' % $._config, legendFormat='{{ code }}'));
+        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="read", %(clusterLabel)s="$cluster"})' % kubernetesMixin._config, legendFormat='{{ code }}'));
 
       local readErrors =
         graphPanel.new(
@@ -72,7 +74,7 @@ local singlestat = grafana.singlestat;
           format='percentunit',
           description='How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?',
         )
-        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read",code=~"5..", %(clusterLabel)s="$cluster"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read", %(clusterLabel)s="$cluster"})' % $._config, legendFormat='{{ resource }}'));
+        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read",code=~"5..", %(clusterLabel)s="$cluster"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="read", %(clusterLabel)s="$cluster"})' % kubernetesMixin._config, legendFormat='{{ resource }}'));
 
       local readDuration =
         graphPanel.new(
@@ -82,18 +84,18 @@ local singlestat = grafana.singlestat;
           format='s',
           description='How many seconds is the 99th percentile for reading (LIST|GET) a given resource?',
         )
-        .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="read", %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{ resource }}'));
+        .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="read", %(clusterLabel)s="$cluster"}' % kubernetesMixin._config, legendFormat='{{ resource }}'));
 
       local writeAvailability =
         singlestat.new(
-          'Write Availability (%dd)' % $._config.SLOs.apiserver.days,
+          'Write Availability (%dd)' % kubernetesMixin._config.SLOs.apiserver.days,
           datasource='$datasource',
           span=3,
           format='percentunit',
           decimals=3,
-          description='How many percent of write requests (POST|PUT|PATCH|DELETE) in %d days have been answered successfully and fast enough?' % $._config.SLOs.apiserver.days,
+          description='How many percent of write requests (POST|PUT|PATCH|DELETE) in %d days have been answered successfully and fast enough?' % kubernetesMixin._config.SLOs.apiserver.days,
         )
-        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="write", %(clusterLabel)s="$cluster"}' % [$._config.SLOs.apiserver.days, $._config.clusterLabel]));
+        .addTarget(prometheus.target('apiserver_request:availability%dd{verb="write", %(clusterLabel)s="$cluster"}' % [kubernetesMixin._config.SLOs.apiserver.days, kubernetesMixin._config.clusterLabel]));
 
       local writeRequests =
         graphPanel.new(
@@ -109,7 +111,7 @@ local singlestat = grafana.singlestat;
         .addSeriesOverride({ alias: '/3../i', color: '#F2CC0C' })
         .addSeriesOverride({ alias: '/4../i', color: '#3274D9' })
         .addSeriesOverride({ alias: '/5../i', color: '#E02F44' })
-        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="write", %(clusterLabel)s="$cluster"})' % $._config, legendFormat='{{ code }}'));
+        .addTarget(prometheus.target('sum by (code) (code_resource:apiserver_request_total:rate5m{verb="write", %(clusterLabel)s="$cluster"})' % kubernetesMixin._config, legendFormat='{{ code }}'));
 
       local writeErrors =
         graphPanel.new(
@@ -120,7 +122,7 @@ local singlestat = grafana.singlestat;
           format='percentunit',
           description='How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?',
         )
-        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write",code=~"5..", %(clusterLabel)s="$cluster"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write", %(clusterLabel)s="$cluster"})' % $._config, legendFormat='{{ resource }}'));
+        .addTarget(prometheus.target('sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write",code=~"5..", %(clusterLabel)s="$cluster"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb="write", %(clusterLabel)s="$cluster"})' % kubernetesMixin._config, legendFormat='{{ resource }}'));
 
       local writeDuration =
         graphPanel.new(
@@ -130,7 +132,7 @@ local singlestat = grafana.singlestat;
           format='s',
           description='How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?',
         )
-        .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="write", %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{ resource }}'));
+        .addTarget(prometheus.target('cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb="write", %(clusterLabel)s="$cluster"}' % kubernetesMixin._config, legendFormat='{{ resource }}'));
 
       local workQueueAddRate =
         graphPanel.new(
@@ -141,7 +143,7 @@ local singlestat = grafana.singlestat;
           legend_show=false,
           min=0,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name)' % $._config, legendFormat='{{instance}} {{name}}'));
+        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name)' % kubernetesMixin._config, legendFormat='{{instance}} {{name}}'));
 
       local workQueueDepth =
         graphPanel.new(
@@ -152,7 +154,7 @@ local singlestat = grafana.singlestat;
           legend_show=false,
           min=0,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_depth{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name)' % $._config, legendFormat='{{instance}} {{name}}'));
+        .addTarget(prometheus.target('sum(rate(workqueue_depth{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name)' % kubernetesMixin._config, legendFormat='{{instance}} {{name}}'));
 
 
       local workQueueLatency =
@@ -167,7 +169,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name, le))' % $._config, legendFormat='{{instance}} {{name}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{%(kubeApiserverSelector)s, instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])) by (instance, name, le))' % kubernetesMixin._config, legendFormat='{{instance}} {{name}}'));
 
       local memory =
         graphPanel.new(
@@ -176,7 +178,7 @@ local singlestat = grafana.singlestat;
           span=4,
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('process_resident_memory_bytes{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local cpu =
         graphPanel.new(
@@ -186,7 +188,7 @@ local singlestat = grafana.singlestat;
           format='short',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}[5m])' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local goroutines =
         graphPanel.new(
@@ -195,13 +197,13 @@ local singlestat = grafana.singlestat;
           span=4,
           format='short',
         )
-        .addTarget(prometheus.target('go_goroutines{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('go_goroutines{%(kubeApiserverSelector)s,instance=~"$instance", %(clusterLabel)s="$cluster"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       dashboard.new(
-        '%(dashboardNamePrefix)sAPI server' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sAPI server' % kubernetesMixin._config.grafanaK8s,
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['apiserver.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['apiserver.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -222,10 +224,10 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(apiserver_request_total, %(clusterLabel)s)' % $._config,
+          'label_values(apiserver_request_total, %(clusterLabel)s)' % kubernetesMixin._config,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -233,7 +235,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(apiserver_request_total{%(kubeApiserverSelector)s, %(clusterLabel)s="$cluster"}, instance)' % $._config,
+          'label_values(apiserver_request_total{%(kubeApiserverSelector)s, %(clusterLabel)s="$cluster"}, instance)' % kubernetesMixin._config,
           refresh='time',
           includeAll=true,
           sort=1,
@@ -281,6 +283,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -7,6 +7,8 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'controller-manager.json':
       local upCount =
@@ -16,7 +18,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s})' % $._config));
+        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s})' % kubernetesMixin._config));
 
       local workQueueAddRate =
         graphPanel.new(
@@ -30,7 +32,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % $._config));
+        .addTarget(prometheus.target('sum(rate(workqueue_adds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % kubernetesMixin._config));
 
       local workQueueDepth =
         graphPanel.new(
@@ -45,7 +47,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(workqueue_depth{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % $._config));
+        .addTarget(prometheus.target('sum(rate(workqueue_depth{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % kubernetesMixin._config));
 
       local workQueueLatency =
         graphPanel.new(
@@ -59,7 +61,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name, le))' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % $._config));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, name, le))' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} {{name}}' % kubernetesMixin._config));
 
       local rpcRate =
         graphPanel.new(
@@ -68,10 +70,10 @@ local singlestat = grafana.singlestat;
           span=4,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % $._config, legendFormat='2xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % $._config, legendFormat='3xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % $._config, legendFormat='4xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % $._config, legendFormat='5xx'));
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % kubernetesMixin._config, legendFormat='2xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % kubernetesMixin._config, legendFormat='3xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % kubernetesMixin._config, legendFormat='4xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(kubeControllerManagerSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % kubernetesMixin._config, legendFormat='5xx'));
 
       local postRequestLatency =
         graphPanel.new(
@@ -81,7 +83,7 @@ local singlestat = grafana.singlestat;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local getRequestLatency =
         graphPanel.new(
@@ -96,7 +98,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local memory =
         graphPanel.new(
@@ -105,7 +107,7 @@ local singlestat = grafana.singlestat;
           span=4,
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local cpu =
         graphPanel.new(
@@ -115,7 +117,7 @@ local singlestat = grafana.singlestat;
           format='short',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}[5m])' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}[5m])' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local goroutines =
         graphPanel.new(
@@ -124,14 +126,14 @@ local singlestat = grafana.singlestat;
           span=4,
           format='short',
         )
-        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
 
       dashboard.new(
-        '%(dashboardNamePrefix)sController Manager' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sController Manager' % kubernetesMixin._config.grafanaK8s,
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['controller-manager.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['controller-manager.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -152,10 +154,10 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(kube_pod_info, %(clusterLabel)s)' % kubernetesMixin._config,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -163,7 +165,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s}, instance)' % $._config,
+          'label_values(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s}, instance)' % kubernetesMixin._config,
           refresh='time',
           includeAll=true,
           sort=1,
@@ -191,6 +193,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -8,6 +8,8 @@ local tablePanel = grafana.tablePanel;
 local statPanel = grafana.statPanel;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'kubelet.json':
       local upCount =
@@ -16,7 +18,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           reducerFunction='lastNotNull',
         )
-        .addTarget(prometheus.target('sum(kubelet_node_name{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config));
+        .addTarget(prometheus.target('sum(kubelet_node_name{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % kubernetesMixin._config));
 
       local runningPodCount =
         statPanel.new(
@@ -25,7 +27,7 @@ local statPanel = grafana.statPanel;
           reducerFunction='lastNotNull',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
-        .addTarget(prometheus.target('sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_pod_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_pod_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local runningContainerCount =
         statPanel.new(
@@ -34,7 +36,7 @@ local statPanel = grafana.statPanel;
           reducerFunction='lastNotNull',
         )
         // TODO: The second query selected by the OR operator is for backward compatibility with kubernetes < 1.19, so this can be retored to a single query once 1.23 is out
-        .addTarget(prometheus.target('sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_container_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}) OR sum(kubelet_running_container_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local actualVolumeCount =
         statPanel.new(
@@ -42,7 +44,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           reducerFunction='lastNotNull',
         )
-        .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance", state="actual_state_of_world"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance", state="actual_state_of_world"})' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local desiredVolumeCount =
         statPanel.new(
@@ -50,7 +52,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           reducerFunction='lastNotNull',
         )
-        .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance",state="desired_state_of_world"})' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance",state="desired_state_of_world"})' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local configErrorCount =
         statPanel.new(
@@ -58,7 +60,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           reducerFunction='lastNotNull',
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_node_config_error{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(rate(kubelet_node_config_error{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m]))' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local operationRate =
         graphPanel.new(
@@ -71,7 +73,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (operation_type, instance)' % $._config, legendFormat='{{instance}} {{operation_type}}'));
+        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (operation_type, instance)' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_type}}'));
 
       local operationErrorRate =
         graphPanel.new(
@@ -84,7 +86,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_errors_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config, legendFormat='{{instance}} {{operation_type}}'));
+        .addTarget(prometheus.target('sum(rate(kubelet_runtime_operations_errors_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_type)' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_type}}'));
 
       local operationLatency =
         graphPanel.new(
@@ -97,7 +99,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config, legendFormat='{{instance}} {{operation_type}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_type, le))' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_type}}'));
 
       local podStartRate =
         graphPanel.new(
@@ -110,8 +112,8 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_pod_start_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance)' % $._config, legendFormat='{{instance}} pod'))
-        .addTarget(prometheus.target('sum(rate(kubelet_pod_worker_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance)' % $._config, legendFormat='{{instance}} worker'));
+        .addTarget(prometheus.target('sum(rate(kubelet_pod_start_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance)' % kubernetesMixin._config, legendFormat='{{instance}} pod'))
+        .addTarget(prometheus.target('sum(rate(kubelet_pod_worker_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance)' % kubernetesMixin._config, legendFormat='{{instance}} worker'));
 
       local podStartLatency =
         graphPanel.new(
@@ -124,8 +126,8 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % $._config, legendFormat='{{instance}} pod'))
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % $._config, legendFormat='{{instance}} worker'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % kubernetesMixin._config, legendFormat='{{instance}} pod'))
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % kubernetesMixin._config, legendFormat='{{instance}} worker'));
 
       local storageOperationRate =
         graphPanel.new(
@@ -140,7 +142,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % $._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
+        .addTarget(prometheus.target('sum(rate(storage_operation_duration_seconds_count{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
 
       local storageOperationErrorRate =
         graphPanel.new(
@@ -155,7 +157,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('sum(rate(storage_operation_errors_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % $._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
+        .addTarget(prometheus.target('sum(rate(storage_operation_errors_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin)' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
 
 
       local storageOperationLatency =
@@ -170,7 +172,7 @@ local statPanel = grafana.statPanel;
           legend_hideEmpty=true,
           legend_hideZero=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin, le))' % $._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_name, volume_plugin, le))' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_name}} {{volume_plugin}}'));
 
       local cgroupManagerRate =
         graphPanel.new(
@@ -183,7 +185,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_cgroup_manager_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_type)' % $._config, legendFormat='{{operation_type}}'));
+        .addTarget(prometheus.target('sum(rate(kubelet_cgroup_manager_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_type)' % kubernetesMixin._config, legendFormat='{{operation_type}}'));
 
       local cgroupManagerDuration =
         graphPanel.new(
@@ -196,7 +198,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_type, le))' % $._config, legendFormat='{{instance}} {{operation_type}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, operation_type, le))' % kubernetesMixin._config, legendFormat='{{instance}} {{operation_type}}'));
 
       local plegRelistRate =
         graphPanel.new(
@@ -210,7 +212,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(kubelet_pleg_relist_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance)' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('sum(rate(kubelet_pleg_relist_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance)' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local plegRelistDuration =
         graphPanel.new(
@@ -223,7 +225,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local plegRelistInterval =
         graphPanel.new(
@@ -236,7 +238,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])) by (instance, le))' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local rpcRate =
         graphPanel.new(
@@ -244,10 +246,10 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % $._config, legendFormat='2xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % $._config, legendFormat='3xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % $._config, legendFormat='4xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % $._config, legendFormat='5xx'));
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % kubernetesMixin._config, legendFormat='2xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % kubernetesMixin._config, legendFormat='3xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % kubernetesMixin._config, legendFormat='4xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % kubernetesMixin._config, legendFormat='5xx'));
 
       local requestDuration =
         graphPanel.new(
@@ -260,7 +262,7 @@ local statPanel = grafana.statPanel;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, verb, url, le))' % $._config, legendFormat='{{instance}} {{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster",%(kubeletSelector)s, instance=~"$instance"}[5m])) by (instance, verb, url, le))' % kubernetesMixin._config, legendFormat='{{instance}} {{verb}} {{url}}'));
 
       local memory =
         graphPanel.new(
@@ -268,7 +270,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local cpu =
         graphPanel.new(
@@ -276,7 +278,7 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='short',
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}[5m])' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local goroutines =
         graphPanel.new(
@@ -284,14 +286,14 @@ local statPanel = grafana.statPanel;
           datasource='$datasource',
           format='short',
         )
-        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster",%(kubeletSelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
 
       dashboard.new(
-        '%(dashboardNamePrefix)sKubelet' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sKubelet' % kubernetesMixin._config.grafanaK8s,
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['kubelet.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['kubelet.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -312,10 +314,10 @@ local statPanel = grafana.statPanel;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(kube_pod_info, %(clusterLabel)s)' % kubernetesMixin._config,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -323,7 +325,7 @@ local statPanel = grafana.statPanel;
         template.new(
           'instance',
           '$datasource',
-          'label_values(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, instance)' % $._config,
+          'label_values(kubelet_runtime_operations_total{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, instance)' % kubernetesMixin._config,
           refresh='time',
           includeAll=true,
           sort=1,
@@ -353,6 +355,6 @@ local statPanel = grafana.statPanel;
       .addPanel(memory, gridPos={ h: 7, w: 8, x: 0, y: 77 })
       .addPanel(cpu, gridPos={ h: 7, w: 8, x: 8, y: 77 })
       .addPanel(goroutines, gridPos={ h: 7, w: 8, x: 16, y: 77 })
-      + { refresh: $._config.grafanaK8s.refresh },
+      + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -9,6 +9,8 @@ local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
 
     'cluster-total.json':
@@ -338,17 +340,17 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
-          hide=if $._config.showMultiCluster then '' else '2',
+          query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
+          hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
           refresh=2
         );
 
       dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Cluster' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
+        title='%(dashboardNamePrefix)sNetworking / Cluster' % kubernetesMixin._config.grafanaK8s,
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
+        refresh=(kubernetesMixin._config.grafanaK8s.refresh),
         time_from='now-1h',
         time_to='now',
       )
@@ -378,14 +380,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newBarplotPanel(
           graphTitle='Current Rate of Bytes Received',
-          graphQuery='sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+          graphQuery='sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
         newBarplotPanel(
           graphTitle='Current Rate of Bytes Transmitted',
-          graphQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+          graphQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -393,14 +395,14 @@ local singlestat = grafana.singlestat;
         newTablePanel(
           tableTitle='Current Status',
           colQueries=[
-            'sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
-            'sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            'sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
+            'sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
           ]
         ),
         gridPos={ h: 9, w: 24, x: 0, y: 10 }
@@ -410,14 +412,14 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newBarplotPanel(
             graphTitle='Average Rate of Bytes Received',
-            graphQuery='sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 11 }
         )
         .addPanel(
           newBarplotPanel(
             graphTitle='Average Rate of Bytes Transmitted',
-            graphQuery='sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 11 }
         ),
@@ -429,14 +431,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newGraphPanel(
           graphTitle='Receive Bandwidth',
-          graphQuery='sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+          graphQuery='sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 24, x: 0, y: 12 }
       )
       .addPanel(
         newGraphPanel(
           graphTitle='Transmit Bandwidth',
-          graphQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+          graphQuery='sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 24, x: 0, y: 21 }
       )
@@ -445,7 +447,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets',
-            graphQuery='sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 24, x: 0, y: 31 }
@@ -453,7 +455,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets',
-            graphQuery='sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 24, x: 0, y: 40 }
@@ -465,7 +467,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets Dropped',
-            graphQuery='sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 24, x: 0, y: 50 }
@@ -473,7 +475,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets Dropped',
-            graphQuery='sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % $._config,
+            graphQuery='sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~".+"}[$interval:$resolution])) by (namespace))' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 24, x: 0, y: 59 }
@@ -481,7 +483,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of TCP Retransmits out of all sent segments',
-            graphQuery='sort_desc(sum(rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution]) / rate(node_netstat_Tcp_OutSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution])) by (instance))' % $._config,
+            graphQuery='sort_desc(sum(rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution]) / rate(node_netstat_Tcp_OutSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution])) by (instance))' % kubernetesMixin._config,
             graphFormat='percentunit',
             legendFormat='{{instance}}'
           ) + { links: [
@@ -495,7 +497,7 @@ local singlestat = grafana.singlestat;
         ).addPanel(
           newGraphPanel(
             graphTitle='Rate of TCP SYN Retransmits out of all retransmits',
-            graphQuery='sort_desc(sum(rate(node_netstat_TcpExt_TCPSynRetrans{%(clusterLabel)s="$cluster"}[$interval:$resolution]) / rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution])) by (instance))' % $._config,
+            graphQuery='sort_desc(sum(rate(node_netstat_TcpExt_TCPSynRetrans{%(clusterLabel)s="$cluster"}[$interval:$resolution]) / rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[$interval:$resolution])) by (instance))' % kubernetesMixin._config,
             graphFormat='percentunit',
             legendFormat='{{instance}}'
           ) + { links: [

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -9,6 +9,8 @@ local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
 
     'namespace-by-pod.json':
@@ -231,8 +233,8 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
-          hide=if $._config.showMultiCluster then '' else '2',
+          query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
+          hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
           refresh=2
         );
 
@@ -240,7 +242,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='namespace',
           datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           allValues='.+',
           current='kube-system',
           hide='',
@@ -251,7 +253,7 @@ local singlestat = grafana.singlestat;
           auto: false,
           auto_count: 30,
           auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           skipUrlSync: false,
         };
 
@@ -346,11 +348,11 @@ local singlestat = grafana.singlestat;
         );
 
       dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Namespace (Pods)' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
+        title='%(dashboardNamePrefix)sNetworking / Namespace (Pods)' % kubernetesMixin._config.grafanaK8s,
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
+        refresh=(kubernetesMixin._config.grafanaK8s.refresh),
         time_from='now-1h',
         time_to='now',
       )
@@ -379,14 +381,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newGaugePanel(
           gaugeTitle='Current Rate of Bytes Received',
-          gaugeQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % $._config,
+          gaugeQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
         newGaugePanel(
           gaugeTitle='Current Rate of Bytes Transmitted',
-          gaugeQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % $._config,
+          gaugeQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -394,12 +396,12 @@ local singlestat = grafana.singlestat;
         newTablePanel(
           tableTitle='Current Status',
           colQueries=[
-            'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+            'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
+            'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
+            'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
+            'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
+            'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
+            'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
           ]
         ),
         gridPos={ h: 9, w: 24, x: 0, y: 10 }
@@ -408,14 +410,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newGraphPanel(
           graphTitle='Receive Bandwidth',
-          graphQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+          graphQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 20 }
       )
       .addPanel(
         newGraphPanel(
           graphTitle='Transmit Bandwidth',
-          graphQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+          graphQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 20 }
       )
@@ -424,7 +426,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets',
-            graphQuery='sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 0, y: 30 }
@@ -432,7 +434,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets',
-            graphQuery='sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 12, y: 30 }
@@ -444,7 +446,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets Dropped',
-            graphQuery='sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 0, y: 40 }
@@ -452,7 +454,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets Dropped',
-            graphQuery='sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 12, y: 40 }

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -9,6 +9,8 @@ local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
 
     'namespace-by-workload.json':
@@ -235,8 +237,8 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
-          hide=if $._config.showMultiCluster then '' else '2',
+          query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
+          hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
           refresh=2
         );
 
@@ -244,7 +246,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='namespace',
           datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           current='kube-system',
           hide='',
           refresh=2,
@@ -254,7 +256,7 @@ local singlestat = grafana.singlestat;
           auto: false,
           auto_count: 30,
           auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           skipUrlSync: false,
         };
 
@@ -262,7 +264,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='type',
           datasource='$datasource',
-          query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config,
+          query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+"}, workload_type)' % kubernetesMixin._config,
           current='deployment',
           hide='',
           refresh=2,
@@ -272,7 +274,7 @@ local singlestat = grafana.singlestat;
           auto: false,
           auto_count: 30,
           auto_min: '10s',
-          definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config,
+          definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+"}, workload_type)' % kubernetesMixin._config,
           skipUrlSync: false,
         };
 
@@ -375,11 +377,11 @@ local singlestat = grafana.singlestat;
         );
 
       dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Namespace (Workload)' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
+        title='%(dashboardNamePrefix)sNetworking / Namespace (Workload)' % kubernetesMixin._config.grafanaK8s,
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
+        refresh=(kubernetesMixin._config.grafanaK8s.refresh),
         time_from='now-1h',
         time_to='now',
       )
@@ -413,7 +415,7 @@ local singlestat = grafana.singlestat;
             sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config,
+          ||| % kubernetesMixin._config,
           legendFormat='{{ workload }}',
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
@@ -425,7 +427,7 @@ local singlestat = grafana.singlestat;
             sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config,
+          ||| % kubernetesMixin._config,
           legendFormat='{{ workload }}',
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
@@ -438,42 +440,42 @@ local singlestat = grafana.singlestat;
               sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             |||
               sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           ]
         ),
         gridPos={ h: 9, w: 24, x: 0, y: 10 }
@@ -487,7 +489,7 @@ local singlestat = grafana.singlestat;
               sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             legendFormat='{{ workload }}',
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 20 }
@@ -499,7 +501,7 @@ local singlestat = grafana.singlestat;
               sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             legendFormat='{{ workload }}',
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 20 }
@@ -516,7 +518,7 @@ local singlestat = grafana.singlestat;
             sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config,
+          ||| % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 38 }
       )
@@ -527,7 +529,7 @@ local singlestat = grafana.singlestat;
             sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config,
+          ||| % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 38 }
       )
@@ -540,7 +542,7 @@ local singlestat = grafana.singlestat;
               sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 40 }
@@ -552,7 +554,7 @@ local singlestat = grafana.singlestat;
               sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 40 }
@@ -568,7 +570,7 @@ local singlestat = grafana.singlestat;
               sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 12, x: 0, y: 41 }
@@ -580,7 +582,7 @@ local singlestat = grafana.singlestat;
               sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 9, w: 12, x: 12, y: 41 }

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -8,6 +8,8 @@ local annotation = grafana.annotation;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
 
     'pod-total.json':
@@ -110,8 +112,8 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
-          hide=if $._config.showMultiCluster then '' else '2',
+          query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
+          hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
           refresh=2
         );
 
@@ -120,7 +122,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='namespace',
           datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           allValues='.+',
           current='kube-system',
           hide='',
@@ -131,7 +133,7 @@ local singlestat = grafana.singlestat;
           auto: false,
           auto_count: 30,
           auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
+          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config,
           skipUrlSync: false,
         };
 
@@ -139,7 +141,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='pod',
           datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}, pod)' % $._config,
+          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}, pod)' % kubernetesMixin._config,
           allValues='.+',
           current='',
           hide='',
@@ -150,7 +152,7 @@ local singlestat = grafana.singlestat;
           auto: false,
           auto_count: 30,
           auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}, pod)' % $._config,
+          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}, pod)' % kubernetesMixin._config,
           skipUrlSync: false,
         };
 
@@ -245,11 +247,11 @@ local singlestat = grafana.singlestat;
         );
 
       dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Pod' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
+        title='%(dashboardNamePrefix)sNetworking / Pod' % kubernetesMixin._config.grafanaK8s,
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
         editable=true,
         schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
+        refresh=(kubernetesMixin._config.grafanaK8s.refresh),
         time_from='now-1h',
         time_to='now',
       )
@@ -279,14 +281,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newGaugePanel(
           gaugeTitle='Current Rate of Bytes Received',
-          gaugeQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution]))' % $._config,
+          gaugeQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution]))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 1 }
       )
       .addPanel(
         newGaugePanel(
           gaugeTitle='Current Rate of Bytes Transmitted',
-          gaugeQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution]))' % $._config,
+          gaugeQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution]))' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 1 }
       )
@@ -294,14 +296,14 @@ local singlestat = grafana.singlestat;
       .addPanel(
         newGraphPanel(
           graphTitle='Receive Bandwidth',
-          graphQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+          graphQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 0, y: 11 }
       )
       .addPanel(
         newGraphPanel(
           graphTitle='Transmit Bandwidth',
-          graphQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+          graphQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
         ),
         gridPos={ h: 9, w: 12, x: 12, y: 11 }
       )
@@ -310,7 +312,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets',
-            graphQuery='sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 0, y: 21 }
@@ -318,7 +320,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets',
-            graphQuery='sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 12, y: 21 }
@@ -330,7 +332,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Received Packets Dropped',
-            graphQuery='sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 0, y: 32 }
@@ -338,7 +340,7 @@ local singlestat = grafana.singlestat;
         .addPanel(
           newGraphPanel(
             graphTitle='Rate of Transmitted Packets Dropped',
-            graphQuery='sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % $._config,
+            graphQuery='sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[$interval:$resolution])) by (pod)' % kubernetesMixin._config,
             graphFormat='pps'
           ),
           gridPos={ h: 10, w: 12, x: 12, y: 32 }

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -9,6 +9,8 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
 local gauge = promgrafonnet.gauge;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'persistentvolumesusage.json':
       local sizeGraph = graphPanel.new(
@@ -34,13 +36,13 @@ local gauge = promgrafonnet.gauge;
             -
             sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
           )
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         legendFormat='Used Space',
         intervalFactor=1,
       )).addTarget(prometheus.target(
         |||
           sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         legendFormat='Free Space',
         intervalFactor=1,
       ));
@@ -57,7 +59,7 @@ local gauge = promgrafonnet.gauge;
           /
           topk(1, kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
           * 100)
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
       ).withLowerBeingBetter();
 
 
@@ -80,7 +82,7 @@ local gauge = promgrafonnet.gauge;
       ).addTarget(prometheus.target(
         |||
           sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         legendFormat='Used inodes',
         intervalFactor=1,
       )).addTarget(prometheus.target(
@@ -90,7 +92,7 @@ local gauge = promgrafonnet.gauge;
             -
             sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
           )
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         legendFormat=' Free inodes',
         intervalFactor=1,
       ));
@@ -103,15 +105,15 @@ local gauge = promgrafonnet.gauge;
           /
           topk(1, kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
           * 100)
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
       ).withLowerBeingBetter();
 
 
       dashboard.new(
-        '%(dashboardNamePrefix)sPersistent Volumes' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sPersistent Volumes' % kubernetesMixin._config.grafanaK8s,
         time_from='now-7d',
-        uid=($._config.grafanaDashboardIDs['persistentvolumesusage.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['persistentvolumesusage.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -132,10 +134,10 @@ local gauge = promgrafonnet.gauge;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kubelet_volume_stats_capacity_bytes, %s)' % $._config.clusterLabel,
+          'label_values(kubelet_volume_stats_capacity_bytes, %s)' % kubernetesMixin._config.clusterLabel,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -143,7 +145,7 @@ local gauge = promgrafonnet.gauge;
         template.new(
           'namespace',
           '$datasource',
-          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, namespace)' % $._config,
+          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, namespace)' % kubernetesMixin._config,
           label='Namespace',
           refresh='time',
           sort=1,
@@ -153,7 +155,7 @@ local gauge = promgrafonnet.gauge;
         template.new(
           'volume',
           '$datasource',
-          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace"}, persistentvolumeclaim)' % $._config,
+          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace"}, persistentvolumeclaim)' % kubernetesMixin._config,
           label='PersistentVolumeClaim',
           refresh='time',
           sort=1,
@@ -168,6 +170,6 @@ local gauge = promgrafonnet.gauge;
         row.new()
         .addPanel(inodesGraph)
         .addPanel(inodeGauge)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -7,6 +7,8 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'proxy.json':
       local upCount =
@@ -16,7 +18,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeProxySelector)s})' % $._config));
+        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeProxySelector)s})' % kubernetesMixin._config));
 
       local rulesSyncRate =
         graphPanel.new(
@@ -26,7 +28,7 @@ local singlestat = grafana.singlestat;
           min=0,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='rate'));
+        .addTarget(prometheus.target('sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % kubernetesMixin._config, legendFormat='rate'));
 
       local rulesSyncLatency =
         graphPanel.new(
@@ -41,7 +43,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local networkProgrammingRate =
         graphPanel.new(
@@ -51,7 +53,7 @@ local singlestat = grafana.singlestat;
           min=0,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(kubeproxy_network_programming_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % $._config, legendFormat='rate'));
+        .addTarget(prometheus.target('sum(rate(kubeproxy_network_programming_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m]))' % kubernetesMixin._config, legendFormat='rate'));
 
       local networkProgrammingLatency =
         graphPanel.new(
@@ -66,7 +68,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m])) by (instance, le))' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance"}[5m])) by (instance, le))' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local rpcRate =
         graphPanel.new(
@@ -75,10 +77,10 @@ local singlestat = grafana.singlestat;
           span=4,
           format='ops',
         )
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"2.."}[5m]))' % $._config, legendFormat='2xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"3.."}[5m]))' % $._config, legendFormat='3xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"4.."}[5m]))' % $._config, legendFormat='4xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"5.."}[5m]))' % $._config, legendFormat='5xx'));
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"2.."}[5m]))' % kubernetesMixin._config, legendFormat='2xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"3.."}[5m]))' % kubernetesMixin._config, legendFormat='3xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"4.."}[5m]))' % kubernetesMixin._config, legendFormat='4xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance",code=~"5.."}[5m]))' % kubernetesMixin._config, legendFormat='5xx'));
 
       local postRequestLatency =
         graphPanel.new(
@@ -88,7 +90,7 @@ local singlestat = grafana.singlestat;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance",verb="POST"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance",verb="POST"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local getRequestLatency =
         graphPanel.new(
@@ -103,7 +105,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local memory =
         graphPanel.new(
@@ -112,7 +114,7 @@ local singlestat = grafana.singlestat;
           span=4,
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local cpu =
         graphPanel.new(
@@ -122,7 +124,7 @@ local singlestat = grafana.singlestat;
           format='short',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}[5m])' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}[5m])' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local goroutines =
         graphPanel.new(
@@ -131,14 +133,14 @@ local singlestat = grafana.singlestat;
           span=4,
           format='short',
         )
-        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeProxySelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
 
       dashboard.new(
-        '%(dashboardNamePrefix)sProxy' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sProxy' % kubernetesMixin._config.grafanaK8s,
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['proxy.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['proxy.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -159,10 +161,10 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(kube_pod_info, %(clusterLabel)s)' % kubernetesMixin._config,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -170,7 +172,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(kubeproxy_network_programming_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s}, instance)' % $._config,
+          'label_values(kubeproxy_network_programming_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeProxySelector)s}, instance)' % kubernetesMixin._config,
           refresh='time',
           includeAll=true,
           sort=1,
@@ -197,6 +199,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -3,14 +3,16 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = grafana.template;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     local clusterTemplate =
       template.new(
         name='cluster',
         datasource='$datasource',
-        query='label_values(node_cpu_seconds_total, %s)' % $._config.clusterLabel,
+        query='label_values(node_cpu_seconds_total, %s)' % kubernetesMixin._config.clusterLabel,
         current='',
-        hide=if $._config.showMultiCluster then '' else '2',
+        hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
         refresh=2,
         includeAll=false,
         sort=1
@@ -20,42 +22,42 @@ local template = grafana.template;
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
           alias: 'Pods',
           linkTooltip: 'Drill down to pods',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           decimals: 0,
         },
         'Value #B': {
           alias: 'Workloads',
           linkTooltip: 'Drill down to workloads',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workloads-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workloads-namespace.json') },
           decimals: 0,
         },
       };
 
 
       local podWorkloadColumns = [
-        'sum(kube_pod_owner{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
-        'count(avg(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster"}) by (workload, namespace)) by (namespace)' % $._config,
+        'sum(kube_pod_owner{%(clusterLabel)s="$cluster"}) by (namespace)' % kubernetesMixin._config,
+        'count(avg(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster"}) by (workload, namespace)) by (namespace)' % kubernetesMixin._config,
       ];
 
       local networkColumns = [
-        'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
-        'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
-        'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
-        'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
-        'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
-        'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config,
+        'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
+        'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
+        'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config,
       ];
 
       local networkTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -85,18 +87,18 @@ local template = grafana.template;
       };
 
       local storageIOColumns = [
-        'sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
-        'sum by(namespace) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
-        'sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
-        'sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
-        'sum by(namespace) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
-        'sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config,
+        'sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
+        'sum by(namespace) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
+        'sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
+        'sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
+        'sum by(namespace) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
+        'sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config,
       ];
 
       local storageIOTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -129,8 +131,8 @@ local template = grafana.template;
       };
 
       g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Cluster' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
+        '%(dashboardNamePrefix)sCompute Resources / Cluster' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       )
       .addRow(
         (g.row('Headlines') +
@@ -140,35 +142,35 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]))' % $._config) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]))' % kubernetesMixin._config) +
+          { interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval },
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
-          g.statPanel('sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('CPU Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) / sum(kube_node_status_allocatable{resource="cpu",%(clusterLabel)s="$cluster"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(node_memory_MemTotal_bytes{%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemAvailable_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(node_memory_MemTotal_bytes{%(clusterLabel)s="$cluster"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +
-          g.statPanel('sum(namespace_memory:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('sum(namespace_memory:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('Memory Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) / sum(kube_node_status_allocatable{resource="memory",%(clusterLabel)s="$cluster"})' % kubernetesMixin._config)
         )
       )
       .addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack
         )
       )
@@ -177,11 +179,11 @@ local template = grafana.template;
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel(podWorkloadColumns + [
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
-            'sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % $._config,
-            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % $._config,
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % $._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace)' % kubernetesMixin._config,
+            'sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(clusterLabel)s="$cluster"}) by (namespace)' % kubernetesMixin._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % kubernetesMixin._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="cpu"}) by (namespace)' % kubernetesMixin._config,
           ], tableStyles {
             'Value #C': { alias: 'CPU Usage' },
             'Value #D': { alias: 'CPU Requests' },
@@ -196,7 +198,7 @@ local template = grafana.template;
         .addPanel(
           g.panel('Memory Usage (w/o cache)') +
           // Not using container_memory_usage_bytes here because that includes page cache
-          g.queryPanel('sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('bytes') },
         )
@@ -207,11 +209,11 @@ local template = grafana.template;
           g.panel('Requests by Namespace') +
           g.tablePanel(podWorkloadColumns + [
             // Not using container_memory_usage_bytes here because that includes page cache
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace)' % $._config,
-            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % $._config,
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % $._config,
-            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % $._config,
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % $._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % kubernetesMixin._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % kubernetesMixin._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container!=""}) by (namespace) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", resource="memory"}) by (namespace)' % kubernetesMixin._config,
           ], tableStyles {
             'Value #C': { alias: 'Memory Usage', unit: 'bytes' },
             'Value #D': { alias: 'Memory Requests', unit: 'bytes' },
@@ -229,20 +231,20 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          { interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
         g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
-          g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Transmit Bandwidth') +
-          g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -251,13 +253,13 @@ local template = grafana.template;
         g.row('Average Container Bandwidth by Namespace')
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Received') +
-          g.queryPanel('avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Average Container Bandwidth by Namespace: Transmitted') +
-          g.queryPanel('avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -266,13 +268,13 @@ local template = grafana.template;
         g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
-          g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
-          g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -281,13 +283,13 @@ local template = grafana.template;
         g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
-          g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
-          g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % $._config, '{{namespace}}') +
+          g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -296,14 +298,14 @@ local template = grafana.template;
         g.row('Storage IO')
         .addPanel(
           g.panel('IOPS(Reads+Writes)') +
-          g.queryPanel('ceil(sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m])))' % $._config, '{{namespace}}') +
+          g.queryPanel('ceil(sum by(namespace) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster"}[5m])))' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('short'), decimals: -1 },
 
         )
         .addPanel(
           g.panel('ThroughPut(Read+Write)') +
-          g.queryPanel('sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % $._config, '{{namespace}}') +
+          g.queryPanel('sum by(namespace) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster"}[5m]))' % kubernetesMixin._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -324,9 +326,9 @@ local template = grafana.template;
           },
         )
       ) + {
-        tags: $._config.grafanaK8s.dashboardTags,
+        tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
         templating+: { list+: [clusterTemplate] },
-        refresh: $._config.grafanaK8s.refresh,
+        refresh: kubernetesMixin._config.grafanaK8s.refresh,
       },
   },
 }

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -3,19 +3,21 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = grafana.template;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+::
-    if $._config.showMultiCluster then {
+    if kubernetesMixin._config.showMultiCluster then {
       'k8s-resources-multicluster.json':
         local tableStyles = {
-          [$._config.clusterLabel]: {
+          [kubernetesMixin._config.clusterLabel]: {
             alias: 'Cluster',
-            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-cluster.json') },
+            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-cluster.json') },
           },
         };
 
         g.dashboard(
-          '%(dashboardNamePrefix)sCompute Resources /  Multi-Cluster' % $._config.grafanaK8s,
-          uid=($._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
+          '%(dashboardNamePrefix)sCompute Resources /  Multi-Cluster' % kubernetesMixin._config.grafanaK8s,
+          uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
         ).addRow(
           (g.row('Headlines') +
            {
@@ -24,7 +26,7 @@ local template = grafana.template;
            })
           .addPanel(
             g.panel('CPU Utilisation') +
-            g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[%(grafanaIntervalVar)s]))' % $._config)
+            g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[%(grafanaIntervalVar)s]))' % kubernetesMixin._config)
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +
@@ -51,7 +53,7 @@ local template = grafana.template;
           g.row('CPU')
           .addPanel(
             g.panel('CPU Usage') +
-            g.queryPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
+            g.queryPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s)' % kubernetesMixin._config, '{{%(clusterLabel)s}}' % kubernetesMixin._config)
             + { fill: 0, linewidth: 2 },
           )
         )
@@ -60,11 +62,11 @@ local template = grafana.template;
           .addPanel(
             g.panel('CPU Quota') +
             g.tablePanel([
-              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s)' % $._config,
-              'sum(kube_pod_container_resource_requests{resource="cpu"}) by (%(clusterLabel)s)' % $._config,
-              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{resource="cpu"}) by (%(clusterLabel)s)' % $._config,
-              'sum(kube_pod_container_resource_limits{resource="cpu"}) by (%(clusterLabel)s)' % $._config,
-              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{resource="cpu"}) by (%(clusterLabel)s)' % $._config,
+              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(kube_pod_container_resource_requests{resource="cpu"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{resource="cpu"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(kube_pod_container_resource_limits{resource="cpu"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{resource="cpu"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
             ], tableStyles {
               'Value #A': { alias: 'CPU Usage' },
               'Value #B': { alias: 'CPU Requests' },
@@ -79,7 +81,7 @@ local template = grafana.template;
           .addPanel(
             g.panel('Memory Usage (w/o cache)') +
             // Not using container_memory_usage_bytes here because that includes page cache
-            g.queryPanel('sum(container_memory_rss{container!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
+            g.queryPanel('sum(container_memory_rss{container!=""}) by (%(clusterLabel)s)' % kubernetesMixin._config, '{{%(clusterLabel)s}}' % kubernetesMixin._config) +
             { fill: 0, linewidth: 2, yaxes: g.yaxes('bytes') },
           )
         )
@@ -89,11 +91,11 @@ local template = grafana.template;
             g.panel('Requests by Cluster') +
             g.tablePanel([
               // Not using container_memory_usage_bytes here because that includes page cache
-              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s)' % $._config,
-              'sum(kube_pod_container_resource_requests{resource="memory"}) by (%(clusterLabel)s)' % $._config,
-              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{resource="memory"}) by (%(clusterLabel)s)' % $._config,
-              'sum(kube_pod_container_resource_limits{resource="memory"}) by (%(clusterLabel)s)' % $._config,
-              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{resource="memory"}) by (%(clusterLabel)s)' % $._config,
+              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(kube_pod_container_resource_requests{resource="memory"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{resource="memory"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(kube_pod_container_resource_limits{resource="memory"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
+              'sum(container_memory_rss{container!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{resource="memory"}) by (%(clusterLabel)s)' % kubernetesMixin._config,
             ], tableStyles {
               'Value #A': { alias: 'Memory Usage', unit: 'bytes' },
               'Value #B': { alias: 'Memory Requests', unit: 'bytes' },
@@ -102,6 +104,6 @@ local template = grafana.template;
               'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
             })
           )
-        ) + { tags: $._config.grafanaK8s.dashboardTags, refresh: $._config.grafanaK8s.refresh },
+        ) + { tags: kubernetesMixin._config.grafanaK8s.dashboardTags, refresh: kubernetesMixin._config.grafanaK8s.refresh },
     } else {},
 }

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -3,14 +3,16 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = grafana.template;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     local clusterTemplate =
       template.new(
         name='cluster',
         datasource='$datasource',
-        query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
         current='',
-        hide=if $._config.showMultiCluster then '' else '2',
+        hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
         refresh=2,
         includeAll=false,
         sort=1
@@ -20,7 +22,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -31,23 +33,23 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 
       local networkColumns = [
-        'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
-        'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
-        'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
-        'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
-        'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
-        'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config,
+        'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
+        'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
+        'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
+        'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config,
       ];
 
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -76,28 +78,28 @@ local template = grafana.template;
         },
       };
 
-      local cpuUsageQuery = 'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config;
+      local cpuUsageQuery = 'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % kubernetesMixin._config;
 
-      local memoryUsageQuery = 'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""}) by (pod)' % $._config;
+      local memoryUsageQuery = 'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""}) by (pod)' % kubernetesMixin._config;
 
-      local cpuQuotaRequestsQuery = 'scalar(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource="requests.cpu"})' % $._config;
+      local cpuQuotaRequestsQuery = 'scalar(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource="requests.cpu"})' % kubernetesMixin._config;
       local cpuQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'limits.cpu');
       local memoryQuotaRequestsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'requests.memory');
       local memoryQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'limits.memory');
 
       local storageIOColumns = [
-        'sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
-        'sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
-        'sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
-        'sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
-        'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
-        'sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config,
+        'sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
+        'sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
+        'sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
+        'sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
+        'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
+        'sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config,
       ];
 
       local storageIOTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -130,8 +132,8 @@ local template = grafana.template;
       };
 
       g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Namespace (Pods)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
+        '%(dashboardNamePrefix)sCompute Resources / Namespace (Pods)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       )
       .addRow(
         (g.row('Headlines') +
@@ -141,19 +143,19 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation (from requests)') +
-          g.statPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})' % $._config)
+          g.statPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('CPU Utilisation (from limits)') +
-          g.statPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})' % $._config)
+          g.statPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('Memory Utilisation (from requests)') +
-          g.statPanel('sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"})' % $._config)
+          g.statPanel('sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"})' % kubernetesMixin._config)
         )
         .addPanel(
           g.panel('Memory Utilisation (from limits)') +
-          g.statPanel('sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"})' % $._config)
+          g.statPanel('sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"})' % kubernetesMixin._config)
         )
       )
       .addRow(
@@ -198,11 +200,11 @@ local template = grafana.template;
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel([
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
-            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % $._config,
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % $._config,
-            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % $._config,
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % $._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % kubernetesMixin._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % kubernetesMixin._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"}) by (pod)' % kubernetesMixin._config,
           ], tableStyles {
             'Value #A': { alias: 'CPU Usage' },
             'Value #B': { alias: 'CPU Requests' },
@@ -257,14 +259,14 @@ local template = grafana.template;
         .addPanel(
           g.panel('Memory Quota') +
           g.tablePanel([
-            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod)' % $._config,
-            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % $._config,
-            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % $._config,
-            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % $._config,
-            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % $._config,
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % $._config,
-            'sum(container_memory_cache{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % $._config,
-            'sum(container_memory_swap{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % $._config,
+            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % kubernetesMixin._config,
+            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod) / sum(kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % kubernetesMixin._config,
+            'sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % kubernetesMixin._config,
+            'sum(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container!="", image!=""}) by (pod) / sum(kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", namespace="$namespace", resource="memory"}) by (pod)' % kubernetesMixin._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % kubernetesMixin._config,
+            'sum(container_memory_cache{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % kubernetesMixin._config,
+            'sum(container_memory_swap{%(clusterLabel)s="$cluster", namespace="$namespace",container!=""}) by (pod)' % kubernetesMixin._config,
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'bytes' },
             'Value #B': { alias: 'Memory Requests', unit: 'bytes' },
@@ -285,20 +287,20 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          { interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
         g.row('Bandwidth')
         .addPanel(
           g.panel('Receive Bandwidth') +
-          g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Transmit Bandwidth') +
-          g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -307,13 +309,13 @@ local template = grafana.template;
         g.row('Rate of Packets')
         .addPanel(
           g.panel('Rate of Received Packets') +
-          g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
-          g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -322,13 +324,13 @@ local template = grafana.template;
         g.row('Rate of Packets Dropped')
         .addPanel(
           g.panel('Rate of Received Packets Dropped') +
-          g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
-          g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -337,14 +339,14 @@ local template = grafana.template;
         g.row('Storage IO')
         .addPanel(
           g.panel('IOPS(Reads+Writes)') +
-          g.queryPanel('ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m])))' % $._config, '{{pod}}') +
+          g.queryPanel('ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m])))' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('short'), decimals: -1 },
 
         )
         .addPanel(
           g.panel('ThroughPut(Read+Write)') +
-          g.queryPanel('sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % $._config, '{{pod}}') +
+          g.queryPanel('sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]) + rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace"}[5m]))' % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -364,6 +366,6 @@ local template = grafana.template;
             },
           },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + { tags: kubernetesMixin._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate] }, refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -3,15 +3,17 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = grafana.template;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
 
     local clusterTemplate =
       template.new(
         name='cluster',
         datasource='$datasource',
-        query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
         current='',
-        hide=if $._config.showMultiCluster then '' else '2',
+        hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
         refresh=2,
         includeAll=false,
         sort=1
@@ -21,7 +23,7 @@ local template = grafana.template;
       template.new(
         name='type',
         datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config.clusterLabel,
+        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}, workload_type)' % kubernetesMixin._config.clusterLabel,
         current='deployment',
         hide='',
         refresh=2,
@@ -31,7 +33,7 @@ local template = grafana.template;
         auto: false,
         auto_count: 30,
         auto_min: '10s',
-        definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}, workload_type)' % $._config.clusterLabel,
+        definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}, workload_type)' % kubernetesMixin._config.clusterLabel,
         skipUrlSync: false,
       },
 
@@ -39,7 +41,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -51,7 +53,7 @@ local template = grafana.template;
       local tableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
         },
         workload_type: {
           alias: 'Workload Type',
@@ -63,38 +65,38 @@ local template = grafana.template;
           (sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload_type="$type"}) by (workload))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
       ];
 
       local networkTableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
           linkTooltip: 'Drill down to pods',
         },
         workload_type: {
@@ -132,7 +134,7 @@ local template = grafana.template;
         * on(namespace,pod)
           group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}
         ) by (workload, workload_type)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
 
       local cpuRequestsQuery = |||
         sum(
@@ -140,9 +142,9 @@ local template = grafana.template;
         * on(namespace,pod)
           group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}
         ) by (workload, workload_type)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
 
-      local podCountQuery = 'count(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}) by (workload, workload_type)' % $._config;
+      local podCountQuery = 'count(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}) by (workload, workload_type)' % kubernetesMixin._config;
       local cpuLimitsQuery = std.strReplace(cpuRequestsQuery, 'requests', 'limits');
 
       local memUsageQuery = |||
@@ -151,18 +153,18 @@ local template = grafana.template;
           * on(namespace,pod)
             group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}
         ) by (workload, workload_type)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
       local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
       local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
 
-      local cpuQuotaRequestsQuery = 'scalar(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource="requests.cpu"})' % $._config;
+      local cpuQuotaRequestsQuery = 'scalar(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource="requests.cpu"})' % kubernetesMixin._config;
       local cpuQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'limits.cpu');
       local memoryQuotaRequestsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'requests.memory');
       local memoryQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'limits.memory');
 
       g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
+        '%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
       )
       .addRow(
         g.row('CPU Usage')
@@ -282,7 +284,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          { interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -293,7 +295,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -303,7 +305,7 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -316,7 +318,7 @@ local template = grafana.template;
             (avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -326,7 +328,7 @@ local template = grafana.template;
             (avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -339,7 +341,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -349,7 +351,7 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -362,7 +364,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -372,11 +374,11 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~".+", workload_type="$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
+          ||| % kubernetesMixin._config, '{{workload}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, typeTemplate, namespaceTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + { tags: kubernetesMixin._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, typeTemplate, namespaceTemplate] }, refresh: kubernetesMixin._config.grafanaK8s.refresh },
 
   },
 }

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -3,14 +3,16 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 local template = grafana.template;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     local clusterTemplate =
       template.new(
         name='cluster',
         datasource='$datasource',
-        query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info, %s)' % kubernetesMixin._config.clusterLabel,
         current='',
-        hide=if $._config.showMultiCluster then '' else '2',
+        hide=if kubernetesMixin._config.showMultiCluster then '' else '2',
         refresh=2,
         includeAll=false,
         sort=1
@@ -20,7 +22,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
+        query='label_values(kube_pod_info{%(clusterLabel)s="$cluster"}, namespace)' % kubernetesMixin._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -32,7 +34,7 @@ local template = grafana.template;
       template.new(
         name='workload',
         datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload)' % $._config.clusterLabel,
+        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload)' % kubernetesMixin._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -44,7 +46,7 @@ local template = grafana.template;
       template.new(
         name='type',
         datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload"}, workload_type)' % $._config.clusterLabel,
+        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload"}, workload_type)' % kubernetesMixin._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -55,7 +57,7 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 
@@ -64,38 +66,38 @@ local template = grafana.template;
           (sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
         |||
           (sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace"}[%(grafanaIntervalVar)s])
           * on (namespace,pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-        ||| % $._config,
+        ||| % kubernetesMixin._config,
       ];
 
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',
@@ -130,7 +132,7 @@ local template = grafana.template;
           * on(namespace,pod)
             group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type="$type"}
         ) by (pod)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
 
       local cpuRequestsQuery = |||
         sum(
@@ -138,7 +140,7 @@ local template = grafana.template;
           * on(namespace,pod)
             group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type="$type"}
         ) by (pod)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
 
       local cpuLimitsQuery = std.strReplace(cpuRequestsQuery, 'requests', 'limits');
 
@@ -148,13 +150,13 @@ local template = grafana.template;
           * on(namespace,pod)
             group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type="$type"}
         ) by (pod)
-      ||| % $._config;
+      ||| % kubernetesMixin._config;
       local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
       local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
 
       g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-workload.json']),
+        '%(dashboardNamePrefix)sCompute Resources / Workload' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-workload.json']),
       )
       .addRow(
         g.row('CPU Usage')
@@ -219,7 +221,7 @@ local template = grafana.template;
             networkColumns,
             networkTableStyles
           ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          { interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval },
         )
       )
       .addRow(
@@ -230,7 +232,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -240,7 +242,7 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -253,7 +255,7 @@ local template = grafana.template;
             (avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -263,7 +265,7 @@ local template = grafana.template;
             (avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -276,7 +278,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -286,7 +288,7 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -299,7 +301,7 @@ local template = grafana.template;
             (sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -309,10 +311,10 @@ local template = grafana.template;
             (sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", namespace=~"$namespace"}[%(grafanaIntervalVar)s])
             * on (namespace,pod)
             group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s=~"$namespace", workload=~"$workload", workload_type="$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
+          ||| % kubernetesMixin._config, '{{pod}}') +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, workloadTemplate, workloadTypeTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + { tags: kubernetesMixin._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, workloadTemplate, workloadTypeTemplate] }, refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -7,6 +7,8 @@ local graphPanel = grafana.graphPanel;
 local singlestat = grafana.singlestat;
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'scheduler.json':
       local upCount =
@@ -16,7 +18,7 @@ local singlestat = grafana.singlestat;
           span=2,
           valueName='min',
         )
-        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s})' % $._config));
+        .addTarget(prometheus.target('sum(up{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s})' % kubernetesMixin._config));
 
       local schedulingRate =
         graphPanel.new(
@@ -31,10 +33,10 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('sum(rate(scheduler_e2e_scheduling_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} e2e' % $._config))
-        .addTarget(prometheus.target('sum(rate(scheduler_binding_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} binding' % $._config))
-        .addTarget(prometheus.target('sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} scheduling algorithm' % $._config))
-        .addTarget(prometheus.target('sum(rate(scheduler_volume_scheduling_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} volume' % $._config));
+        .addTarget(prometheus.target('sum(rate(scheduler_e2e_scheduling_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} e2e' % kubernetesMixin._config))
+        .addTarget(prometheus.target('sum(rate(scheduler_binding_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} binding' % kubernetesMixin._config))
+        .addTarget(prometheus.target('sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} scheduling algorithm' % kubernetesMixin._config))
+        .addTarget(prometheus.target('sum(rate(scheduler_volume_scheduling_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance)' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} volume' % kubernetesMixin._config));
 
 
       local schedulingLatency =
@@ -50,10 +52,10 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} e2e' % $._config))
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} binding' % $._config))
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} scheduling algorithm' % $._config))
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % $._config, legendFormat='{{%(clusterLabel)s}} {{instance}} volume' % $._config));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} e2e' % kubernetesMixin._config))
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} binding' % kubernetesMixin._config))
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} scheduling algorithm' % kubernetesMixin._config))
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[5m])) by (%(clusterLabel)s, instance, le))' % kubernetesMixin._config, legendFormat='{{%(clusterLabel)s}} {{instance}} volume' % kubernetesMixin._config));
 
       local rpcRate =
         graphPanel.new(
@@ -63,10 +65,10 @@ local singlestat = grafana.singlestat;
           format='ops',
           min=0,
         )
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % $._config, legendFormat='2xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % $._config, legendFormat='3xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % $._config, legendFormat='4xx'))
-        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % $._config, legendFormat='5xx'));
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"2.."}[5m]))' % kubernetesMixin._config, legendFormat='2xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"3.."}[5m]))' % kubernetesMixin._config, legendFormat='3xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"4.."}[5m]))' % kubernetesMixin._config, legendFormat='4xx'))
+        .addTarget(prometheus.target('sum(rate(rest_client_requests_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance",code=~"5.."}[5m]))' % kubernetesMixin._config, legendFormat='5xx'));
 
       local postRequestLatency =
         graphPanel.new(
@@ -76,7 +78,7 @@ local singlestat = grafana.singlestat;
           format='s',
           min=0,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance", verb="POST"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local getRequestLatency =
         graphPanel.new(
@@ -91,7 +93,7 @@ local singlestat = grafana.singlestat;
           legend_alignAsTable=true,
           legend_rightSide=true,
         )
-        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % $._config, legendFormat='{{verb}} {{url}}'));
+        .addTarget(prometheus.target('histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance", verb="GET"}[5m])) by (verb, url, le))' % kubernetesMixin._config, legendFormat='{{verb}} {{url}}'));
 
       local memory =
         graphPanel.new(
@@ -100,7 +102,7 @@ local singlestat = grafana.singlestat;
           span=4,
           format='bytes',
         )
-        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('process_resident_memory_bytes{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local cpu =
         graphPanel.new(
@@ -110,7 +112,7 @@ local singlestat = grafana.singlestat;
           format='bytes',
           min=0,
         )
-        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('rate(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[5m])' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
       local goroutines =
         graphPanel.new(
@@ -119,14 +121,14 @@ local singlestat = grafana.singlestat;
           span=4,
           format='short',
         )
-        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}' % $._config, legendFormat='{{instance}}'));
+        .addTarget(prometheus.target('go_goroutines{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}' % kubernetesMixin._config, legendFormat='{{instance}}'));
 
 
       dashboard.new(
-        '%(dashboardNamePrefix)sScheduler' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sScheduler' % kubernetesMixin._config.grafanaK8s,
         time_from='now-1h',
-        uid=($._config.grafanaDashboardIDs['scheduler.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['scheduler.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -147,10 +149,10 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(kube_pod_info, %(clusterLabel)s)' % kubernetesMixin._config,
           label='cluster',
           refresh='time',
-          hide=if $._config.showMultiCluster then '' else 'variable',
+          hide=if kubernetesMixin._config.showMultiCluster then '' else 'variable',
           sort=1,
         )
       )
@@ -158,7 +160,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s}, instance)' % $._config,
+          'label_values(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s}, instance)' % kubernetesMixin._config,
           refresh='time',
           includeAll=true,
           sort=1,
@@ -181,6 +183,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -10,19 +10,21 @@ local gauge = promgrafonnet.gauge;
 local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
 
 {
+  local kubernetesMixin = self,
+
   grafanaDashboards+:: {
     'k8s-resources-windows-cluster.json':
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-namespace.json') },
         },
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Cluster(Windows)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-windows-cluster.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        '%(dashboardNamePrefix)sCompute Resources / Cluster(Windows)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-windows-cluster.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -132,14 +134,14 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-pod.json') },
         },
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Namespace(Windows)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-windows-namespace.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        '%(dashboardNamePrefix)sCompute Resources / Namespace(Windows)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-windows-namespace.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -230,9 +232,9 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Pod(Windows)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-windows-pod.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        '%(dashboardNamePrefix)sCompute Resources / Pod(Windows)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-resources-windows-pod.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -337,23 +339,23 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
             legend_avg=true,
           )
           .addTarget(prometheus.target(
-            'sort_desc(sum by (container) (rate(windows_container_network_received_bytes_total{namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+            'sort_desc(sum by (container) (rate(windows_container_network_received_bytes_total{namespace="$namespace", pod="$pod"}[1m])))' % kubernetesMixin._config,
             legendFormat='Received : {{ container }}',
           ))
           .addTarget(prometheus.target(
-            'sort_desc(sum by (container) (rate(windows_container_network_transmitted_bytes_total{namespace="$namespace", pod="$pod"}[1m])))' % $._config,
+            'sort_desc(sum by (container) (rate(windows_container_network_transmitted_bytes_total{namespace="$namespace", pod="$pod"}[1m])))' % kubernetesMixin._config,
             legendFormat='Transmitted : {{ container }}',
           ))
         )
       ),
 
     'k8s-windows-cluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(uid)s/k8s-windows-node-rsrc-use' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-windows-node-rsrc-use.json') };
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-windows-node-rsrc-use' % { prefix: kubernetesMixin._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-windows-node-rsrc-use.json') };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sUSE Method / Cluster(Windows)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-windows-cluster-rsrc-use.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        '%(dashboardNamePrefix)sUSE Method / Cluster(Windows)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-windows-cluster-rsrc-use.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -427,7 +429,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
           g.queryPanel(
             |||
               sum by (instance)(node:windows_node_filesystem_usage:)
-            ||| % $._config, '{{instance}}', legendLink
+            ||| % kubernetesMixin._config, '{{instance}}', legendLink
           ) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
@@ -436,9 +438,9 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 
     'k8s-windows-node-rsrc-use.json':
       dashboard.new(
-        '%(dashboardNamePrefix)sUSE Method / Node(Windows)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-windows-node-rsrc-use.json']),
-        tags=($._config.grafanaK8s.dashboardTags),
+        '%(dashboardNamePrefix)sUSE Method / Node(Windows)' % kubernetesMixin._config.grafanaK8s,
+        uid=(kubernetesMixin._config.grafanaDashboardIDs['k8s-windows-node-rsrc-use.json']),
+        tags=(kubernetesMixin._config.grafanaK8s.dashboardTags),
       ).addTemplate(
         {
           current: {
@@ -474,7 +476,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         )
         .addPanel(
           g.panel('CPU Usage Per Core') +
-          g.queryPanel('sum by (core) (irate(windows_cpu_time_total{%(wmiExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, '{{core}}') +
+          g.queryPanel('sum by (core) (irate(windows_cpu_time_total{%(wmiExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % kubernetesMixin._config, '{{core}}') +
           { yaxes: g.yaxes('percentunit') },
         )
       )
@@ -495,10 +497,10 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
                 windows_os_visible_memory_bytes{%(wmiExporterSelector)s, instance="$instance"}
                 - windows_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"}
               )
-            ||| % $._config, legendFormat='memory used'
+            ||| % kubernetesMixin._config, legendFormat='memory used'
           ))
-          .addTarget(prometheus.target('max(node:windows_node_memory_totalCached_bytes:sum{%(wmiExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory cached'))
-          .addTarget(prometheus.target('max(windows_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory free'))
+          .addTarget(prometheus.target('max(node:windows_node_memory_totalCached_bytes:sum{%(wmiExporterSelector)s, instance="$instance"})' % kubernetesMixin._config, legendFormat='memory cached'))
+          .addTarget(prometheus.target('max(windows_memory_available_bytes{%(wmiExporterSelector)s, instance="$instance"})' % kubernetesMixin._config, legendFormat='memory free'))
         )
         .addPanel(
           g.panel('Memory Saturation (Swap I/O) Pages') +
@@ -515,9 +517,9 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         )
         .addPanel(
           graphPanel.new('Disk I/O', datasource='$datasource')
-          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='read'))
-          .addTarget(prometheus.target('max(rate(windows_logical_disk_write_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='written'))
-          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]) + rate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]))' % $._config, legendFormat='io time')) +
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % kubernetesMixin._config, legendFormat='read'))
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_write_bytes_total{%(wmiExporterSelector)s, instance="$instance"}[2m]))' % kubernetesMixin._config, legendFormat='written'))
+          .addTarget(prometheus.target('max(rate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]) + rate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s,  instance="$instance"}[2m]))' % kubernetesMixin._config, legendFormat='io time')) +
           {
             seriesOverrides: [
               {
@@ -556,11 +558,11 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
           g.queryPanel(
             |||
               node:windows_node_filesystem_usage:{instance="$instance"}
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             '{{volume}}',
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ) + { refresh: kubernetesMixin._config.grafanaK8s.refresh },
   },
 }

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     cadvisorSelector: 'job="cadvisor"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
@@ -20,7 +22,7 @@
               ) * on (%(clusterLabel)s, namespace, pod) group_left(node) topk by (%(clusterLabel)s, namespace, pod) (
                 1, max by(%(clusterLabel)s, namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node_namespace_pod_container:container_memory_working_set_bytes',
@@ -29,7 +31,7 @@
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node_namespace_pod_container:container_memory_rss',
@@ -38,7 +40,7 @@
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node_namespace_pod_container:container_memory_cache',
@@ -47,7 +49,7 @@
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node_namespace_pod_container:container_memory_swap',
@@ -56,7 +58,7 @@
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'namespace_memory:kube_pod_container_resource_requests:sum',
@@ -70,7 +72,7 @@
                       )
                   )
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'namespace_cpu:kube_pod_container_resource_requests:sum',
@@ -84,7 +86,7 @@
                       )
                   )
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           // workload aggregation for deployments
           {
@@ -103,7 +105,7 @@
                   "workload", "$1", "owner_name", "(.*)"
                 )
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               workload_type: 'deployment',
             },
@@ -117,7 +119,7 @@
                   "workload", "$1", "owner_name", "(.*)"
                 )
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               workload_type: 'daemonset',
             },
@@ -131,7 +133,7 @@
                   "workload", "$1", "owner_name", "(.*)"
                 )
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
             labels: {
               workload_type: 'statefulset',
             },

--- a/rules/kube_scheduler.libsonnet
+++ b/rules/kube_scheduler.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeSchedulerSelector: 'job="kube-scheduler"',
     podLabel: 'pod',
@@ -13,7 +15,7 @@
             record: 'cluster_quantile:%s:histogram_quantile' % metric,
             expr: |||
               histogram_quantile(%(quantile)s, sum(rate(%(metric)s_bucket{%(kubeSchedulerSelector)s}[5m])) without(instance, %(podLabel)s))
-            ||| % ({ quantile: quantile, metric: metric } + $._config),
+            ||| % ({ quantile: quantile, metric: metric } + kubernetesMixin._config),
             labels: {
               quantile: quantile,
             },

--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeletSelector: 'job="kubelet"',
   },
@@ -12,7 +14,7 @@
             record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile',
             expr: |||
               histogram_quantile(%(quantile)s, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s})
-            ||| % ({ quantile: quantile } + $._config),
+            ||| % ({ quantile: quantile } + kubernetesMixin._config),
             labels: {
               quantile: quantile,
             },

--- a/rules/node.libsonnet
+++ b/rules/node.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   _config+:: {
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
     nodeExporterSelector: 'job="node-exporter"',
@@ -24,7 +26,7 @@
                 max by (node, namespace, %(podLabel)s) (
                   label_replace(kube_pod_info{%(kubeStateMetricsSelector)s,node!=""}, "%(podLabel)s", "$1", "pod", "(.*)")
               ))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // This rule gives the number of CPUs per node.
@@ -35,7 +37,7 @@
               * on (namespace, %(podLabel)s) group_left(node)
                 topk by(namespace, %(podLabel)s) (1, node_namespace_pod:kube_pod_info:)
               ))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           // Add separate rules for Available memory, so we can aggregate across clusters in dashboards.
           {
@@ -50,7 +52,7 @@
                   node_memory_Slab_bytes{%(nodeExporterSelector)s}
                 )
               ) by (%(clusterLabel)s)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
         ],
       },

--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -1,4 +1,6 @@
 {
+  local kubernetesMixin = self,
+
   prometheusRules+:: {
     groups+: [
       {
@@ -11,7 +13,7 @@
               count (
                 windows_system_system_up_time{%(wmiExporterSelector)s}
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // This rule gives the number of CPUs per node.
@@ -20,14 +22,14 @@
               count by (instance) (sum by (instance, core) (
                 windows_cpu_time_total{%(wmiExporterSelector)s}
               ))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // CPU utilisation is % CPU is not idle.
             record: ':windows_node_cpu_utilisation:avg1m',
             expr: |||
               1 - avg(rate(windows_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m]))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // CPU utilisation is % CPU is not idle.
@@ -36,7 +38,7 @@
               1 - avg by (instance) (
                 rate(windows_cpu_time_total{%(wmiExporterSelector)s,mode="idle"}[1m])
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: ':windows_node_memory_utilisation:',
@@ -45,7 +47,7 @@
               sum(windows_memory_available_bytes{%(wmiExporterSelector)s})
               /
               sum(windows_os_visible_memory_bytes{%(wmiExporterSelector)s})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           // Add separate rules for Free & Total, so we can aggregate across clusters
           // in dashboards.
@@ -53,19 +55,19 @@
             record: ':windows_node_memory_MemFreeCached_bytes:sum',
             expr: |||
               sum(windows_memory_available_bytes{%(wmiExporterSelector)s} + windows_memory_cache_bytes{%(wmiExporterSelector)s})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_memory_totalCached_bytes:sum',
             expr: |||
               (windows_memory_cache_bytes{%(wmiExporterSelector)s} + windows_memory_modified_page_list_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_core_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_normal_priority_bytes{%(wmiExporterSelector)s} + windows_memory_standby_cache_reserve_bytes{%(wmiExporterSelector)s})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: ':windows_node_memory_MemTotal_bytes:sum',
             expr: |||
               sum(windows_os_visible_memory_bytes{%(wmiExporterSelector)s})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // Available memory per node
@@ -75,7 +77,7 @@
               sum by (instance) (
                 (windows_memory_available_bytes{%(wmiExporterSelector)s})
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // Total memory per node
@@ -84,7 +86,7 @@
               sum by (instance) (
                 windows_os_visible_memory_bytes{%(wmiExporterSelector)s}
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // Memory utilisation per node, normalized by per-node memory
@@ -99,13 +101,13 @@
             record: 'node:windows_node_memory_utilisation:',
             expr: |||
               1 - (node:windows_node_memory_bytes_available:sum / node:windows_node_memory_bytes_total:sum)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_memory_swap_io_pages:irate',
             expr: |||
               irate(windows_memory_swap_page_operations_total{%(wmiExporterSelector)s}[5m])
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // Disk utilisation (ms spent, by rate() it's bound by 1 second)
@@ -114,7 +116,7 @@
               avg(irate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) + 
                   irate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m])
                 )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             // Disk utilisation (ms spent, by rate() it's bound by 1 second)
@@ -124,7 +126,7 @@
                 (irate(windows_logical_disk_read_seconds_total{%(wmiExporterSelector)s}[1m]) +
                  irate(windows_logical_disk_write_seconds_total{%(wmiExporterSelector)s}[1m]))
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_filesystem_usage:',
@@ -134,19 +136,19 @@
               - windows_logical_disk_free_bytes{%(wmiExporterSelector)s})
               / windows_logical_disk_size_bytes{%(wmiExporterSelector)s}
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_filesystem_avail:',
             expr: |||
               max by (instance, volume) (windows_logical_disk_free_bytes{%(wmiExporterSelector)s} / windows_logical_disk_size_bytes{%(wmiExporterSelector)s})
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: ':windows_node_net_utilisation:sum_irate',
             expr: |||
               sum(irate(windows_net_bytes_total{%(wmiExporterSelector)s}[1m]))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_net_utilisation:sum_irate',
@@ -154,14 +156,14 @@
               sum by (instance) (
                 (irate(windows_net_bytes_total{%(wmiExporterSelector)s}[1m]))
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: ':windows_node_net_saturation:sum_irate',
             expr: |||
               sum(irate(windows_net_packets_received_discarded_total{%(wmiExporterSelector)s}[1m])) +
               sum(irate(windows_net_packets_outbound_discarded_total{%(wmiExporterSelector)s}[1m]))
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'node:windows_node_net_saturation:sum_irate',
@@ -170,7 +172,7 @@
                 (irate(windows_net_packets_received_discarded_total{%(wmiExporterSelector)s}[1m]) +
                 irate(windows_net_packets_outbound_discarded_total{%(wmiExporterSelector)s}[1m]))
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
         ],
       },
@@ -181,37 +183,37 @@
             record: 'windows_pod_container_available',
             expr: |||
               windows_container_available{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'windows_container_total_runtime',
             expr: |||
               windows_container_cpu_usage_seconds_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'windows_container_memory_usage',
             expr: |||
               windows_container_memory_usage_commit_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'windows_container_private_working_set_usage',
             expr: |||
               windows_container_memory_usage_private_working_set_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'windows_container_network_received_bytes_total',
             expr: |||
               windows_container_network_receive_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'windows_container_network_transmitted_bytes_total',
             expr: |||
               windows_container_network_transmit_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'kube_pod_windows_container_resource_memory_request',
@@ -219,13 +221,13 @@
               max by (namespace, pod, container) (
                 kube_pod_container_resource_requests{resource="memory",%(kubeStateMetricsSelector)s}
               ) * on(container,pod,namespace) (windows_pod_container_available)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'kube_pod_windows_container_resource_memory_limit',
             expr: |||
               kube_pod_container_resource_limits{resource="memory",%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'kube_pod_windows_container_resource_cpu_cores_request',
@@ -233,13 +235,13 @@
               max by (namespace, pod, container) (
                 kube_pod_container_resource_requests{resource="cpu",%(kubeStateMetricsSelector)s}
               ) * on(container,pod,namespace) (windows_pod_container_available)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'kube_pod_windows_container_resource_cpu_cores_limit',
             expr: |||
               kube_pod_container_resource_limits{resource="cpu",%(kubeStateMetricsSelector)s} * on(container,pod,namespace) (windows_pod_container_available)
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
           {
             record: 'namespace_pod_container:windows_container_cpu_usage_seconds_total:sum_rate',
@@ -247,7 +249,7 @@
               sum by (namespace, pod, container) (
                 rate(windows_container_total_runtime{}[5m])
               )
-            ||| % $._config,
+            ||| % kubernetesMixin._config,
           },
         ],
       },


### PR DESCRIPTION
This should not change any functional aspect of the Kubernetes Mixin, so
it should not have an effect on users, but it has a readability effect
and causes us to keep configuration and their use closer, which makes
the code easier to understand when reading it, as we're using local
references as opposed to seemingly random global accesses.

@metalmatze @paulfantom @povilasv @csmarchbanks 