### PR TITLE
chore(KubeContainerWaiting): improve alert usage

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -198,7 +198,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.',
+              description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on container {{ $labels.container}} has been in waiting state for longer than 1 hour.',
               summary: 'Pod container waiting longer than 1 hour',
             },
             'for': '1h',


### PR DESCRIPTION
when running as an oncall, I want to select the string and run in..
in the new process I will

```
kubectl get <PASTE_ONE> -n <PASTE_TWO>
```
before I needed to 
```
kubectl get po <TAKE_ONLY_SECOND_SLASH> -n <TAKE_ONLY_FIRST_SLASH>
```

this solution can be changed to all alerts