### PR TITLE
alerts: Include namespace in grouping for KubeClientErrors

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -28,9 +28,9 @@
             // this is normal and an expected error, therefore it should be
             // ignored in this alert.
             expr: |||
-              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
+              (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job, namespace)
                 /
-              sum(rate(rest_client_requests_total[5m])) by (instance, job))
+              sum(rate(rest_client_requests_total[5m])) by (instance, job, namespace))
               > 0.01
             |||,
             'for': '15m',


### PR DESCRIPTION
The expression for the KubeClientErrors alert is already grouped by
instance and job labels.  This includes the namespace as well, as many
people find it useful to route alerts based on namespace.