### PR TITLE
Fix faild evaluations on windows, when a container_id is not already available

### DIFF
--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -180,37 +180,37 @@
           {
             record: 'windows_pod_container_available',
             expr: |||
-              windows_container_available{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_available{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_total_runtime',
             expr: |||
-              windows_container_cpu_usage_seconds_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_cpu_usage_seconds_total{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_memory_usage',
             expr: |||
-              windows_container_memory_usage_commit_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_commit_bytes{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_private_working_set_usage',
             expr: |||
-              windows_container_memory_usage_private_working_set_bytes{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_memory_usage_private_working_set_bytes{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_received_bytes_total',
             expr: |||
-              windows_container_network_receive_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_receive_bytes_total{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {
             record: 'windows_container_network_transmitted_bytes_total',
             expr: |||
-              windows_container_network_transmit_bytes_total{%(wmiExporterSelector)s} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s}) by(container, container_id, pod, namespace)
+              windows_container_network_transmit_bytes_total{%(wmiExporterSelector)s,container_id!=""} * on(container_id) group_left(container, pod, namespace) max(kube_pod_container_info{%(kubeStateMetricsSelector)s,container_id!=""}) by(container, container_id, pod, namespace)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
Fixes https://github.com/prometheus-operator/kube-prometheus/issues/1175

This seems to be the case when a container is in its early starting phase or the windows node is failing (due to overload for e.g.) and no container_id is available.