### PR TITLE
Reduce size of apiserver rule groups

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -237,24 +237,10 @@
           {
             record: 'code_verb:apiserver_request_total:increase1h',
             expr: |||
-              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb="%s",code=~"%s"}[1h]))
-            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, verb, code],
+              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
+            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, code],
           }
           for code in ['2..', '3..', '4..', '5..']
-          for verb in ['LIST', 'GET']
-        ],
-      },
-      {
-        name: 'kube-apiserver-request.rules',
-        rules: [
-          {
-            record: 'code_verb:apiserver_request_total:increase1h',
-            expr: |||
-              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb="%s",code=~"%s"}[1h]))
-            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, verb, code],
-          }
-          for code in ['2..', '3..', '4..', '5..']
-          for verb in ['POST', 'PUT', 'PATCH', 'DELETE']
         ],
       },
     ],


### PR DESCRIPTION
This PR reduces the size of some rule groups (specifically the [apiserver rule groups](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/rules/kube_apiserver.libsonnet)), taking advantage of parallel execution of rule groups (with sequential execution within a group).

Also, in the `kube-apiserver-availability` group, the `apiserver_request:availability30d` rules reference the `code:apiserver_request_total:increase30d` metrics which are defined later in the group. If I understand correctly, since rules within a group are evaluated sequentially, the dependency rules should be defined first. This PR also fixes this.

The net change is a no-op with respect to recording rule metrics, and simply reorganizes the existing defined rules into smaller groups. I tried to keep the eval intervals for most rules the same, and tried to keep groups to around ~15 rules. I tested on a 3-node K8s cluster (with no running workloads beyond Helm/kube-prom stack), and noticed the following improvements:

**Before:**
`kube-apiserver-availability.rules`
30 rules
`3m` eval interval
~5s group eval time

`kube-apiserver.rules`
21 rules
`1m` eval interval
~3.5s group eval time

**After:**
`kube-apiserver-burnrate.rules`
14 rules
`1m` eval
~145 ms

`kube-apiserver-histogram.rules`
5 rules
`1m` eval
~675ms

`kube-apiserver-availability.rules`
12 rules
`3m` eval
~25ms

In terms of load on Prometheus I noticed no significant difference (in fact CPU usage dropped from 0.5 to 0.25 but pretty meaningless given the workload), and a slight, barely noticeable decrease in memory pressure.

This also allows for better parallelization of rule group execution in horizontally scalable envs like Cortex.

Also happy to sync these changes into kube-prometheus and Helm/kube-prometheus!