### PR TITLE
Improve KubePodCrashLooping and add unit test for it

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -14,7 +14,7 @@
             expr: |||
               increase(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) > 0
               and
-              sum without (phase) (kube_pod_status_phase{phase!="Running",%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} == 1)
+              kube_pod_container_status_waiting{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} == 1
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/tests.yaml
+++ b/tests.yaml
@@ -697,3 +697,28 @@ tests:
         summary: "The apiserver has terminated 33.33% of its incoming requests."
         description: "The apiserver has terminated 33.33% of its incoming requests."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
+
+- interval: 30s
+  input_series:
+  - series: 'kube_pod_container_status_restarts_total{namespace="test",pod="static-web",container="script",job="kube-state-metrics"}'
+    values: '0 1 2 3 4+0x3 5+0x6 6+0x12 7+0x12 8+0x33'
+  - series: 'kube_pod_container_status_waiting{namespace="test",pod="static-web",container="script",job="kube-state-metrics"}'
+    values: '1+0x38 0+0x32'
+  alert_rule_test:
+  - eval_time: 10m    # alert hasn't fired
+    alertname: KubePodCrashLooping
+  - eval_time: 16m   # alert fired
+    alertname: KubePodCrashLooping
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        container: "script"
+        job: "kube-state-metrics"
+        namespace: "test"
+        pod: "static-web"
+      exp_annotations:
+        description: "Pod test/static-web (script) is restarting 2.00 times / 10 minutes."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
+        summary: "Pod is crash looping."
+  - eval_time: 20m 
+    alertname: KubePodCrashLooping  # alert recovery


### PR DESCRIPTION
Crashlooping containers are in `waiting` phase, which we can use for the alert.

This is a follow-up to #617 which wasn't sufficiently tested and introduced a bug that rendered alert useless. (Thanks @adinhodovic for reporting!)

I also added here a test case for the alert.

Below is a screenshot of a query when a crash-looping container is present.
![Screenshot_20210705_100015](https://user-images.githubusercontent.com/3531758/124437880-d0de2c00-dd77-11eb-893a-b4569bc19d3c.png)
