### PR TITLE
*: cleanup

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -6,4 +6,4 @@
 (import 'kubelet.libsonnet') +
 (import 'kube_scheduler.libsonnet') +
 (import 'kube_controller_manager.libsonnet') +
-(import 'add-runbook-links.libsonnet')
+(import '../lib/add-runbook-links.libsonnet')

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -1,4 +1,4 @@
-local utils = import 'utils.libsonnet';
+local utils = import '../lib/utils.libsonnet';
 
 {
   _config+:: {

--- a/alerts/utils.libsonnet
+++ b/alerts/utils.libsonnet
@@ -1,6 +1,0 @@
-{
-  humanizeSeconds(s)::
-    if s > 60 * 60 * 24
-    then '%.1f days' % (s / 60 / 60 / 24)
-    else '%.1f hours' % (s / 60 / 60),
-}

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -301,13 +301,13 @@ local template = grafana.template;
         g.row('Storage IO - Distribution(Pod - Read & Writes)')
         .addPanel(
           g.panel('IOPS') +
-          g.queryPanel(['ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config, 'ceil(sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config,], ['Reads','Writes']) +
+          g.queryPanel(['ceil(sum by(pod) (rate(container_fs_reads_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config, 'ceil(sum by(pod) (rate(container_fs_writes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m])))' % $._config], ['Reads', 'Writes']) +
           g.stack +
           { yaxes: g.yaxes('short'), decimals: -1 },
         )
         .addPanel(
           g.panel('ThroughPut') +
-          g.queryPanel(['sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config, 'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config,], ['Reads','Writes']) +
+          g.queryPanel(['sum by(pod) (rate(container_fs_reads_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config, 'sum by(pod) (rate(container_fs_writes_bytes_total{container!="", %(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[5m]))' % $._config], ['Reads', 'Writes']) +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )

--- a/lib/add-runbook-links.libsonnet
+++ b/lib/add-runbook-links.libsonnet
@@ -1,4 +1,4 @@
-local utils = import '../lib/utils.libsonnet';
+local utils = import 'utils.libsonnet';
 
 local lower(x) =
   local cp(c) = std.codepoint(c);

--- a/lib/utils.libsonnet
+++ b/lib/utils.libsonnet
@@ -10,4 +10,9 @@
       for group in super.groups
     ],
   },
+
+  humanizeSeconds(s)::
+    if s > 60 * 60 * 24
+    then '%.1f days' % (s / 60 / 60 / 24)
+    else '%.1f hours' % (s / 60 / 60),
 }


### PR DESCRIPTION
This should improve the discoverability and consumption of library files shipped with the project.

List of changes:
- consolidated both `utils.libsonnet` libraries into one
- moved `add-runbook-links.libsonnet` into `lib/` as it can be consumed independently of using mixin
- ran `jsonnetfmt`