### PR TITLE
Parameterize datasource name value

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -85,6 +85,9 @@
 
     namespaceLabel: 'namespace',
 
+    // Default datasource name
+    datasourceName: 'default',
+
     // This list of filesystem is referenced in various expressions.
     fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
     fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),

--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -206,7 +206,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -136,7 +136,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -296,7 +296,7 @@ local statPanel = grafana.statPanel;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -362,7 +362,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -358,7 +358,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -387,7 +387,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -257,7 +257,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -271,7 +271,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -116,7 +116,7 @@ local gauge = promgrafonnet.gauge;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -143,7 +143,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -131,7 +131,7 @@ local singlestat = grafana.singlestat;
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -144,7 +144,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         {
           current: {
             text: 'default',
-            value: 'default',
+            value: $._config.datasourceName,
           },
           hide: 0,
           label: null,


### PR DESCRIPTION
This allows to set the name of the Prometheus datasource in cases where its name is not 'default'