### PR TITLE
fix empty query result issue cause by vector(0)

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -31,7 +31,7 @@
                     (
                       sum by (%(clusterLabel)s) (rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(window)s]))
                       or
-                      vector(0)
+                      (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0)
                     )
                     +
                     sum by (%(clusterLabel)s) (rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(window)s]))
@@ -143,7 +143,7 @@
                     (
                       sum by (%(clusterLabel)s) (increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(SLODays)s]))
                       or
-                      vector(0)
+                      (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0)
                     )
                     +
                     sum by (%(clusterLabel)s) (increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s]))
@@ -152,7 +152,7 @@
                   )
                 ) +
                 # errors
-                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{code=~"5.."} or vector(0))
+                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{code=~"5.."} or (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0))
               )
               /
               sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s)
@@ -172,7 +172,7 @@
                   (
                     sum by (%(clusterLabel)s) (increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope=~"resource|",le="0.1"}[%(SLODays)s]))
                     or
-                    vector(0)
+                    (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0)
                   )
                   +
                   sum by (%(clusterLabel)s) (increase(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,scope="namespace",le="0.5"}[%(SLODays)s]))
@@ -181,7 +181,7 @@
                 )
                 +
                 # errors
-                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="read",code=~"5.."} or vector(0))
+                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="read",code=~"5.."} or (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0))
               )
               /
               sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="read"})
@@ -202,7 +202,7 @@
                 )
                 +
                 # errors
-                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="write",code=~"5.."} or vector(0))
+                sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="write",code=~"5.."} or (min(apiserver_current_inflight_requests{%(kubeApiserverSelector)s}) by (%(clusterLabel)s) * 0))
               )
               /
               sum by (%(clusterLabel)s) (code:apiserver_request_total:increase%(SLODays)s{verb="write"})


### PR DESCRIPTION
`vector(0)` in some recording rule could cause a empty query result error. For example: 
```
      (
        (
          # too slow
          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
          -
          (
            (
              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d]))
              or
              vector(0)
            )
            +
            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1d]))
            +
            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1d]))
          )
        )
        +
        # errors
        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
      )
      /
      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
```

If `sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d]))` returns an empty query result, `sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d])) or vector(0)` will return `{} 0` which lost `cluster` tag and whole recoding rule returns a an empty query result.

The `vector(0)` should be replace by `(min(apiserver_current_inflight_requests{job="kube-apiserver"}) by (cluster) * 0)`. The difference is the second clause will return zero with `cluster` tags. 