### PR TITLE
alerts: fix CPU and Memory overcommit alerts

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -25,40 +25,34 @@
           {
             alert: 'KubeCPUOvercommit',
             expr: |||
-              sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s})
-                /
-              sum(kube_node_status_allocatable{resource="cpu"})
-                >
-              ((count(kube_node_status_allocatable{resource="cpu"}) > 1) - 1) / count(kube_node_status_allocatable{resource="cpu"})
+              sum(namespace_cpu:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+              and
+              (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',
             },
             annotations: {
-              description: 'Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.',
+              description: 'Cluster has overcommitted CPU resource requests for Pods by {{ $value }} CPU shares and cannot tolerate node failure.',
               summary: 'Cluster has overcommitted CPU resource requests.',
             },
-            'for': '5m',
+            'for': '10m',
           },
           {
             alert: 'KubeMemoryOvercommit',
             expr: |||
-              sum(namespace_memory:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s})
-                /
-              sum(kube_node_status_allocatable{resource="memory"})
-                >
-              ((count(kube_node_status_allocatable{resource="memory"}) > 1) - 1)
-                /
-              count(kube_node_status_allocatable{resource="memory"})
+              sum(namespace_memory:kube_pod_container_resource_requests:sum{%(ignoringOverprovisionedWorkloadSelector)s}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+              and
+              (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
             ||| % $._config,
             labels: {
               severity: 'warning',
             },
             annotations: {
-              description: 'Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.',
+              description: 'Cluster has overcommitted memory resource requests for Pods by {{ $value }} bytes and cannot tolerate node failure.',
               summary: 'Cluster has overcommitted memory resource requests.',
             },
-            'for': '5m',
+            'for': '10m',
           },
           {
             alert: 'KubeCPUQuotaOvercommit',


### PR DESCRIPTION
As pointed out in #589 we are comparing apples and oranges in KubeCPUOvercommit and KubeMemoryOvercommit alerts. In both cases, we have a percentage of resource requests to total allocatable resources on LHS, but we compare it with the percentage of available nodes. This approach may work in specific cases but is incorrect when non-homogeneous environments are used.

IMHO it would be better to use an alert expression like:
```
total requested resources > (total allocatable resources - total allocatable resources of the largest node)
```

This way we care only about the largest chunk of allocatable resource going away (node down) as clusters can tolerate failures of much smaller nodes.

That expression could be amended to include prevention for single-node clusters and reorganized to allow using a value in alert description to note how much resources will be lacking. Those improvements are included in PR code.