### PR TITLE
rules: update cluster latency threshold

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -9,7 +9,7 @@
     // If you want to change these, make sure the "le" buckets exist on the histogram!
     kubeApiserverReadResourceLatency: '1',
     kubeApiserverReadNamespaceLatency: '5',
-    kubeApiserverReadClusterLatency: '40',  // 30 doesn't exist as a bucket and thus it's 40
+    kubeApiserverReadClusterLatency: '30',
     kubeApiserverWriteLatency: '1',
   },
 


### PR DESCRIPTION
Update apiserver cluster-scoped request latency threshold to the one
recommended by sig-scalability [1].

It is also safe to use the 30s bucket now since it has been in Kubernetes
for a while now [2]. It was added to the project 2 years ago as part of [3].

[1] https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md#steady-state-slisslos
[2] https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go#L106-L107
[3] https://github.com/kubernetes/kubernetes/pull/73638

cc @metalmatze 