### PR TITLE
fix(alerts): lower KubeletTooManyPods severity to info

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -62,7 +62,7 @@
             ||| % $._config,
             'for': '15m',
             labels: {
-              severity: 'warning',
+              severity: 'info',
             },
             annotations: {
               description: "Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.",

--- a/tests.yaml
+++ b/tests.yaml
@@ -144,7 +144,7 @@ tests:
     exp_alerts:
     - exp_labels:
         node: minikube
-        severity: warning
+        severity: info
       exp_annotations:
         summary: "Kubelet is running at capacity."
         description: "Kubelet 'minikube' is running at 100% of its Pod capacity."


### PR DESCRIPTION
Fixes #529

This is a noisy alerts when using nodes efficiently, lowering the severity as per
suggestion in #529.