### PR TITLE
Allow to disable alerts/dashboards via config

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -6,7 +6,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.apps_enabled then 'groups']+: [
       {
         name: 'kubernetes-apps',
         rules: [

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -11,7 +11,7 @@ local utils = import 'utils.libsonnet';
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.kube_apiserver_enabled then 'groups']+: [
       {
         name: 'kube-apiserver-slos',
         rules: [

--- a/alerts/kube_controller_manager.libsonnet
+++ b/alerts/kube_controller_manager.libsonnet
@@ -4,7 +4,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.kube_controller_manager_enabled then 'groups']+: [
       {
         name: 'kubernetes-system-controller-manager',
         rules: [

--- a/alerts/kube_scheduler.libsonnet
+++ b/alerts/kube_scheduler.libsonnet
@@ -4,7 +4,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.kube_scheduler_enabled then 'groups']+: [
       {
         name: 'kubernetes-system-scheduler',
         rules: [

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -13,7 +13,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.kubelet_enabled then 'groups']+: [
       {
         name: 'kubernetes-system-kubelet',
         rules: [

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -18,7 +18,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.resource_enabled then 'groups']+: [
       {
         name: 'kubernetes-resources',
         rules: [

--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -12,7 +12,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.storage_enabled then 'groups']+: [
       {
         name: 'kubernetes-storage',
         rules: [

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -4,7 +4,7 @@
   },
 
   prometheusAlerts+:: {
-    groups+: [
+    [if $._config.alerts.system_enabled then 'groups']+: [
       {
         name: 'kubernetes-system',
         rules: [

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -17,6 +17,28 @@
       },
     },
 
+    dashboards: {
+      network_enabled: true,
+      persistentvolumesusage_enabled: true,
+      resources_enabled: true,
+      apiserver_enabled: true,
+      controller_manager_enabled: true,
+      scheduler_enabled: true,
+      proxy_enabled: true,
+      kubelet_enabled: true,
+    },
+
+    alerts: {
+      apps_enabled: true,
+      resource_enabled: true,
+      storage_enabled: true,
+      system_enabled: true,
+      kube_apiserver_enabled: true,
+      kubelet_enabled: true,
+      kube_scheduler_enabled: true,
+      kube_controller_manager_enabled: true,
+    },
+
     // Selectors are inserted between {} in Prometheus queries.
     cadvisorSelector: 'job="cadvisor"',
     kubeletSelector: 'job="kubelet"',

--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -12,7 +12,7 @@ local singlestat = grafana.singlestat;
   },
 
   grafanaDashboards+:: {
-    'apiserver.json':
+    [if $._config.dashboards.apiserver_enabled then 'apiserver.json']:
       local availability1d =
         singlestat.new(
           'Availability (%dd) > %.3f%%' % [$._config.SLOs.apiserver.days, 100 * $._config.SLOs.apiserver.target],

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -8,7 +8,7 @@ local singlestat = grafana.singlestat;
 
 {
   grafanaDashboards+:: {
-    'controller-manager.json':
+    [if $._config.dashboards.controller_manager_enabled then 'controller-manager.json']:
       local upCount =
         singlestat.new(
           'Up',

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -9,7 +9,7 @@ local statPanel = grafana.statPanel;
 
 {
   grafanaDashboards+:: {
-    'kubelet.json':
+    [if $._config.dashboards.kubelet_enabled then 'kubelet.json']:
       local upCount =
         statPanel.new(
           'Running Kubelets',

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -11,7 +11,7 @@ local singlestat = grafana.singlestat;
 {
   grafanaDashboards+:: {
 
-    'cluster-total.json':
+    [if $._config.dashboards.network_enabled then 'cluster-total.json']:
 
       local newStyle(
         alias,

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -11,7 +11,7 @@ local singlestat = grafana.singlestat;
 {
   grafanaDashboards+:: {
 
-    'namespace-by-pod.json':
+    [if $._config.dashboards.network_enabled then 'namespace-by-pod.json']:
 
       local newStyle(
         alias,

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -11,7 +11,7 @@ local singlestat = grafana.singlestat;
 {
   grafanaDashboards+:: {
 
-    'namespace-by-workload.json':
+    [if $._config.dashboards.network_enabled then 'namespace-by-workload.json']:
 
       local newStyle(
         alias,

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -10,7 +10,7 @@ local singlestat = grafana.singlestat;
 {
   grafanaDashboards+:: {
 
-    'pod-total.json':
+    [if $._config.dashboards.network_enabled then 'pod-total.json']:
 
       local newGaugePanel(gaugeTitle, gaugeQuery) =
         local target =

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -10,7 +10,7 @@ local singlestat = grafana.singlestat;
 {
   grafanaDashboards+:: {
 
-    'workload-total.json':
+    [if $._config.dashboards.network_enabled then 'workload-total.json']:
 
       local newBarplotPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
         local target =

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -10,7 +10,7 @@ local gauge = promgrafonnet.gauge;
 
 {
   grafanaDashboards+:: {
-    'persistentvolumesusage.json':
+    [if $._config.dashboards.persistentvolumesusage_enabled then 'persistentvolumesusage.json']:
       local sizeGraph = graphPanel.new(
         'Volume Space Usage',
         datasource='$datasource',

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -8,7 +8,7 @@ local singlestat = grafana.singlestat;
 
 {
   grafanaDashboards+:: {
-    'proxy.json':
+    [if $._config.dashboards.proxy_enabled then 'proxy.json']:
       local upCount =
         singlestat.new(
           'Up',

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -16,7 +16,7 @@ local template = grafana.template;
         sort=1
       ),
 
-    'k8s-resources-cluster.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-cluster.json']:
       local tableStyles = {
         namespace: {
           alias: 'Namespace',

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -5,7 +5,7 @@ local template = grafana.template;
 {
   grafanaDashboards+::
     if $._config.showMultiCluster then {
-      'k8s-resources-multicluster.json':
+      [if $._config.dashboards.resources_enabled then 'k8s-resources-multicluster.json']:
         local tableStyles = {
           [$._config.clusterLabel]: {
             alias: 'Cluster',

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -27,7 +27,7 @@ local template = grafana.template;
         includeAll=false,
         sort=1
       ),
-    'k8s-resources-namespace.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-namespace.json']:
       local tableStyles = {
         pod: {
           alias: 'Pod',

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -29,7 +29,7 @@ local template = grafana.template;
         sort=1
       ),
 
-    'k8s-resources-node.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-node.json']:
       local tableStyles = {
         pod: {
           alias: 'Pod',

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -40,7 +40,7 @@ local template = grafana.template;
         sort=1
       ),
 
-    'k8s-resources-pod.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-pod.json']:
       local tableStyles = {
         container: {
           alias: 'Container',
@@ -301,13 +301,13 @@ local template = grafana.template;
         g.row('Storage IO - Distribution(Pod - Read & Writes)')
         .addPanel(
           g.panel('IOPS') +
-          g.queryPanel(['ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config, 'ceil(sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config,], ['Reads','Writes']) +
+          g.queryPanel(['ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config, 'ceil(sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config], ['Reads', 'Writes']) +
           g.stack +
           { yaxes: g.yaxes('short'), decimals: -1 },
         )
         .addPanel(
           g.panel('ThroughPut') +
-          g.queryPanel(['sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config, 'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config,], ['Reads','Writes']) +
+          g.queryPanel(['sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config, 'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config], ['Reads', 'Writes']) +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -47,7 +47,7 @@ local template = grafana.template;
         sort=1
       ),
 
-    'k8s-resources-workloads-namespace.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-workloads-namespace.json']:
       local tableStyles = {
         workload: {
           alias: 'Workload',

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -51,7 +51,7 @@ local template = grafana.template;
         includeAll=false,
         sort=1
       ),
-    'k8s-resources-workload.json':
+    [if $._config.dashboards.resources_enabled then 'k8s-resources-workload.json']:
       local tableStyles = {
         pod: {
           alias: 'Pod',

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -8,7 +8,7 @@ local singlestat = grafana.singlestat;
 
 {
   grafanaDashboards+:: {
-    'scheduler.json':
+    [if $._config.dashboards.scheduler_enabled then 'scheduler.json']:
       local upCount =
         singlestat.new(
           'Up',


### PR DESCRIPTION
With this PR it is now possible to disable unnecessary dashboards/alerts.
for example in managed Kubernetes the controller-manager, scheduler and proxy are usually not available.

so they can be turned off like this:
```
    dashboards: {
      network_enabled: true,
      persistentvolumesusage_enabled: true,
      resources_enabled: true,
      apiserver_enabled: true,
      controller_manager_enabled: fasle,
      scheduler_enabled: false,
      proxy_enabled: false,
      kubelet_enabled: true,
    },

    alerts: {
      apps_enabled: true,
      resource_enabled: true,
      storage_enabled: true,
      system_enabled: true,
      kube_apiserver_enabled: true,
      kubelet_enabled: true,
      kube_scheduler_enabled: false,
      kube_controller_manager_enabled: false,
    },
 ```