### PR TITLE
fix: KubePersistentVolumeFillingUp - false alert fires for PVCs with volumeMode as block

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -19,10 +19,13 @@
           {
             alert: 'KubePersistentVolumeFillingUp',
             expr: |||
-              kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
-                /
-              kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
-                < 0.03
+              (
+                kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
+                  /
+                kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
+              ) < 0.03
+              and
+              kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
             ||| % $._config,
             'for': '1m',
             labels: {
@@ -41,6 +44,8 @@
                   /
                 kubelet_volume_stats_capacity_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}
               ) < 0.15
+              and
+              kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
               and
               predict_linear(kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}[%(volumeFullPredictionSampleTime)s], 4 * 24 * 3600) < 0
             ||| % $._config,

--- a/tests.yaml
+++ b/tests.yaml
@@ -11,6 +11,8 @@ tests:
     values: '1024 512 64 16'
   - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
     values: '1024 1024 1024 1024'
+  - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '16 64 512 1024'
   alert_rule_test:
   - eval_time: 1m
     alertname: KubePersistentVolumeFillingUp
@@ -31,12 +33,34 @@ tests:
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring is only 1.562% free.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
 
+# Block volume mounts can report 0 for the kubelet_volume_stats_used_bytes metric but it shouldn't trigger the KubePersistentVolumeFillingUp alert.
+# See https://github.com/kubernetes/kubernetes/commit/b997e0e4d6ccbead435a47d6ac75b0db3d17252f for details.
+- interval: 1m
+  input_series:
+  - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024 512 64 16'
+  - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024 1024 1024 1024'
+  - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '0 0 0 0'
+  alert_rule_test:
+  - eval_time: 1m
+    alertname: KubePersistentVolumeFillingUp
+  - eval_time: 2m
+    alertname: KubePersistentVolumeFillingUp
+  - eval_time: 3m
+    alertname: KubePersistentVolumeFillingUp
+  - eval_time: 4m
+    alertname: KubePersistentVolumeFillingUp
+
 - interval: 1m
   input_series:
   - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
     values: '1024-10x61'
   - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
     values: '32768+0x61'
+  - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024+10x61'
   alert_rule_test:
   - eval_time: 1h
     alertname: KubePersistentVolumeFillingUp
@@ -57,6 +81,8 @@ tests:
     values: '1024-10x61'
   - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
     values: '32768+0x61'
+  - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024+10x61'
   alert_rule_test:
   - eval_time: 61m
     alertname: KubePersistentVolumeFillingUp
@@ -79,6 +105,20 @@ tests:
         summary: "PersistentVolume is filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring is only 1.263% free.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+
+# Block volume mounts can report 0 for the kubelet_volume_stats_used_bytes metric but it shouldn't trigger the KubePersistentVolumeFillingUp alert.
+# See https://github.com/kubernetes/kubernetes/commit/b997e0e4d6ccbead435a47d6ac75b0db3d17252f for details.
+- interval: 1m
+  input_series:
+  - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '1024-10x61'
+  - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '32768+0x61'
+  - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+    values: '0x61'
+  alert_rule_test:
+  - eval_time: 61m
+    alertname: KubePersistentVolumeFillingUp
 
 - interval: 1m
   input_series:


### PR DESCRIPTION
After [1] kubelet metrics `kubelet_volume_stats_available_bytes` and `kubelet_volume_stats_used_bytes` are set to 0 for all block PVC mounts. This causes the `KubePersistentVolumeFillingUp` alert to be fired immediately.

Block volume mount stats can't really carry the `kubelet_volume_stats_used_bytes` because it is a raw storage device, not a file system. It is upto the workloads to deal with raw devices.

This PR fixes the alert expression by testing `kubelet_volume_stats_used_bytes > 0` which prevents alert for block volume mounts.

[1] https://github.com/kubernetes/kubernetes/commit/b997e0e4d6ccbead435a47d6ac75b0db3d17252f

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>