### PR TITLE
Improve alert aggregations for multiple clusters

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -30,11 +30,11 @@
             // label exists for 2 values. This avoids "many-to-many matching
             // not allowed" errors when joining with kube_pod_status_phase.
             expr: |||
-              sum by (namespace, pod) (
-                max by(namespace, pod) (
+              sum by (namespace, pod, %(clusterGroupLabelsStr)s) (
+                max by(namespace, pod, %(clusterGroupLabelsStr)s) (
                   kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}
-                ) * on(namespace, pod) group_left(owner_kind) topk by(namespace, pod) (
-                  1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})
+                ) * on(namespace, pod, %(clusterGroupLabelsStr)s) group_left(owner_kind) topk by(namespace, pod, %(clusterGroupLabelsStr)s) (
+                  1, max by(namespace, pod, owner_kind, %(clusterGroupLabelsStr)s) (kube_pod_owner{owner_kind!="Job"})
                 )
               ) > 0
             ||| % $._config,
@@ -192,7 +192,7 @@
           },
           {
             expr: |||
-              sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
+              sum by (namespace, pod, container, %(clusterGroupLabelsStr)s) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -25,9 +25,16 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+              sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (%(clusterGroupLabelsStr)s)
+              - (
+                sum(kube_node_status_allocatable{resource="cpu"}) by (%(clusterGroupLabelsStr)s)
+                - max(kube_node_status_allocatable{resource="cpu"}) by (%(clusterGroupLabelsStr)s)
+              ) > 0
               and
-              (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+              (
+                sum(kube_node_status_allocatable{resource="cpu"}) by (%(clusterGroupLabelsStr)s)
+                - max(kube_node_status_allocatable{resource="cpu"}) by (%(clusterGroupLabelsStr)s)
+              ) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -41,9 +48,16 @@
           {
             alert: 'KubeMemoryOvercommit',
             expr: |||
-              sum(namespace_memory:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+              sum(namespace_memory:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) by (%(clusterGroupLabelsStr)s)
+              - (
+                sum(kube_node_status_allocatable{resource="memory"}) by (%(clusterGroupLabelsStr)s)
+                - max(kube_node_status_allocatable{resource="memory"}) by (%(clusterGroupLabelsStr)s)
+              ) > 0
               and
-              (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+              (
+                sum(kube_node_status_allocatable{resource="memory"}) by (%(clusterGroupLabelsStr)s)
+                 - max(kube_node_status_allocatable{resource="memory"}) by (%(clusterGroupLabelsStr)s)
+              ) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -57,9 +71,9 @@
           {
             alert: 'KubeCPUQuotaOvercommit',
             expr: |||
-              sum(min without(resource) (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource=~"(cpu|requests.cpu)"}))
+              sum(min without(resource) (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource=~"(cpu|requests.cpu)"})) by (%(clusterGroupLabelsStr)s)
                 /
-              sum(kube_node_status_allocatable{resource="cpu", %(kubeStateMetricsSelector)s})
+              sum(kube_node_status_allocatable{resource="cpu", %(kubeStateMetricsSelector)s}) by (%(clusterGroupLabelsStr)s)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -74,9 +88,9 @@
           {
             alert: 'KubeMemoryQuotaOvercommit',
             expr: |||
-              sum(min without(resource) (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource=~"(memory|requests.memory)"}))
+              sum(min without(resource) (kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource=~"(memory|requests.memory)"})) by (%(clusterGroupLabelsStr)s)
                 /
-              sum(kube_node_status_allocatable{resource="memory", %(kubeStateMetricsSelector)s})
+              sum(kube_node_status_allocatable{resource="memory", %(kubeStateMetricsSelector)s}) by (%(clusterGroupLabelsStr)s)
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {
@@ -142,9 +156,9 @@
           {
             alert: 'CPUThrottlingHigh',
             expr: |||
-              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)
+              sum(increase(container_cpu_cfs_throttled_periods_total{container!="", %(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, %(clusterGroupLabelsStr)s)
                 /
-              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace)
+              sum(increase(container_cpu_cfs_periods_total{%(cpuThrottlingSelector)s}[5m])) by (container, pod, namespace, %(clusterGroupLabelsStr)s)
                 > ( %(cpuThrottlingPercent)s / 100 )
             ||| % $._config,
             'for': '15m',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -11,7 +11,11 @@
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (git_version) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
+              count(
+                count by (git_version, %(clusterGroupLabelsStr)s) (
+                  label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*")
+                )
+              )  by (%(clusterGroupLabelsStr)s) > 1
             ||| % $._config,
             'for': '15m',
             labels: {
@@ -28,11 +32,11 @@
             // this is normal and an expected error, therefore it should be
             // ignored in this alert.
             expr: |||
-              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job, namespace)
+              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job, %(clusterGroupLabelsStr)s)
                 /
-              sum(rate(rest_client_requests_total[5m])) by (instance, job, namespace))
+              sum(rate(rest_client_requests_total[5m])) by (instance, job, %(clusterGroupLabelsStr)s))
               > 0.01
-            |||,
+            ||| % $._config,
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -82,6 +82,8 @@
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
     clusterLabel: 'cluster',
+    clusterGroupLabels: if self.showMultiCluster then [self.clusterLabel] else [],
+    clusterGroupLabelsStr: std.join(',', self.clusterGroupLabels),
 
     namespaceLabel: 'namespace',
 


### PR DESCRIPTION
Many of the alerts  are aggregating on metrics and throwing away the cluster label.

While this isn't the end of the world, pod names are probably going to be unique, but if you have many clusters trying to figure out which one `kube-proxy-4jlm2` is running on is a pain.

Because these labels are currently just hardcoded into strings its also difficult to override them in your own jsonnet.

This PR adds extra labels to aggregations.
Only if multi cluster is enabled and extensible.

For example in my environment I also inject a `dc` label with the AWS region for all metrics as well as the `cluster` label.
So in my config I can do

```jsonnet
_config+:: {
  showMultiCluster: true,
  clusterGroupLabels+: ['dc'],
}
```
and include that `dc` label in aggregations