### PR TITLE
Update depricated label hpa to horizontalpodautoscaler

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -284,7 +284,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the desired number of replicas for longer than 15 minutes.',
+              description: 'HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }} has not matched the desired number of replicas for longer than 15 minutes.',
               summary: 'HPA has not matched descired number of replicas.',
             },
             'for': '15m',
@@ -300,7 +300,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at max replicas for longer than 15 minutes.',
+              description: 'HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }} has been running at max replicas for longer than 15 minutes.',
               summary: 'HPA is running at max replicas',
             },
             'for': '15m',


### PR DESCRIPTION
label.hpa is depreicated and should now be label.horizontalpodautoscaler

From alerts in slack. Should be HPA Default/*NAME*... image
![image](https://user-images.githubusercontent.com/4808216/124491046-1d932880-ddb3-11eb-80ed-713aeed2e76b.png)
Labels from alertmanager

![image](https://user-images.githubusercontent.com/4808216/124491023-166c1a80-ddb3-11eb-8adf-ec5c4a8b8775.png)
