### PR TITLE
Add cluster to clause in k8s.rules

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -65,7 +65,7 @@
                   sum by (namespace, pod, cluster) (
                       max by (namespace, pod, container, cluster) (
                         kube_pod_container_resource_requests{resource="memory",%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )
@@ -79,7 +79,7 @@
                   sum by (namespace, pod, cluster) (
                       max by (namespace, pod, container, cluster) (
                         kube_pod_container_resource_requests{resource="cpu",%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )
@@ -93,7 +93,7 @@
                   sum by (namespace, pod, cluster) (
                       max by (namespace, pod, container, cluster) (
                         kube_pod_container_resource_limits{resource="memory",%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )
@@ -107,7 +107,7 @@
                   sum by (namespace, pod, cluster) (
                       max by (namespace, pod, container, cluster) (
                         kube_pod_container_resource_limits{resource="cpu",%(kubeStateMetricsSelector)s}
-                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                      ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                       )
                   )

--- a/tests.yaml
+++ b/tests.yaml
@@ -197,6 +197,51 @@ tests:
 
 - interval: 1m
   input_series:
+  - series: 'kube_pod_container_resource_requests{resource="cpu",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm",cluster="test"}'
+    values: '0.15+0x10'
+  - series: 'kube_pod_container_resource_requests{resource="cpu",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm",cluster="test"}'
+    values: '0.15+0x10'
+  - series: 'kube_pod_container_resource_requests{resource="cpu",container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm",cluster="test"}'
+    values: '0.1+0x10'
+  - series: 'kube_pod_container_resource_requests{resource="memory",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm",cluster="test"}'
+    values: '1E9+0x10'
+  - series: 'kube_pod_container_resource_requests{resource="memory",container="kube-apiserver-67",endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-2",service="ksm",cluster="test"}'
+    values: '1E9+0x10'
+  - series: 'kube_pod_container_resource_requests{resource="memory",container="kube-apiserver-67",endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",node="node-1",pod="pod-1",service="ksm",cluster="test"}'
+    values: '0.5E9+0x10'
+  # Duplicate kube_pod_status_phase timeseries for the same pod.
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",phase="Running",pod="pod-1",service="ksm",cluster="test"}'
+    values: '1 stale'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",phase="Pending",pod="pod-1",service="ksm",cluster="test"}'
+    values: '1+0x10'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="ksm-1",job="kube-state-metrics",namespace="kube-apiserver",phase="Completed",pod="pod-2",service="ksm",cluster="test"}'
+    values: '1+0x10'
+  - series: 'kube_pod_status_phase{endpoint="https-main",instance="ksm-2",job="kube-state-metrics",namespace="kube-apiserver",phase="Running",pod="pod-1",service="ksm",cluster="test"}'
+    values: '1+0x10'
+  promql_expr_test:
+  - eval_time: 0m
+    expr: namespace_cpu:kube_pod_container_resource_requests:sum
+    exp_samples:
+    - value: 0.15
+      labels: 'namespace_cpu:kube_pod_container_resource_requests:sum{namespace="kube-apiserver",cluster="test"}'
+  - eval_time: 0m
+    expr: namespace_memory:kube_pod_container_resource_requests:sum
+    exp_samples:
+    - value: 1.0e+9
+      labels: 'namespace_memory:kube_pod_container_resource_requests:sum{namespace="kube-apiserver",cluster="test"}'
+  - eval_time: 1m
+    expr: namespace_cpu:kube_pod_container_resource_requests:sum
+    exp_samples:
+    - value: 0.15
+      labels: 'namespace_cpu:kube_pod_container_resource_requests:sum{namespace="kube-apiserver",cluster="test"}'
+  - eval_time: 1m
+    expr: namespace_memory:kube_pod_container_resource_requests:sum
+    exp_samples:
+    - value: 1.0e+9
+      labels: 'namespace_memory:kube_pod_container_resource_requests:sum{namespace="kube-apiserver",cluster="test"}'
+
+- interval: 1m
+  input_series:
   # Create a histogram where all of the last 10 samples are in the +Inf (> 10 seconds) bucket.
   - series: 'kubelet_pleg_relist_duration_seconds_bucket{job="kublet", le="0.005", instance="10.0.2.15:10250"}'
     values: '1+0x10'


### PR DESCRIPTION
The recording rules for:

- namespace_memory:kube_pod_container_resource_requests:sum
- namespace_cpu:kube_pod_container_resource_requests:sum
- namespace_cpu:kube_pod_container_resource_requests:sum
- namespace_memory:kube_pod_container_resource_limits:sum

use cluster in the `sum by` section however `cluster` is not referenced in the final `max by` clause of the rule. This causes queries to return no data.

Updating these rules and queries ensures data is returned.

<details>
<summary> Query as is `namespace_cpu:kube_pod_container_resource_requests:sum`:</summary>

![CleanShot 2021-07-06 at 18 40 20](https://user-images.githubusercontent.com/4558793/124644237-f22f3d00-de89-11eb-9bf0-b79f92934073.png)

</details>

<details>
<summary> Query with extra `cluster` in `max by` `namespace_cpu:kube_pod_container_resource_requests:sum`:</summary>

![CleanShot 2021-07-06 at 18 40 38](https://user-images.githubusercontent.com/4558793/124644381-1a1ea080-de8a-11eb-8637-83c2d23773a6.png)

</details>