### PR TITLE
Use up metric for templating variables

### DIFF
--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -152,7 +152,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(up{%(kubeControllerManagerSelector)s}, %(clusterLabel)s)' % $._config,
           label='cluster',
           refresh='time',
           hide=if $._config.showMultiCluster then '' else 'variable',
@@ -163,7 +163,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'instance',
           '$datasource',
-          'label_values(process_cpu_seconds_total{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s}, instance)' % $._config,
+          'label_values(up{%(clusterLabel)s="$cluster", %(kubeControllerManagerSelector)s}, instance)' % $._config,
           refresh='time',
           includeAll=true,
           sort=1,

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -312,7 +312,7 @@ local statPanel = grafana.statPanel;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(up{%(kubeletSelector)s}, %(clusterLabel)s)' % $._config,
           label='cluster',
           refresh='time',
           hide=if $._config.showMultiCluster then '' else 'variable',

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -338,7 +338,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
           hide=if $._config.showMultiCluster then '' else '2',
           refresh=2
         );

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -231,7 +231,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
           hide=if $._config.showMultiCluster then '' else '2',
           refresh=2
         );

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -235,7 +235,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
           hide=if $._config.showMultiCluster then '' else '2',
           refresh=2
         );

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -110,7 +110,7 @@ local singlestat = grafana.singlestat;
         template.new(
           name='cluster',
           datasource='$datasource',
-          query='label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
           hide=if $._config.showMultiCluster then '' else '2',
           refresh=2
         );

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -8,7 +8,7 @@ local template = grafana.template;
       template.new(
         name='cluster',
         datasource='$datasource',
-        query='label_values(node_cpu_seconds_total, %s)' % $._config.clusterLabel,
+        query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
         current='',
         hide=if $._config.showMultiCluster then '' else '2',
         refresh=2,

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -147,7 +147,7 @@ local singlestat = grafana.singlestat;
         template.new(
           'cluster',
           '$datasource',
-          'label_values(kube_pod_info, %(clusterLabel)s)' % $._config,
+          'label_values(up{%(kubeSchedulerSelector)s}, %(clusterLabel)s)' % $._config,
           label='cluster',
           refresh='time',
           hide=if $._config.showMultiCluster then '' else 'variable',


### PR DESCRIPTION
Using 'up' for templating variables seems to be a better choice than these often expensive metrics with many dimensions.