### PR TITLE
Data source template variable should be labelled 'Data Source'.

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -324,6 +324,7 @@ local statPanel = grafana.statPanel;
           'instance',
           '$datasource',
           'label_values(up{%(kubeletSelector)s,%(clusterLabel)s="$cluster"}, instance)' % $._config,
+          label='Data Source',
           refresh='time',
           includeAll=true,
           sort=1,

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -119,7 +119,7 @@ local gauge = promgrafonnet.gauge;
             value: $._config.datasourceName,
           },
           hide: 0,
-          label: null,
+          label: 'Data Source',
           name: 'datasource',
           options: [],
           query: 'prometheus',


### PR DESCRIPTION
We're building a dashboard linter and this is one of the things that came up.  Super minor nit, sorry about that.

Signed-off-by: Tom Wilkie <tom@grafana.com>