### PR TITLE
alerts:KubePodCrashLooping: Adjust alert to avoid non firing when fla…

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -12,15 +12,13 @@
         rules: [
           {
             expr: |||
-              increase(kube_pod_container_status_restarts_total{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[10m]) > 0
-              and
-              kube_pod_container_status_waiting{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} == 1
+              max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", %(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m]) >= 1
             ||| % $._config,
             labels: {
               severity: 'warning',
             },
             annotations: {
-              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 10 minutes.',
+              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: "CrashLoopBackOff").',
               summary: 'Pod is crash looping.',
             },
             'for': '15m',

--- a/tests.yaml
+++ b/tests.yaml
@@ -783,12 +783,10 @@ tests:
         description: "The apiserver has terminated 33.33% of its incoming requests."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
 
-- interval: 30s
+- interval: 1m
   input_series:
-  - series: 'kube_pod_container_status_restarts_total{namespace="test",pod="static-web",container="script",job="kube-state-metrics"}'
-    values: '0 1 2 3 4+0x3 5+0x6 6+0x12 7+0x12 8+0x33'
-  - series: 'kube_pod_container_status_waiting{namespace="test",pod="static-web",container="script",job="kube-state-metrics"}'
-    values: '1+0x38 0+0x32'
+  - series: 'kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",namespace="test",pod="static-web",container="script",job="kube-state-metrics"}'
+    values: '1 1 stale _x3 1 1 stale _x2 1+0x4 stale'
   alert_rule_test:
   - eval_time: 10m    # alert hasn't fired
     alertname: KubePodCrashLooping
@@ -796,14 +794,29 @@ tests:
     alertname: KubePodCrashLooping
     exp_alerts:
     - exp_labels:
-        severity: warning
+        severity: "warning"
         container: "script"
         job: "kube-state-metrics"
         namespace: "test"
         pod: "static-web"
+        reason: "CrashLoopBackOff"
       exp_annotations:
-        description: "Pod test/static-web (script) is restarting 2.00 times / 10 minutes."
+        description: 'Pod test/static-web (script) is in waiting state (reason: "CrashLoopBackOff").'
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
         summary: "Pod is crash looping."
-  - eval_time: 20m 
-    alertname: KubePodCrashLooping  # alert recovery
+  - eval_time: 20m
+    alertname: KubePodCrashLooping   # alert fired for a period of 5 minutes after resolution because the alert looks back at the last 5 minutes of data and the range vector doesn't take stale samples into account 
+    exp_alerts:
+      - exp_labels:
+          severity: "warning"
+          container: "script"
+          job: "kube-state-metrics"
+          namespace: "test"
+          pod: "static-web"
+          reason: "CrashLoopBackOff"
+        exp_annotations:
+          description: 'Pod test/static-web (script) is in waiting state (reason: "CrashLoopBackOff").'
+          runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
+          summary: "Pod is crash looping."
+  - eval_time: 21m    # alert recovers
+    alertname: KubePodCrashLooping


### PR DESCRIPTION
…pping

Due to the series going stale when the pod stops crashlooping,
the alert can continue to fire five minutes after resolution.

Co-authored-by: Simon Pasquier <spasquie@redhat.com>