### PR TITLE
[WIP] Kubernetes "Explore" Dashboards

### DIFF
--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -6,4 +6,5 @@
 (import 'scheduler.libsonnet') +
 (import 'proxy.libsonnet') +
 (import 'kubelet.libsonnet') +
+(import 'model/model.libsonnet') +
 (import 'defaults.libsonnet')

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -6,5 +6,5 @@
 (import 'scheduler.libsonnet') +
 (import 'proxy.libsonnet') +
 (import 'kubelet.libsonnet') +
-(import 'model/model.libsonnet') +
+(import 'model/object-dashboard.libsonnet') +
 (import 'defaults.libsonnet')

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -6,5 +6,5 @@
 (import 'scheduler.libsonnet') +
 (import 'proxy.libsonnet') +
 (import 'kubelet.libsonnet') +
-(import 'model/object-dashboard.libsonnet') +
+(import 'model/extensions.libsonnet') +
 (import 'defaults.libsonnet')

--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -6,36 +6,36 @@
   // of the file name and set the timezone to be 'default'.
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
-      uid: std.md5(filename),
-      timezone: kubernetesMixin._config.grafanaK8s.grafanaTimezone,
-      refresh: kubernetesMixin._config.grafanaK8s.refresh,
-      tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
-    } +
-    if 'rows' in super then
-    {
-      rows: [
-        row {
-          panels: [
-            panel {
-              // Modify tooltip to only show a single value
-              tooltip+: {
-                shared: false,
-              },
-              // Modify legend to always show as table on right side
-              legend+: {
-                alignAsTable: true,
-                rightSide: true,
-              },
-              // Set minimum time interval for all panels
-              interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval,
-            }
-            for panel in super.panels
-          ],
-        }
-        for row in super.rows
-      ],
+                  uid: std.md5(filename),
+                  timezone: kubernetesMixin._config.grafanaK8s.grafanaTimezone,
+                  refresh: kubernetesMixin._config.grafanaK8s.refresh,
+                  tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
+                } +
+                if 'rows' in super then
+                  {
+                    rows: [
+                      row {
+                        panels: [
+                          panel {
+                            // Modify tooltip to only show a single value
+                            tooltip+: {
+                              shared: false,
+                            },
+                            // Modify legend to always show as table on right side
+                            legend+: {
+                              alignAsTable: true,
+                              rightSide: true,
+                            },
+                            // Set minimum time interval for all panels
+                            interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval,
+                          }
+                          for panel in super.panels
+                        ],
+                      }
+                      for row in super.rows
+                    ],
 
-    } else {}
+                  } else {}
     for filename in std.objectFields(grafanaDashboards)
   },
 }

--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -10,7 +10,9 @@
       timezone: kubernetesMixin._config.grafanaK8s.grafanaTimezone,
       refresh: kubernetesMixin._config.grafanaK8s.refresh,
       tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
-
+    } +
+    if 'rows' in super then
+    {
       rows: [
         row {
           panels: [
@@ -33,7 +35,7 @@
         for row in super.rows
       ],
 
-    }
+    } else {}
     for filename in std.objectFields(grafanaDashboards)
   },
 }

--- a/dashboards/model/alerts-by-namespace.libsonnet
+++ b/dashboards/model/alerts-by-namespace.libsonnet
@@ -1,0 +1,43 @@
+local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
+
+{
+  local alert_by_namespace_panel =
+    grafana.statPanel.new(title='Alerts by Namespace', datasource='${datasource}', reducerFunction='lastNotNull', colorMode='value', graphMode='none', textMode='value_and_name', justifyMode='center')
+    .addTarget(
+      grafana.prometheus.target('count(kube_namespace_created{%(clusterLabel)s="$cluster"} or ALERTS{%(clusterLabel)s="$cluster"}) by (namespace) - 1' % $._config, legendFormat='{{namespace}}')
+    )
+    .addThresholds([{ color: 'green' }, { color: 'red', value: 1 }])
+    .addDataLink(
+      { title: 'Explore Namespace', url: '/d/c4cbf5e16859ad85ce39f8464478b279/explore-namespace?var-namespace=${__field.labels.namespace}' }
+    )
+    + { gridPos: { w: 24, h: 24 } },
+
+
+  grafanaDashboards+:: {
+    'model-alerts-by-namespace.json':
+      g.dashboard.new(title='Explore / Alerts By Namespace')
+      .addPanel(alert_by_namespace_panel)
+      + {
+        templating+: {
+          list+: [
+            g.template.datasource.new(
+              name='datasource',
+              label='Data Source',
+              query='prometheus'
+            ),
+            g.template.query.new(
+              name='cluster',
+              label='Cluster',
+              datasource='$datasource',
+              query='label_values(up{%(kubeStateMetricsSelector)s}, %(clusterLabel)s)' % $._config,
+              hide=if $._config.showMultiCluster then 0 else 2,
+              refresh=2,
+              includeAll=false,
+              sort=1
+            ),
+          ],
+        },
+      },
+  },
+}

--- a/dashboards/model/alerts-by-namespace.libsonnet
+++ b/dashboards/model/alerts-by-namespace.libsonnet
@@ -9,7 +9,10 @@ local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libso
     )
     .addThresholds([{ color: 'green' }, { color: 'red', value: 1 }])
     .addDataLink(
-      { title: 'Explore Namespace', url: '/d/c4cbf5e16859ad85ce39f8464478b279/explore-namespace?var-namespace=${__field.labels.namespace}' }
+      { 
+        title: 'Explore Namespace', 
+        url: '/d/%s/explore-namespace?var-namespace=${__field.labels.namespace}' % std.md5('model-namespace.json')
+      }
     )
     + { gridPos: { w: 24, h: 24 } },
 

--- a/dashboards/model/alerts-by-namespace.libsonnet
+++ b/dashboards/model/alerts-by-namespace.libsonnet
@@ -9,9 +9,9 @@ local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libso
     )
     .addThresholds([{ color: 'green' }, { color: 'red', value: 1 }])
     .addDataLink(
-      { 
-        title: 'Explore Namespace', 
-        url: '/d/%s/explore-namespace?var-namespace=${__field.labels.namespace}' % std.md5('model-namespace.json')
+      {
+        title: 'Explore Namespace',
+        url: '/d/%s/explore-namespace?var-namespace=${__field.labels.namespace}' % std.md5('model-namespace.json'),
       }
     )
     + { gridPos: { w: 24, h: 24 } },

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,7 +1,6 @@
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local model = import 'model.libsonnet';
-local config = import '../../config.libsonnet';
 
 {
   dashboard(kind, config):

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -47,7 +47,7 @@ local model = import 'model.libsonnet';
           query='',
           refresh=1,
           regex='',
-          //hide=2,
+          hide=2,
         )
       ),
 
@@ -72,40 +72,40 @@ local model = import 'model.libsonnet';
   addLinkPanel(kind, text, height=2):
     local icon = model.kinds[kind].icon;
     function(d)
-        d.addPanel({
-            gridPos: {
-                w: 8,
-                h: height,
-            },
-            type: 'text',
-            options: {
-                mode: 'html',
-                content: |||
-                    <div style="padding: 0px;">
-                        <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
-                            <img style="height: 32px; width: 32px; margin-right: 10px;" src="%s" alt="%s"/>
-                            <h2 style="margin-top: 5px;">%s</h1>
-                        </div>
-                    </div>
-                ||| % [icon, kind, text],
-            },
-            transparent: true,
-            datasource: null,
-        }),
+      d.addPanel({
+        gridPos: {
+          w: 8,
+          h: height,
+        },
+        type: 'text',
+        options: {
+          mode: 'html',
+          content: |||
+            <div style="padding: 0px;">
+                <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
+                    <img style="height: 32px; width: 32px; margin-right: 10px;" src="%s" alt="%s"/>
+                    <h2 style="margin-top: 5px;">%s</h1>
+                </div>
+            </div>
+          ||| % [icon, kind, text],
+        },
+        transparent: true,
+        datasource: null,
+      }),
 
-  addTextPanel(text, height=2):
+  addTextPanel(text, width=8, height=2):
     function(d)
       d.addPanel({
         type: 'text',
         title: '',
         gridPos: {
-          w: 8,
+          w: width,
           h: height,
         },
         transparent: true,
         options: {
           mode: 'markdown',
-          content: '## %s' % text,
+          content: '%s' % text,
         },
       }),
 
@@ -437,4 +437,33 @@ local model = import 'model.libsonnet';
         ],
         datasource: null,
       }),
+
+  addLogsPanel(query):
+    function(d)
+      d.addPanel({
+          gridPos: {
+            w: 12,
+            h: 8,
+          },
+          type: 'logs',
+          title: 'Pod Logs',
+          targets: [
+            {
+              refId: 'A',
+              datasource: 'Grafana Logging',
+              expr: query,
+            },
+          ],
+          options: {
+            showTime: false,
+            showLabels: false,
+            showCommonLabels: false,
+            wrapLogMessage: false,
+            prettifyLogMessage: false,
+            enableLogDetails: true,
+            dedupStrategy: 'none',
+            sortOrder: 'Descending',
+          },
+          datasource: 'Grafana Logging',
+        }),
 }

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,9 +1,8 @@
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local model = import 'model.libsonnet';
-local config = import '../../config.libsonnet';
 
-config {
+{
   dashboard(kind):
     g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
     .setTime(from='now-1h', to='now')

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,8 +1,9 @@
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local model = import 'model.libsonnet';
+local config = import '../../config.libsonnet';
 
-{
+config {
   dashboard(kind):
     g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
     .setTime(from='now-1h', to='now')

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,6 +1,7 @@
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local model = import 'model.libsonnet';
+local config = import '../../config.libsonnet';
 
 {
   dashboard(kind, config):

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,415 +1,415 @@
-local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
+local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 
 {
-    dashboard(kind):
-        g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
-        .setTime(from='now-1h', to='now')
-        .addTemplate(
-            g.template.datasource.new(name='datasource', query='prometheus')
-            .setCurrent(text='default', value='default')
+  dashboard(kind):
+    g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
+    .setTime(from='now-1h', to='now')
+    .addTemplate(
+      g.template.datasource.new(name='datasource', query='prometheus')
+      .setCurrent(text='default', value='default')
+    )
+    .addTemplate(
+      g.template.query.new(
+        datasource='${datasource}',
+        label='cluster',
+        name='cluster',
+        query='label_values(up{job="default/kube-state-metrics"}, cluster)',
+        refresh=1,
+        regex='',
+      )
+    )
+    + layout {
+      // To make building dashboards easier, we use monads(!).
+      //
+      // The idea is that you build a a list of monads to a dashboard by
+      // calling add.
+      //
+      // dashboard('test').chain([
+      //     $.addTemplate('pod'),
+      //     $.addRow('Info'),
+      //     $.addTextRow('Name'),
+      //     $.addLabelPanel('group by (name) (kube_pod_info{pod="$pod"})', 'name'),
+      //     $.newRow,
+      // ])
+      //
+      // This saves you having to nest the return value from each monad.
+      chain(fs):: std.foldl(function(d, f) if f != null then f(d) else d, fs, self),
+    },
+
+  addTemplate(name):
+    function(d)
+      d.addTemplate(
+        g.template.query.new(
+          datasource='${datasource}',
+          name=name,
+          query='',
+          refresh=1,
+          regex='',
+          //hide=2,
         )
-        .addTemplate(
-            g.template.query.new(
-                datasource='${datasource}',
-                label='cluster',
-                name='cluster',
-                query='label_values(up{job="default/kube-state-metrics"}, cluster)',
-                refresh=1,
-                regex='',
-            )
-        )
-        + layout {
-            // To make building dashboards easier, we use monads(!).
-            //
-            // The idea is that you build a a list of monads to a dashboard by
-            // calling add.
-            //
-            // dashboard('test').chain([
-            //     $.addTemplate('pod'),
-            //     $.addRow('Info'),
-            //     $.addTextRow('Name'),
-            //     $.addLabelPanel('group by (name) (kube_pod_info{pod="$pod"})', 'name'),
-            //     $.newRow,
-            // ])
-            //
-            // This saves you having to nest the return value from each monad.
-            chain(fs):: std.foldl(function(d, f) if f != null then f(d) else d, fs, self),
+      ),
+
+  addRow(title):
+    function(d)
+      d.addPanel({
+        collapsed: false,
+        datasource: null,
+        gridPos: {
+          h: 1,
+          w: 24,
         },
+        id: 25,
+        panels: [],
+        title: title,
+        type: 'row',
+      })
+      .nextRow(),
 
-    addTemplate(name):
-        function(d)
-            d.addTemplate(
-                g.template.query.new(
-                    datasource='${datasource}',
-                    name=name,
-                    query='',
-                    refresh=1,
-                    regex='',
-                    //hide=2,
-                )
-        ),
+  nextRow(d): d.nextRow(),
 
-    addRow(title):
-         function(d)
-            d.addPanel({
-                collapsed: false,
-                datasource: null,
-                gridPos: {
-                    h: 1,
-                    w: 24,
-                },
-                id: 25,
-                panels: [],
-                title: title,
-                type: 'row',
-            })
-            .nextRow(),
+  addTextPanel(text, height=2):
+    function(d)
+      d.addPanel({
+        type: 'text',
+        title: '',
+        gridPos: {
+          w: 8,
+          h: height,
+        },
+        transparent: true,
+        options: {
+          mode: 'markdown',
+          content: '## %s' % text,
+        },
+      }),
 
-    nextRow(d): d.nextRow(),
+  addLabelPanel(query, label, link=null):
+    function(d)
+      d.addPanel({
+        type: 'stat',
+        gridPos: {
+          w: 16,
+          h: 2,
+        },
+        transformations: [],
+        datasource: '$datasource',
+        targets: [
+          {
+            expr: query,
+            legendFormat: '{{%s}} ' % label,  // TODO space to handle missing labels
+            interval: '',
+            exemplar: false,
+            refId: 'A',
+            datasource: '$datasource',
+            instant: true,
+          },
+        ],
+        options: {
+          reduceOptions: {
+            values: true,
+            calcs: [
+              'lastNotNull',
+            ],
+            fields: '',
+          },
+          orientation: 'auto',
+          textMode: 'name',
+          colorMode: 'value',
+          graphMode: 'area',
+          justifyMode: 'auto',
+          text: {
+            valueSize: 18,
+          },
+        },
+        fieldConfig: {
+          defaults: {
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  color: 'text',
+                  value: null,
+                },
+              ],
+            },
+            mappings: [],
+            color: {
+              mode: 'thresholds',
+            },
+            [if link != null then 'links' else null]: [
+              {
+                title: label,
+                url: link,
+              },
+            ],
+          },
+          overrides: [],
+        },
+      }),
 
-    addTextPanel(text, height=2):
-        function(d)
-            d.addPanel({
-                type: 'text',
-                title: '',
-                gridPos: {
-                    w: 8,
-                    h: height,
+  addNumberPanel(query):
+    function(d)
+      d.addPanel({
+        type: 'stat',
+        gridPos: {
+          w: 16,
+          h: 2,
+        },
+        transformations: [],
+        datasource: '$datasource',
+        targets: [
+          {
+            expr: query,
+            legendFormat: '',
+            interval: '',
+            exemplar: false,
+            refId: 'A',
+            datasource: '$datasource',
+            instant: true,
+          },
+        ],
+        options: {
+          reduceOptions: {
+            values: true,
+            calcs: [
+              'lastNotNull',
+            ],
+            fields: '',
+          },
+          orientation: 'auto',
+          textMode: 'value',
+          colorMode: 'value',
+          graphMode: 'area',
+          justifyMode: 'auto',
+          text: {
+            valueSize: 18,
+          },
+        },
+        fieldConfig: {
+          defaults: {
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  color: 'text',
+                  value: null,
                 },
-                transparent: true,
-                options: {
-                    mode: "markdown",
-                    content: "## %s" % text
-                },
-            }),
+              ],
+            },
+            mappings: [],
+            color: {
+              mode: 'thresholds',
+            },
+          },
+          overrides: [],
+        },
+      }),
 
-    addLabelPanel(query, label, link=null):
-        function(d)
-            d.addPanel({
-                type: "stat",
-                gridPos: {
-                    "w": 16,
-                    "h": 2,
+  addDatetimePanel(query):
+    function(d)
+      d.addPanel({
+        type: 'stat',
+        gridPos: {
+          w: 16,
+          h: 2,
+        },
+        transformations: [],
+        datasource: '$datasource',
+        targets: [
+          {
+            expr: query,
+            legendFormat: '',
+            interval: '',
+            exemplar: false,
+            refId: 'A',
+            datasource: '$datasource',
+            instant: true,
+          },
+        ],
+        options: {
+          reduceOptions: {
+            values: true,
+            calcs: [
+              'lastNotNull',
+            ],
+            fields: '',
+          },
+          orientation: 'auto',
+          textMode: 'value',
+          colorMode: 'value',
+          graphMode: 'area',
+          justifyMode: 'auto',
+          text: {
+            valueSize: 18,
+          },
+        },
+        fieldConfig: {
+          defaults: {
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  color: 'text',
+                  value: null,
                 },
-                transformations: [],
-                datasource: '$datasource',
-                targets: [
-                    {
-                        "expr": query,
-                        "legendFormat": '{{%s}} ' % label, // TODO space to handle missing labels
-                        "interval": "",
-                        "exemplar": false,
-                        "refId": "A",
-                        "datasource": "$datasource",
-                        "instant": true,
-                    }
-                ],
-                options: {
-                    "reduceOptions": {
-                        "values": true,
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": ""
-                    },
-                    "orientation": "auto",
-                    "textMode": "name",
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "text": {
-                        "valueSize": 18
-                    }
-                },
-                fieldConfig: {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                "color": "text",
-                                "value": null
-                                }
-                            ]
-                        },
-                        "mappings": [],
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        [if link != null then 'links' else null]: [
-                            {
-                                title: label,
-                                url: link,
-                            }
-                        ],
-                    },
-                    "overrides": []
-                },
-            }),
+              ],
+            },
+            mappings: [],
+            color: {
+              mode: 'thresholds',
+            },
+            unit: 'dateTimeAsIso',
+          },
+          overrides: [],
+        },
+      }),
 
-    addNumberPanel(query):
-        function(d)
-            d.addPanel({
-                type: "stat",
-                gridPos: {
-                    "w": 16,
-                    "h": 2,
+  addTablePanel(query, label, link=null):
+    function(d)
+      d.addPanel({
+        datasource: '$datasource',
+        fieldConfig: {
+          defaults: {
+            custom: {
+              align: null,
+              filterable: false,
+            },
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  color: 'text',
+                  value: null,
                 },
-                transformations: [],
-                datasource: '$datasource',
-                targets: [
-                    {
-                        "expr": query,
-                        "legendFormat": '',
-                        "interval": "",
-                        "exemplar": false,
-                        "refId": "A",
-                        "datasource": "$datasource",
-                        "instant": true,
-                    }
-                ],
-                options: {
-                    "reduceOptions": {
-                        "values": true,
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": ""
-                    },
-                    "orientation": "auto",
-                    "textMode": "value",
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "text": {
-                        "valueSize": 18
-                    }
-                },
-                fieldConfig: {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "text",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "mappings": [],
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                    },
-                    "overrides": []
-                },
-            }),
+              ],
+            },
+            mappings: [
+              {
+                id: 1,
+                type: 1,
+                from: '',
+                to: '',
+                text: '',
+              },
+            ],
+            links: [
+              {
+                title: label,
+                url: link,
+              },
+            ],
+            color: {
+              mode: 'thresholds',
+            },
+          },
+          overrides: [],
+        },
+        gridPos: {
+          h: 4,
+          w: 16,
+        },
+        options: {
+          showHeader: true,
+        },
+        targets: [
+          {
+            expr: query,
+            legendFormat: '',
+            interval: '',
+            datasource: '$datasource',
+            exemplar: false,
+            instant: true,
+            refId: 'A',
+          },
+        ],
+        transformations: [
+          {
+            id: 'labelsToFields',
+            options: {},
+          },
+          {
+            id: 'organize',
+            options: {
+              excludeByName: {
+                Time: true,
+                Value: true,
+              },
+              indexByName: {
+                Time: 0,
+                Value: 1,
+                namespace: 2,
+                [label]: 3,
+              },
+              renameByName: {},
+            },
+          },
+        ],
+        type: 'table',
+        pluginVersion: '7.2.2',
+      }),
 
-    addDatetimePanel(query):
-        function(d)
-            d.addPanel({
-                type: "stat",
-                gridPos: {
-                    "w": 16,
-                    "h": 2,
+  addLabelTablePanel(query, prefix):
+    function(d)
+      d.addPanel({
+        type: 'table',
+        title: '',
+        gridPos: {
+          w: 16,
+          h: 2,
+        },
+        targets: [
+          {
+            expr: query,
+            legendFormat: '',
+            interval: '',
+            refId: 'A',
+            instant: true,
+          },
+        ],
+        fieldConfig: {
+          defaults: {
+            custom: {
+              align: null,
+              filterable: false,
+            },
+            thresholds: {
+              mode: 'absolute',
+              steps: [
+                {
+                  value: null,
+                  color: 'green',
                 },
-                transformations: [],
-                datasource: '$datasource',
-                targets: [
-                    {
-                        "expr": query,
-                        "legendFormat": '',
-                        "interval": "",
-                        "exemplar": false,
-                        "refId": "A",
-                        "datasource": "$datasource",
-                        "instant": true,
-                    }
-                ],
-                options: {
-                    "reduceOptions": {
-                        "values": true,
-                        "calcs": [
-                            "lastNotNull"
-                        ],
-                        "fields": ""
-                    },
-                    "orientation": "auto",
-                    "textMode": "value",
-                    "colorMode": "value",
-                    "graphMode": "area",
-                    "justifyMode": "auto",
-                    "text": {
-                        "valueSize": 18
-                    }
+                {
+                  value: 80,
+                  color: 'red',
                 },
-                fieldConfig: {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "text",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "mappings": [],
-                        "color": {
-                            "mode": "thresholds"
-                        },
-                        "unit": "dateTimeAsIso"
-                    },
-                    "overrides": []
-                },
-            }),
-
-    addTablePanel(query, label, link=null):
-        function(d)
-            d.addPanel({
-                "datasource": "$datasource",
-                "fieldConfig": {
-                    "defaults": {
-                        "custom": {
-                            "align": null,
-                            "filterable": false
-                        },
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                {
-                                    "color": "text",
-                                    "value": null
-                                }
-                            ]
-                        },
-                        "mappings": [
-                            {
-                                "id": 1,
-                                "type": 1,
-                                "from": "",
-                                "to": "",
-                                "text": ""
-                            }
-                        ],
-                        "links": [
-                            {
-                                "title": label,
-                                "url": link,
-                            }
-                        ],
-                        "color": {
-                            "mode": "thresholds"
-                        }
-                    },
-                    "overrides": []
-                },
-                "gridPos": {
-                    "h": 4,
-                    "w": 16,
-                },
-                "options": {
-                    "showHeader": true
-                },
-                "targets": [
-                    {
-                        "expr": query,
-                        "legendFormat": "",
-                        "interval": "",
-                        "datasource": "$datasource",
-                        "exemplar": false,
-                        "instant": true,
-                        "refId": "A"
-                    }
-                ],
-                "transformations": [
-                    {
-                        "id": "labelsToFields",
-                        "options": {}
-                    },
-                    {
-                        "id": "organize",
-                        "options": {
-                            "excludeByName": {
-                                "Time": true,
-                                "Value": true,
-                            },
-                            "indexByName": {
-                                "Time": 0,
-                                "Value": 1,
-                                "namespace": 2,
-                                [label]: 3,
-                            },
-                            "renameByName": {}
-                        }
-                    }
-                ],
-                "type": "table",
-                "pluginVersion": "7.2.2"
-            }),
-
-    addLabelTablePanel(query, prefix):
-        function(d)
-             d.addPanel({
-                "type": "table",
-                "title": "",
-                "gridPos": {
-                    "w": 16,
-                    "h": 2
-                },
-                "targets": [
-                    {
-                    "expr": query,
-                    "legendFormat": "",
-                    "interval": "",
-                    "refId": "A",
-                    "instant": true
-                    }
-                ],
-                "fieldConfig": {
-                    "defaults": {
-                    "custom": {
-                        "align": null,
-                        "filterable": false
-                    },
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "value": null,
-                                "color": "green"
-                            },
-                            {
-                                "value": 80,
-                                "color": "red"
-                            }
-                        ]
-                    },
-                    "mappings": []
-                    },
-                    "overrides": []
-                },
-                "pluginVersion": "7.2.2",
-                "timeFrom": null,
-                "timeShift": null,
-                "options": {
-                    "showHeader": true
-                },
-                "transformations": [
-                    {
-                        "id": "labelsToFields",
-                        "options": {}
-                    },
-                    {
-                        "id": "filterFieldsByName",
-                        "options": {
-                            "include": {
-                                "pattern": prefix,
-                            }
-                        }
-                    }
-                ],
-                "datasource": null
-            }),
+              ],
+            },
+            mappings: [],
+          },
+          overrides: [],
+        },
+        pluginVersion: '7.2.2',
+        timeFrom: null,
+        timeShift: null,
+        options: {
+          showHeader: true,
+        },
+        transformations: [
+          {
+            id: 'labelsToFields',
+            options: {},
+          },
+          {
+            id: 'filterFieldsByName',
+            options: {
+              include: {
+                pattern: prefix,
+              },
+            },
+          },
+        ],
+        datasource: null,
+      }),
 }

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -3,7 +3,7 @@ local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonn
 local model = import 'model.libsonnet';
 
 {
-  dashboard(kind):
+  dashboard(kind, config):
     g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
     .setTime(from='now-1h', to='now')
     .addTemplate(
@@ -15,7 +15,7 @@ local model = import 'model.libsonnet';
         datasource='${datasource}',
         label='cluster',
         name='cluster',
-        query='label_values(up{%(kubeStateMetricsSelector)s}, cluster)' % $._config,
+        query='label_values(up{%(kubeStateMetricsSelector)s}, cluster)' % config,
         refresh=1,
         regex='',
       )

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -100,7 +100,7 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                 targets: [
                     {
                         "expr": query,
-                        "legendFormat": '{{%s}}' % label,
+                        "legendFormat": '{{%s}} ' % label, // TODO space to handle missing labels
                         "interval": "",
                         "exemplar": false,
                         "refId": "A",

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -75,7 +75,7 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
         function(d)
             d.addPanel({
                 type: 'text',
-                title: text,
+                title: '',
                 gridPos: {
                     w: 8,
                     h: height,
@@ -83,7 +83,7 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                 transparent: true,
                 options: {
                     mode: "markdown",
-                    content: ""
+                    content: "## %s" % text
                 },
             }),
 

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -71,14 +71,14 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
 
     nextRow(d): d.nextRow(),
 
-    addTextPanel(text):
+    addTextPanel(text, height=2):
         function(d)
             d.addPanel({
                 type: 'text',
                 title: text,
                 gridPos: {
                     w: 8,
-                    h: 1,
+                    h: height,
                 },
                 transparent: true,
                 options: {
@@ -149,5 +149,84 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                     },
                     "overrides": []
                 },
+            }),
+
+    addTablePanel(query, label, link=null):
+        function(d)
+            d.addPanel({
+                "datasource": "$datasource",
+                "fieldConfig": {
+                    "defaults": {
+                        "custom": {
+                            "align": null,
+                            "filterable": false
+                        },
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "text",
+                                    "value": null
+                                }
+                            ]
+                        },
+                        "mappings": [
+                            {
+                                "id": 1,
+                                "type": 1,
+                                "from": "",
+                                "to": "",
+                                "text": ""
+                            }
+                        ],
+                        "links": [
+                            {
+                                "title": label,
+                                "url": link,
+                            }
+                        ],
+                        "color": {
+                            "mode": "thresholds"
+                        }
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 4,
+                    "w": 16,
+                },
+                "options": {
+                    "showHeader": false
+                },
+                "targets": [
+                    {
+                        "expr": query,
+                        "legendFormat": "",
+                        "interval": "",
+                        "datasource": "$datasource",
+                        "exemplar": false,
+                        "instant": true,
+                        "refId": "A"
+                    }
+                ],
+                "transformations": [
+                    {
+                        "id": "labelsToFields",
+                        "options": {}
+                    },
+                    {
+                        "id": "organize",
+                        "options": {
+                            "excludeByName": {
+                            "Time": true,
+                            "Value": true
+                            },
+                            "indexByName": {},
+                            "renameByName": {}
+                        }
+                    }
+                ],
+                "type": "table",
+                "pluginVersion": "7.2.2"
             }),
 }

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -37,7 +37,7 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
             // ])
             //
             // This saves you having to nest the return value from each monad.
-            chain(fs):: std.foldl(function(d, f) f(d), fs, self),
+            chain(fs):: std.foldl(function(d, f) if f != null then f(d) else d, fs, self),
         },
 
     addTemplate(name):
@@ -228,5 +228,69 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                 ],
                 "type": "table",
                 "pluginVersion": "7.2.2"
+            }),
+
+    addLabelTablePanel(query, prefix):
+        function(d)
+             d.addPanel({
+                "type": "table",
+                "title": "",
+                "gridPos": {
+                    "w": 16,
+                    "h": 2
+                },
+                "targets": [
+                    {
+                    "expr": query,
+                    "legendFormat": "",
+                    "interval": "",
+                    "refId": "A",
+                    "instant": true
+                    }
+                ],
+                "fieldConfig": {
+                    "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "value": null,
+                                "color": "green"
+                            },
+                            {
+                                "value": 80,
+                                "color": "red"
+                            }
+                        ]
+                    },
+                    "mappings": []
+                    },
+                    "overrides": []
+                },
+                "pluginVersion": "7.2.2",
+                "timeFrom": null,
+                "timeShift": null,
+                "options": {
+                    "showHeader": true
+                },
+                "transformations": [
+                    {
+                        "id": "labelsToFields",
+                        "options": {}
+                    },
+                    {
+                        "id": "filterFieldsByName",
+                        "options": {
+                            "include": {
+                                "pattern": prefix,
+                            }
+                        }
+                    }
+                ],
+                "datasource": null
             }),
 }

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -7,13 +7,13 @@ local model = import 'model.libsonnet';
     g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
     .setTime(from='now-1h', to='now')
     .addTemplate(
-      g.template.datasource.new(name='datasource', query='prometheus')
+      g.template.datasource.new(name='datasource', query='prometheus', label='Data Source')
       .setCurrent(text='default', value='default')
     )
     .addTemplate(
       g.template.query.new(
         datasource='${datasource}',
-        label='cluster',
+        label='Cluster',
         name='cluster',
         query='label_values(up{%(kubeStateMetricsSelector)s}, cluster)' % config,
         refresh=1,

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,0 +1,153 @@
+local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
+local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
+
+{
+    dashboard(kind):
+        g.dashboard.new(title='Explore / %s' % kind, refresh='5m', uid=std.md5(kind))
+        .setTime(from='now-1h', to='now')
+        .addTemplate(
+            g.template.datasource.new(name='datasource', query='prometheus')
+            .setCurrent(text='default', value='default')
+        )
+        .addTemplate(
+            g.template.query.new(
+                allValue='.+',
+                datasource='${datasource}',
+                includeAll=true,
+                label='cluster',
+                name='cluster',
+                query='',
+                refresh=1,
+                regex='',
+                //hide=2,
+            )
+        )
+        + layout {
+            // To make building dashboards easier, we use monads(!).
+            //
+            // The idea is that you build a a list of monads to a dashboard by
+            // calling add.
+            //
+            // dashboard('test').chain([
+            //     $.addTemplate('pod'),
+            //     $.addRow('Info'),
+            //     $.addTextRow('Name'),
+            //     $.addLabelPanel('group by (name) (kube_pod_info{pod="$pod"})', 'name'),
+            //     $.newRow,
+            // ])
+            //
+            // This saves you having to nest the return value from each monad.
+            chain(fs):: std.foldl(function(d, f) f(d), fs, self),
+        },
+
+    addTemplate(name):
+        function(d)
+            d.addTemplate(
+                g.template.query.new(
+                    datasource='${datasource}',
+                    name=name,
+                    query='',
+                    refresh=1,
+                    regex='',
+                    //hide=2,
+                )
+        ),
+
+    addRow(title):
+         function(d)
+            d.addPanel({
+                collapsed: false,
+                datasource: null,
+                gridPos: {
+                    h: 1,
+                    w: 24,
+                },
+                id: 25,
+                panels: [],
+                title: title,
+                type: 'row',
+            })
+            .nextRow(),
+
+    nextRow(d): d.nextRow(),
+
+    addTextPanel(text):
+        function(d)
+            d.addPanel({
+                type: 'text',
+                title: text,
+                gridPos: {
+                    w: 8,
+                    h: 1,
+                },
+                transparent: true,
+                options: {
+                    mode: "markdown",
+                    content: ""
+                },
+            }),
+
+    addLabelPanel(query, label, link=null):
+        function(d)
+            d.addPanel({
+                type: "stat",
+                gridPos: {
+                    "w": 16,
+                    "h": 2,
+                },
+                transformations: [],
+                datasource: '$datasource',
+                targets: [
+                    {
+                        "expr": query,
+                        "legendFormat": '{{%s}}' % label,
+                        "interval": "",
+                        "exemplar": false,
+                        "refId": "A",
+                        "datasource": "$datasource",
+                        "instant": true,
+                    }
+                ],
+                options: {
+                    "reduceOptions": {
+                        "values": true,
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": ""
+                    },
+                    "orientation": "auto",
+                    "textMode": "name",
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "text": {
+                        "valueSize": 18
+                    }
+                },
+                fieldConfig: {
+                    "defaults": {
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                "color": "text",
+                                "value": null
+                                }
+                            ]
+                        },
+                        "mappings": [],
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        [if link != null then 'links' else null]: [
+                            {
+                                title: label,
+                                url: link,
+                            }
+                        ],
+                    },
+                    "overrides": []
+                },
+            }),
+}

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -44,7 +44,7 @@ local model = import 'model.libsonnet';
         g.template.query.new(
           datasource='${datasource}',
           name=name,
-          query='label_values(up{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % {kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name},
+          query='label_values(up{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % { kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name },
           refresh=1,
           regex='',
           hide=2,
@@ -441,29 +441,29 @@ local model = import 'model.libsonnet';
   addLogsPanel(query):
     function(d)
       d.addPanel({
-          gridPos: {
-            w: 12,
-            h: 8,
+        gridPos: {
+          w: 12,
+          h: 8,
+        },
+        type: 'logs',
+        title: 'Pod Logs',
+        targets: [
+          {
+            refId: 'A',
+            datasource: 'Grafana Logging',
+            expr: query,
           },
-          type: 'logs',
-          title: 'Pod Logs',
-          targets: [
-            {
-              refId: 'A',
-              datasource: 'Grafana Logging',
-              expr: query,
-            },
-          ],
-          options: {
-            showTime: false,
-            showLabels: false,
-            showCommonLabels: false,
-            wrapLogMessage: false,
-            prettifyLogMessage: false,
-            enableLogDetails: true,
-            dedupStrategy: 'none',
-            sortOrder: 'Descending',
-          },
-          datasource: 'Grafana Logging',
-        }),
+        ],
+        options: {
+          showTime: false,
+          showLabels: false,
+          showCommonLabels: false,
+          wrapLogMessage: false,
+          prettifyLogMessage: false,
+          enableLogDetails: true,
+          dedupStrategy: 'none',
+          sortOrder: 'Descending',
+        },
+        datasource: 'Grafana Logging',
+      }),
 }

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -12,7 +12,7 @@ local model = import 'model.libsonnet';
     )
     .addTemplate(
       g.template.query.new(
-        datasource='${datasource}',
+        datasource='$datasource',
         label='Cluster',
         name='cluster',
         query='label_values(up{%(kubeStateMetricsSelector)s}, cluster)' % config,
@@ -42,7 +42,7 @@ local model = import 'model.libsonnet';
     function(d)
       d.addTemplate(
         g.template.query.new(
-          datasource='${datasource}',
+          datasource='$datasource',
           name=name,
           query='label_values(kube_%(name)s_created{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % { kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name },
           refresh=1,
@@ -54,7 +54,7 @@ local model = import 'model.libsonnet';
     function(d)
       d.addPanel({
         collapsed: false,
-        datasource: null,
+        datasource: '$datasource',
         gridPos: {
           h: 1,
           w: 24,
@@ -89,7 +89,7 @@ local model = import 'model.libsonnet';
           ||| % [icon, kind, text],
         },
         transparent: true,
-        datasource: null,
+        datasource: '$datasource',
       }),
 
   addTextPanel(text, width=8, height=2):
@@ -106,6 +106,7 @@ local model = import 'model.libsonnet';
           mode: 'markdown',
           content: '%s' % text,
         },
+        datasource: '$datasource',
       }),
 
   addLabelPanel(query, label, link=null):

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -11,15 +11,12 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
         )
         .addTemplate(
             g.template.query.new(
-                allValue='.+',
                 datasource='${datasource}',
-                includeAll=true,
                 label='cluster',
                 name='cluster',
-                query='',
+                query='label_values(up{job="default/kube-state-metrics"}, cluster)',
                 refresh=1,
                 regex='',
-                //hide=2,
             )
         )
         + layout {
@@ -146,6 +143,123 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                                 url: link,
                             }
                         ],
+                    },
+                    "overrides": []
+                },
+            }),
+
+    addNumberPanel(query):
+        function(d)
+            d.addPanel({
+                type: "stat",
+                gridPos: {
+                    "w": 16,
+                    "h": 2,
+                },
+                transformations: [],
+                datasource: '$datasource',
+                targets: [
+                    {
+                        "expr": query,
+                        "legendFormat": '',
+                        "interval": "",
+                        "exemplar": false,
+                        "refId": "A",
+                        "datasource": "$datasource",
+                        "instant": true,
+                    }
+                ],
+                options: {
+                    "reduceOptions": {
+                        "values": true,
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": ""
+                    },
+                    "orientation": "auto",
+                    "textMode": "value",
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "text": {
+                        "valueSize": 18
+                    }
+                },
+                fieldConfig: {
+                    "defaults": {
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "text",
+                                    "value": null
+                                }
+                            ]
+                        },
+                        "mappings": [],
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                    },
+                    "overrides": []
+                },
+            }),
+
+    addDatetimePanel(query):
+        function(d)
+            d.addPanel({
+                type: "stat",
+                gridPos: {
+                    "w": 16,
+                    "h": 2,
+                },
+                transformations: [],
+                datasource: '$datasource',
+                targets: [
+                    {
+                        "expr": query,
+                        "legendFormat": '',
+                        "interval": "",
+                        "exemplar": false,
+                        "refId": "A",
+                        "datasource": "$datasource",
+                        "instant": true,
+                    }
+                ],
+                options: {
+                    "reduceOptions": {
+                        "values": true,
+                        "calcs": [
+                            "lastNotNull"
+                        ],
+                        "fields": ""
+                    },
+                    "orientation": "auto",
+                    "textMode": "value",
+                    "colorMode": "value",
+                    "graphMode": "area",
+                    "justifyMode": "auto",
+                    "text": {
+                        "valueSize": 18
+                    }
+                },
+                fieldConfig: {
+                    "defaults": {
+                        "thresholds": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                    "color": "text",
+                                    "value": null
+                                }
+                            ]
+                        },
+                        "mappings": [],
+                        "color": {
+                            "mode": "thresholds"
+                        },
+                        "unit": "dateTimeAsIso"
                     },
                     "overrides": []
                 },

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -38,13 +38,13 @@ local model = import 'model.libsonnet';
       chain(fs):: std.foldl(function(d, f) if f != null then f(d) else d, fs, self),
     },
 
-  addTemplate(name):
+  addTemplate(name, config):
     function(d)
       d.addTemplate(
         g.template.query.new(
           datasource='${datasource}',
           name=name,
-          query='',
+          query='label_values(up{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % {kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name},
           refresh=1,
           regex='',
           hide=2,

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -44,10 +44,9 @@ local model = import 'model.libsonnet';
         g.template.query.new(
           datasource='${datasource}',
           name=name,
-          query='label_values(up{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % { kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name },
+          query='label_values(kube_%(name)s_created{%(kubeStateMetricsSelector)s, cluster="$cluster"}, %(name)s)' % { kubeStateMetricsSelector: config.kubeStateMetricsSelector, name: name },
           refresh=1,
           regex='',
-          hide=2,
         )
       ),
 

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -15,7 +15,7 @@ local model = import 'model.libsonnet';
         datasource='${datasource}',
         label='cluster',
         name='cluster',
-        query='label_values(up{job="default/kube-state-metrics"}, cluster)',
+        query='label_values(up{job="%(kubeStateMetricsSelector)s"}, cluster)' % $._config,
         refresh=1,
         regex='',
       )

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -16,7 +16,7 @@ config {
         datasource='${datasource}',
         label='cluster',
         name='cluster',
-        query='label_values(up{job="%(kubeStateMetricsSelector)s"}, cluster)' % $._config,
+        query='label_values(up{%(kubeStateMetricsSelector)s}, cluster)' % $._config,
         refresh=1,
         regex='',
       )

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -435,7 +435,7 @@ local model = import 'model.libsonnet';
             },
           },
         ],
-        datasource: null,
+        datasource: '$datasource',
       }),
 
   addLogsPanel(query):

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -1,5 +1,6 @@
 local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
+local model = import 'model.libsonnet';
 
 {
   dashboard(kind):
@@ -67,6 +68,30 @@ local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonn
       .nextRow(),
 
   nextRow(d): d.nextRow(),
+
+  addLinkPanel(kind, text, height=2):
+    local icon = model.kinds[kind].icon;
+    function(d)
+        d.addPanel({
+            gridPos: {
+                w: 8,
+                h: height,
+            },
+            type: 'text',
+            options: {
+                mode: 'html',
+                content: |||
+                    <div style="padding: 0px;">
+                        <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
+                            <img style="height: 32px; width: 32px; margin-right: 10px;" src="%s" alt="%s"/>
+                            <h2 style="margin-top: 5px;">%s</h1>
+                        </div>
+                    </div>
+                ||| % [icon, kind, text],
+            },
+            transparent: true,
+            datasource: null,
+        }),
 
   addTextPanel(text, height=2):
     function(d)

--- a/dashboards/model/common.libsonnet
+++ b/dashboards/model/common.libsonnet
@@ -310,7 +310,7 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                     "w": 16,
                 },
                 "options": {
-                    "showHeader": false
+                    "showHeader": true
                 },
                 "targets": [
                     {
@@ -332,10 +332,15 @@ local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet
                         "id": "organize",
                         "options": {
                             "excludeByName": {
-                            "Time": true,
-                            "Value": true
+                                "Time": true,
+                                "Value": true,
                             },
-                            "indexByName": {},
+                            "indexByName": {
+                                "Time": 0,
+                                "Value": 1,
+                                "namespace": 2,
+                                [label]: 3,
+                            },
                             "renameByName": {}
                         }
                     }

--- a/dashboards/model/extensions.libsonnet
+++ b/dashboards/model/extensions.libsonnet
@@ -1,0 +1,75 @@
+local c = import 'common.libsonnet';
+
+(import 'object-dashboard.libsonnet') {
+  grafanaDashboards+: {
+    'model-pod.json':
+      super['model-pod.json'].chain([
+        c.addRow('Debugging'),
+        c.addTextPanel(|||
+          ### Shell into Pod:
+
+          ```
+          $ kubectl exec -ti --namespace "$namespace" --pod "$pod" -- /bin/sh
+          ```
+
+          ### Port forward to the pod
+
+          ```
+          $ kubectl port-forward --namespace "$namespace" --pod "$pod" 8080:8080
+          ```
+
+          ### Delete Pod:
+
+          ```
+          $ kubectl delete pod --namespace "$namespace" --pod "$pod"
+          ```
+        |||, width=12, height=8),
+        c.addLogsPanel('{cluster="$cluster", namespace="$namespace", pod="$pod"}'),
+      ]),
+
+    'model-deployment.json':
+      super['model-deployment.json'].chain([
+        c.addRow('Debugging'),
+        c.addTextPanel(|||
+          ### Scale Deployment:
+
+          ```
+          $ kubectl scale --replicas=3 --namespace "$namespace" deploy/$deployment
+          ```
+        |||, width=12, height=8),
+        c.addLogsPanel('{cluster="$cluster", namespace="$namespace", name="$deployment"}'),
+      ]),
+
+    'model-statefulset.json':
+      super['model-statefulset.json'].chain([
+        c.addRow('Debugging'),
+        c.addTextPanel(|||
+          ### Scale Deployment:
+
+          ```
+          $ kubectl scale --replicas=3 --namespace "$namespace" statefulset/$statefulset
+          ```
+        |||, width=12, height=8),
+        c.addLogsPanel('{cluster="$cluster", namespace="$namespace", name="$statefulset"}'),
+      ]),
+
+    'model-node.json':
+      super['model-node.json'].chain([
+        c.addRow('Debugging'),
+        c.addTextPanel(|||
+          ### Cordon Node:
+
+          ```
+          $ kubectl cordon $node
+          $ kubectl uncordon $node
+          ```
+
+          ### Drain Node:
+
+          ```
+          $ kubectl drain $node
+          ```
+        |||, width=12, height=8),
+      ]),
+  },
+}

--- a/dashboards/model/extensions.libsonnet
+++ b/dashboards/model/extensions.libsonnet
@@ -1,6 +1,6 @@
 local c = import 'common.libsonnet';
 
-(import 'object-dashboard.libsonnet') {
+(import 'object-dashboard.libsonnet') + (import 'alerts-by-namespace.libsonnet') + {
   grafanaDashboards+:: {
     'model-pod.json':
       super['model-pod.json'].chain([

--- a/dashboards/model/extensions.libsonnet
+++ b/dashboards/model/extensions.libsonnet
@@ -1,7 +1,7 @@
 local c = import 'common.libsonnet';
 
 (import 'object-dashboard.libsonnet') {
-  grafanaDashboards+: {
+  grafanaDashboards+:: {
     'model-pod.json':
       super['model-pod.json'].chain([
         c.addRow('Debugging'),

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -1,201 +1,59 @@
-local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
-local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
-
-local relationships = [
-    {
-        one: 'Namespace',
-        many: 'Pod',
-        metric: 'kube_pod_info',
-    },
-    {
-        one: 'Node',
-        many: 'Pod',
-        metric: 'kube_pod_info',
-    },
-    {
-        one: 'Pod',
-        many: 'Persistentvolumeclaims',
-        metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
-    },
-    {
-        one: 'ReplicaSet',
-        many: 'Pod',
-        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="ReplicaSet"}',
-    },
-    {
-        one: 'StatefulSet',
-        many: 'Pod',
-        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="StatefulSet"}',
-    },
-    {
-        one: 'ReplicaSet',
-        many: 'Pod',
-        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="ReplicaSet"}',
-    },
-    {
-        one: 'Job',
-        many: 'Pod',
-        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="Job"}',
-    },
-    {
-        one: 'DaemonSet',
-        many: 'Pod',
-        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="DaemonSet"}',
-    },
-];
-
-local kinds = std.set(
-    [r.one for r in relationships] +
-    [r.many for r in relationships]
-);
-
-local textPanel(text) = {
-  type: 'text',
-  title: text,
-  gridPos: {
-    w: 8,
-    h: 1
-  },
-  transparent: true,
-  options: {
-    mode: "markdown",
-    content: ""
-  },
-};
-
-local labelPanel(query, label) = {
-  type: "stat",
-  gridPos: {
-    "w": 16,
-    "h": 1
-  },
-  transformations: [],
-  datasource: '$datasource',
-  targets: [
-    {
-      "expr": query,
-      "legendFormat": '{{%s}}' % label,
-      "interval": "",
-      "exemplar": false,
-      "refId": "A",
-      "datasource": "$datasource",
-      "instant": true,
-    }
-  ],
-  options: {
-    "reduceOptions": {
-      "values": true,
-      "calcs": [
-        "lastNotNull"
-      ],
-      "fields": ""
-    },
-    "orientation": "auto",
-    "textMode": "name",
-    "colorMode": "value",
-    "graphMode": "area",
-    "justifyMode": "auto",
-    "text": {
-      "valueSize": 18
-    }
-  },
-  fieldConfig: {
-    "defaults": {
-      "thresholds": {
-        "mode": "absolute",
-        "steps": [
-          {
-            "color": "text",
-            "value": null
-          }
-        ]
-      },
-      "mappings": [],
-      "color": {
-        "mode": "thresholds"
-      }
-    },
-    "overrides": []
-  },
-};
-
-local manyToOne(d, many) =
-    std.foldl(function(d, r)
-        local oneLabel = std.asciiLower(r.one);
-        local manyLabel = std.asciiLower(r.many);
-
-        if r.many != many
-        then d
-        else d
-            .addPanel(textPanel(r.one))
-            .addPanel(labelPanel('group by (%s) (%s{%s="$%s"})' % [oneLabel, r.metric, manyLabel, manyLabel], oneLabel))
-            .nextRow(),
-    relationships, d);
-
 {
-  local dashboard(name) =
-    g.dashboard.new(title=name, refresh='5m', uid=std.md5(name))
-    .setTime(from='now-1h', to='now')
-    .addTemplate(
-      g.template.datasource.new(name='datasource', query='prometheus')
-      .setCurrent(text='default', value='default')
-    )
-    .addTemplate(
-      g.template.query.new(
-        allValue='.+',
-        datasource='${datasource}',
-        includeAll=true,
-        label='cluster',
-        name='cluster',
-        query='label_values(up{%(kubeStateMetricsSelector)s}, %(clusterLabel)s)' % $._config,
-        refresh=1,
-        regex='',
-      )
-      .setCurrent(selected=true, text=['All'], value=['$__all'])
-    )
-    .addTemplate(
-      g.template.query.new(
-        allValue='.+',
-        datasource='${datasource}',
-        includeAll=true,
-        label='namespace',
-        name='namespace',
-        query='label_values(kube_namespace_created{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
-        refresh=1,
-        regex='',
-      )
-      .setCurrent(selected=true, text=['All'], value=['$__all'])
-    ) + layout,
+    relationships: [
+        {
+            one: 'Namespace',
+            many: 'Pod',
+            metric: 'kube_pod_info',
+        },
+        {
+            one: 'Node',
+            many: 'Pod',
+            metric: 'kube_pod_info',
+        },
+        {
+            one: 'Pod',
+            many: 'Persistentvolumeclaims',
+            metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
+        },
+        {
+            one: 'ReplicaSet',
+            many: 'Pod',
+            one_label: 'owner_name',
+            metric: 'kube_pod_owner',
+            filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
+        },
+        {
+            one: 'StatefulSet',
+            many: 'Pod',
+            one_label: 'owner_name',
+            metric: 'kube_pod_owner',
+            filters: ['owner_is_controller="true"', 'owner_kind="StatefulSet"'],
+        },
+        {
+            one: 'ReplicaSet',
+            many: 'Pod',
+            one_label: 'owner_name',
+            metric: 'kube_pod_owner',
+            filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
+        },
+        {
+            one: 'Job',
+            many: 'Pod',
+            one_label: 'owner_name',
+            metric: 'kube_pod_owner',
+            filters: ['owner_is_controller="true"', 'owner_kind="Job"'],
+        },
+        {
+            one: 'DaemonSet',
+            many: 'Pod',
+            one_label: 'owner_name',
+            metric: 'kube_pod_owner',
+            filters: ['owner_is_controller="true"', 'owner_kind="DaemonSet"'],
+        },
+    ],
 
-    local dashboardForKind(kind) =
-        local kindLabel = std.asciiLower(kind);
-        local d =
-            dashboard('Explore / %s' % kind)
-            .addTemplate(
-                g.template.query.new(
-                    datasource='${datasource}',
-                    label=kindLabel,
-                    name=kindLabel,
-                    query='',
-                )
-            )
-            .addPanel({
-                collapsed: false,
-                datasource: null,
-                gridPos: {
-                    h: 1,
-                    w: 24,
-                },
-                id: 25,
-                panels: [],
-                title: kind,
-                type: 'row',
-            })
-            .nextRow();
-        manyToOne(d, kind),
-
-    grafanaDashboards: {
-        ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
-        for kind in std.trace(std.toString(kinds), kinds)
-    },
+    kinds: std.set(
+        [r.one for r in $.relationships] +
+        [r.many for r in $.relationships]
+    ),
 }

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -11,6 +11,7 @@
     // }
     kinds: {
         ConfigMap: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cm-128.png",
             namespaced: true,
             info: [
                 {
@@ -27,6 +28,7 @@
             relationships: [],
         },
         CronJob: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cronjob-128.png",
             namespaced: true,
             info: [
                 {
@@ -47,6 +49,7 @@
             ],
         },
         DaemonSet: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ds-128.png",
             namespaced: true,
             info: [],
             relationships: [
@@ -60,6 +63,7 @@
             ],
         },
         Job: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/job-128.png",
             namespaced: true,
             info: [],
             relationships: [
@@ -73,6 +77,7 @@
             ],
         },
         Namespace: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ns-128.png",
             namespaced: false,
             info: [],
             relationships: [
@@ -88,12 +93,28 @@
                 },
                 {
                     one: 'Namespace',
+                    many: 'DaemonSet',
+                    metric: 'kube_daemonset_info',
+                },
+                {
+                    one: 'Namespace',
+                    many: 'Deployment',
+                    metric: 'kube_deployment_info',
+                },
+                {
+                    one: 'Namespace',
+                    many: 'StatefulSet',
+                    metric: 'kube_statefulset_info',
+                },
+                {
+                    one: 'Namespace',
                     many: 'Pod',
                     metric: 'kube_pod_info',
                 },
             ],
         },
         Node: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/infrastructure_components/unlabeled/node-128.png",
             namespaced: false,
             info: [
                 {
@@ -136,6 +157,7 @@
             ],
         },
         Pod: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pod-128.png",
             namespaced: true,
             info: [
                 {
@@ -154,6 +176,7 @@
             ],
         },
         ReplicaSet: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/rs-128.png",
             namespaced: true,
             info: [],
             relationships: [
@@ -167,6 +190,7 @@
             ],
         },
         StatefulSet: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/sts-128.png",
             namespaced: true,
             info: [],
             relationships: [

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -1,99 +1,157 @@
 {
-    info: {
-        ConfigMap: [
-            {
-                name: "Labels",
-                type: "labels",
-                prefix: "label_",
-                metric: "kube_configmap_labels"
-            },
-            {
-                name: "Annotations",
-                type: "labels",
-                prefix: "annotation_",
-                metrics: "kube_configmap_annotations",
-            },
-            {
-                name: "Created On",
-                type: "datetime",
-                metric: "kube_configmap_created"
-            },
-            {
-                name: "Resource Version",
-                type: "number",
-                metric: "kube_configmap_metadata_resource_version",
-            },
-        ],
-        Pod: [
-            {
-                name: "Labels",
-                type: "labels",
-                prefix: "label_",
-                metric: "kube_pod_labels"
-            },
-            {
-                name: "Annotations",
-                type: "labels",
-                prefix: "annotation_",
-                metrics: "kube_pod_annotations",
-            },
-        ],
+    // On record for each k8s kind.
+    //
+    // Records should be of the format:
+    // {
+    //   icon: ...,
+    //   namespaced: <bool>    - if this object is in a namespace.
+    //   info: [...],          - list of metrics to render as info
+    //   relationships: [...], - list of one-to-many relationships for this kind.
+    //   metrics: [...],       - list of meaninful metrics for this kind.
+    // }
+    kinds: {
+        ConfigMap: {
+            namespaced: true,
+            info: [
+                {
+                    name: "Created On",
+                    type: "datetime",
+                    metric: "kube_configmap_created"
+                },
+                {
+                    name: "Resource Version",
+                    type: "number",
+                    metric: "kube_configmap_metadata_resource_version",
+                },
+            ],
+            relationships: [],
+        },
+        CronJob: {
+            namespaced: true,
+            info: [
+                {
+                    name: 'Schedule',
+                    type: 'label',
+                    metric: 'kube_cronjob_info',
+                    label: 'schedule',
+                },
+                {
+                    name: 'Concurrency Policy',
+                    type: 'label',
+                    metric: 'kube_cronjob_info',
+                    label: 'concurrency_policy',
+                },
+            ],
+            relationships: [
+                // TODO find a metric to relate CronJobs to Jobs.
+            ],
+        },
+        DaemonSet: {
+            namespaced: true,
+            info: [],
+            relationships: [
+                {
+                    one: 'DaemonSet',
+                    many: 'Pod',
+                    one_label: 'owner_name',
+                    metric: 'kube_pod_owner',
+                    filters: ['owner_is_controller="true"', 'owner_kind="DaemonSet"'],
+                },
+            ],
+        },
+        Job: {
+            namespaced: true,
+            info: [],
+            relationships: [
+                {
+                    one: 'Job',
+                    many: 'Pod',
+                    one_label: 'owner_name',
+                    metric: 'kube_pod_owner',
+                    filters: ['owner_is_controller="true"', 'owner_kind="Job"'],
+                },
+            ],
+        },
+        Namespace: {
+            namespaced: false,
+            info: [],
+            relationships: [
+                {
+                    one: 'Namespace',
+                    many: 'ConfigMap',
+                    metric: 'kube_configmap_info',
+                },
+                {
+                    one: 'Namespace',
+                    many: 'CronJob',
+                    metric: 'kube_cronjob_info',
+                },
+                {
+                    one: 'Namespace',
+                    many: 'Pod',
+                    metric: 'kube_pod_info',
+                },
+            ],
+        },
+        Node: {
+            namespaced: false,
+            info: [],
+            relationships: [
+                 {
+                    one: 'Node',
+                    many: 'Pod',
+                    metric: 'kube_pod_info',
+                },
+            ],
+        },
+        Pod: {
+            namespaced: true,
+            info: [
+                {
+                    name: 'Pod IP',
+                    type: 'label',
+                    metric: 'kube_pod_info',
+                    label: 'pod_ip',
+                },
+            ],
+            relationships: [
+                {
+                    one: 'Pod',
+                    many: 'Persistentvolumeclaims',
+                    metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
+                },
+            ],
+        },
+        ReplicaSet: {
+            namespaced: true,
+            info: [],
+            relationships: [
+                {
+                    one: 'ReplicaSet',
+                    many: 'Pod',
+                    one_label: 'owner_name',
+                    metric: 'kube_pod_owner',
+                    filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
+                },
+            ],
+        },
+        StatefulSet: {
+            namespaced: true,
+            info: [],
+            relationships: [
+                {
+                    one: 'StatefulSet',
+                    many: 'Pod',
+                    one_label: 'owner_name',
+                    metric: 'kube_pod_owner',
+                    filters: ['owner_is_controller="true"', 'owner_kind="StatefulSet"'],
+                },
+            ],
+        },
     },
 
-    relationships: [
-        {
-            one: 'Namespace',
-            many: 'Pod',
-            metric: 'kube_pod_info',
-        },
-        {
-            one: 'Namespace',
-            many: 'ConfigMap',
-            metric: 'kube_configmap_info',
-        },
-
-        {
-            one: 'Node',
-            many: 'Pod',
-            metric: 'kube_pod_info',
-        },
-        {
-            one: 'Pod',
-            many: 'Persistentvolumeclaims',
-            metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
-        },
-        {
-            one: 'StatefulSet',
-            many: 'Pod',
-            one_label: 'owner_name',
-            metric: 'kube_pod_owner',
-            filters: ['owner_is_controller="true"', 'owner_kind="StatefulSet"'],
-        },
-        {
-            one: 'ReplicaSet',
-            many: 'Pod',
-            one_label: 'owner_name',
-            metric: 'kube_pod_owner',
-            filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
-        },
-        {
-            one: 'Job',
-            many: 'Pod',
-            one_label: 'owner_name',
-            metric: 'kube_pod_owner',
-            filters: ['owner_is_controller="true"', 'owner_kind="Job"'],
-        },
-        {
-            one: 'DaemonSet',
-            many: 'Pod',
-            one_label: 'owner_name',
-            metric: 'kube_pod_owner',
-            filters: ['owner_is_controller="true"', 'owner_kind="DaemonSet"'],
-        },
-    ],
-
-    kinds: std.set(
-        [r.one for r in $.relationships] +
-        [r.many for r in $.relationships]
-    ),
+    relationships: std.flattenArrays([
+        $.kinds[k].relationships
+        for k in std.objectFields($.kinds)
+    ]),
 }

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -1,261 +1,261 @@
 {
-    // On record for each k8s kind.
-    //
-    // Records should be of the format:
-    // {
-    //   icon: ...,
-    //   namespaced: <bool>    - if this object is in a namespace.
-    //   info: [...],          - list of metrics to render as info
-    //   relationships: [...], - list of one-to-many relationships for this kind.
-    //   metrics: [...],       - list of meaninful metrics for this kind.
-    // }
-    kinds: {
-        ConfigMap: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cm-128.png",
-            namespaced: true,
-            info: [
-                {
-                    name: "Created On",
-                    type: "datetime",
-                    metric: "kube_configmap_created"
-                },
-                {
-                    name: "Resource Version",
-                    type: "number",
-                    metric: "kube_configmap_metadata_resource_version",
-                },
-            ],
-            relationships: [],
+  // On record for each k8s kind.
+  //
+  // Records should be of the format:
+  // {
+  //   icon: ...,
+  //   namespaced: <bool>    - if this object is in a namespace.
+  //   info: [...],          - list of metrics to render as info
+  //   relationships: [...], - list of one-to-many relationships for this kind.
+  //   metrics: [...],       - list of meaninful metrics for this kind.
+  // }
+  kinds: {
+    ConfigMap: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cm-128.png',
+      namespaced: true,
+      info: [
+        {
+          name: 'Created On',
+          type: 'datetime',
+          metric: 'kube_configmap_created',
         },
-        CronJob: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cronjob-128.png",
-            namespaced: true,
-            info: [
-                {
-                    name: 'Schedule',
-                    type: 'label',
-                    metric: 'kube_cronjob_info',
-                    label: 'schedule',
-                },
-                {
-                    name: 'Concurrency Policy',
-                    type: 'label',
-                    metric: 'kube_cronjob_info',
-                    label: 'concurrency_policy',
-                },
-            ],
-            relationships: [
-                // TODO find a metric to relate CronJobs to Jobs.
-            ],
+        {
+          name: 'Resource Version',
+          type: 'number',
+          metric: 'kube_configmap_metadata_resource_version',
         },
-        Deployment: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/deploy-128.png",
-            namespaced: true,
-            info: [
-                {
-                    name: "Created On",
-                    type: "datetime",
-                    metric: "kube_deployment_created",
-                },
-                {
-                    name: "Intended Replicas",
-                    type: "number",
-                    metric: "kube_deployment_spec_replicas",
-                },
-                {
-                    name: "Current Replicas",
-                    type: "number",
-                    metric: "kube_deployment_status_replicas",
-                },
-            ],
-            relationships: [
-                {
-                    one: 'Deployment',
-                    many: 'ReplicaSet',
-                    one_label: 'owner_name',
-                    metric: 'kube_replicaset_owner',
-                    filters: ['owner_is_controller="true"', 'owner_kind="Deployment"'],
-                },
-            ],
-        },
-        DaemonSet: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ds-128.png",
-            namespaced: true,
-            info: [],
-            relationships: [
-                {
-                    one: 'DaemonSet',
-                    many: 'Pod',
-                    one_label: 'owner_name',
-                    metric: 'kube_pod_owner',
-                    filters: ['owner_is_controller="true"', 'owner_kind="DaemonSet"'],
-                },
-            ],
-        },
-        Job: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/job-128.png",
-            namespaced: true,
-            info: [],
-            relationships: [
-                {
-                    one: 'Job',
-                    many: 'Pod',
-                    one_label: 'owner_name',
-                    metric: 'kube_pod_owner',
-                    filters: ['owner_is_controller="true"', 'owner_kind="Job"'],
-                },
-            ],
-        },
-        Namespace: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ns-128.png",
-            namespaced: false,
-            info: [
-                {
-                    name: 'Phase',
-                    type: 'label',
-                    metric: 'kube_namespace_status_phase',
-                    label: 'phase',
-                    value: 1,
-                },
-                {
-                    name: 'Created On',
-                    type: 'datetime',
-                    metric: 'kube_namespace_created',
-                },
-            ],
-            relationships: [
-                {
-                    one: 'Namespace',
-                    many: 'ConfigMap',
-                    metric: 'kube_configmap_info',
-                },
-                {
-                    one: 'Namespace',
-                    many: 'CronJob',
-                    metric: 'kube_cronjob_info',
-                },
-                {
-                    one: 'Namespace',
-                    many: 'DaemonSet',
-                    metric: 'kube_daemonset_labels',
-                },
-                {
-                    one: 'Namespace',
-                    many: 'Deployment',
-                    metric: 'kube_deployment_labels', // TODO no info metric?
-                },
-                {
-                    one: 'Namespace',
-                    many: 'StatefulSet',
-                    metric: 'kube_statefulset_labels',
-                },
-                {
-                    one: 'Namespace',
-                    many: 'Pod',
-                    metric: 'kube_pod_info',
-                },
-            ],
-        },
-        Node: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/infrastructure_components/unlabeled/node-128.png",
-            namespaced: false,
-            info: [
-                {
-                    name: 'Internal IP',
-                    type: 'label',
-                    metric: 'kube_node_info',
-                    label: 'internal_ip',
-                },
-                {
-                    name: 'Pod CIDR',
-                    type: 'label',
-                    metric: 'kube_node_info',
-                    label: 'pod_cidr ',
-                },
-                {
-                    name: 'Kubelet Version',
-                    type: 'label',
-                    metric: 'kube_node_info',
-                    label: 'kubelet_version',
-                },
-                {
-                    name: 'KubeProxy Version',
-                    type: 'label',
-                    metric: 'kube_node_info',
-                    label: 'kubeproxy_version',
-                },
-                {
-                    name: 'Kernel Version',
-                    type: 'label',
-                    metric: 'kube_node_info',
-                    label: 'kernel_version',
-                },
-            ],
-            relationships: [
-                 {
-                    one: 'Node',
-                    many: 'Pod',
-                    metric: 'kube_pod_info',
-                },
-            ],
-        },
-        Persistentvolumeclaims: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pvc-128.png",
-            namespaced: true,
-            info: [],
-            relationships: [],
-        },
-        Pod: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pod-128.png",
-            namespaced: true,
-            info: [
-                {
-                    name: 'Pod IP',
-                    type: 'label',
-                    metric: 'kube_pod_info',
-                    label: 'pod_ip',
-                },
-            ],
-            relationships: [
-                {
-                    one: 'Pod',
-                    many: 'Persistentvolumeclaims',
-                    metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
-                },
-            ],
-        },
-        ReplicaSet: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/rs-128.png",
-            namespaced: true,
-            info: [],
-            relationships: [
-                {
-                    one: 'ReplicaSet',
-                    many: 'Pod',
-                    one_label: 'owner_name',
-                    metric: 'kube_pod_owner',
-                    filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
-                },
-            ],
-        },
-        StatefulSet: {
-            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/sts-128.png",
-            namespaced: true,
-            info: [],
-            relationships: [
-                {
-                    one: 'StatefulSet',
-                    many: 'Pod',
-                    one_label: 'owner_name',
-                    metric: 'kube_pod_owner',
-                    filters: ['owner_is_controller="true"', 'owner_kind="StatefulSet"'],
-                },
-            ],
-        },
+      ],
+      relationships: [],
     },
+    CronJob: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/cronjob-128.png',
+      namespaced: true,
+      info: [
+        {
+          name: 'Schedule',
+          type: 'label',
+          metric: 'kube_cronjob_info',
+          label: 'schedule',
+        },
+        {
+          name: 'Concurrency Policy',
+          type: 'label',
+          metric: 'kube_cronjob_info',
+          label: 'concurrency_policy',
+        },
+      ],
+      relationships: [
+        // TODO find a metric to relate CronJobs to Jobs.
+      ],
+    },
+    Deployment: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/deploy-128.png',
+      namespaced: true,
+      info: [
+        {
+          name: 'Created On',
+          type: 'datetime',
+          metric: 'kube_deployment_created',
+        },
+        {
+          name: 'Intended Replicas',
+          type: 'number',
+          metric: 'kube_deployment_spec_replicas',
+        },
+        {
+          name: 'Current Replicas',
+          type: 'number',
+          metric: 'kube_deployment_status_replicas',
+        },
+      ],
+      relationships: [
+        {
+          one: 'Deployment',
+          many: 'ReplicaSet',
+          one_label: 'owner_name',
+          metric: 'kube_replicaset_owner',
+          filters: ['owner_is_controller="true"', 'owner_kind="Deployment"'],
+        },
+      ],
+    },
+    DaemonSet: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ds-128.png',
+      namespaced: true,
+      info: [],
+      relationships: [
+        {
+          one: 'DaemonSet',
+          many: 'Pod',
+          one_label: 'owner_name',
+          metric: 'kube_pod_owner',
+          filters: ['owner_is_controller="true"', 'owner_kind="DaemonSet"'],
+        },
+      ],
+    },
+    Job: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/job-128.png',
+      namespaced: true,
+      info: [],
+      relationships: [
+        {
+          one: 'Job',
+          many: 'Pod',
+          one_label: 'owner_name',
+          metric: 'kube_pod_owner',
+          filters: ['owner_is_controller="true"', 'owner_kind="Job"'],
+        },
+      ],
+    },
+    Namespace: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ns-128.png',
+      namespaced: false,
+      info: [
+        {
+          name: 'Phase',
+          type: 'label',
+          metric: 'kube_namespace_status_phase',
+          label: 'phase',
+          value: 1,
+        },
+        {
+          name: 'Created On',
+          type: 'datetime',
+          metric: 'kube_namespace_created',
+        },
+      ],
+      relationships: [
+        {
+          one: 'Namespace',
+          many: 'ConfigMap',
+          metric: 'kube_configmap_info',
+        },
+        {
+          one: 'Namespace',
+          many: 'CronJob',
+          metric: 'kube_cronjob_info',
+        },
+        {
+          one: 'Namespace',
+          many: 'DaemonSet',
+          metric: 'kube_daemonset_labels',
+        },
+        {
+          one: 'Namespace',
+          many: 'Deployment',
+          metric: 'kube_deployment_labels',  // TODO no info metric?
+        },
+        {
+          one: 'Namespace',
+          many: 'StatefulSet',
+          metric: 'kube_statefulset_labels',
+        },
+        {
+          one: 'Namespace',
+          many: 'Pod',
+          metric: 'kube_pod_info',
+        },
+      ],
+    },
+    Node: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/infrastructure_components/unlabeled/node-128.png',
+      namespaced: false,
+      info: [
+        {
+          name: 'Internal IP',
+          type: 'label',
+          metric: 'kube_node_info',
+          label: 'internal_ip',
+        },
+        {
+          name: 'Pod CIDR',
+          type: 'label',
+          metric: 'kube_node_info',
+          label: 'pod_cidr ',
+        },
+        {
+          name: 'Kubelet Version',
+          type: 'label',
+          metric: 'kube_node_info',
+          label: 'kubelet_version',
+        },
+        {
+          name: 'KubeProxy Version',
+          type: 'label',
+          metric: 'kube_node_info',
+          label: 'kubeproxy_version',
+        },
+        {
+          name: 'Kernel Version',
+          type: 'label',
+          metric: 'kube_node_info',
+          label: 'kernel_version',
+        },
+      ],
+      relationships: [
+        {
+          one: 'Node',
+          many: 'Pod',
+          metric: 'kube_pod_info',
+        },
+      ],
+    },
+    Persistentvolumeclaims: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pvc-128.png',
+      namespaced: true,
+      info: [],
+      relationships: [],
+    },
+    Pod: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pod-128.png',
+      namespaced: true,
+      info: [
+        {
+          name: 'Pod IP',
+          type: 'label',
+          metric: 'kube_pod_info',
+          label: 'pod_ip',
+        },
+      ],
+      relationships: [
+        {
+          one: 'Pod',
+          many: 'Persistentvolumeclaims',
+          metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
+        },
+      ],
+    },
+    ReplicaSet: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/rs-128.png',
+      namespaced: true,
+      info: [],
+      relationships: [
+        {
+          one: 'ReplicaSet',
+          many: 'Pod',
+          one_label: 'owner_name',
+          metric: 'kube_pod_owner',
+          filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
+        },
+      ],
+    },
+    StatefulSet: {
+      icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/sts-128.png',
+      namespaced: true,
+      info: [],
+      relationships: [
+        {
+          one: 'StatefulSet',
+          many: 'Pod',
+          one_label: 'owner_name',
+          metric: 'kube_pod_owner',
+          filters: ['owner_is_controller="true"', 'owner_kind="StatefulSet"'],
+        },
+      ],
+    },
+  },
 
-    relationships: std.flattenArrays([
-        $.kinds[k].relationships
-        for k in std.objectFields($.kinds)
-    ]),
+  relationships: std.flattenArrays([
+    $.kinds[k].relationships
+    for k in std.objectFields($.kinds)
+  ]),
 }

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -48,6 +48,20 @@
                 // TODO find a metric to relate CronJobs to Jobs.
             ],
         },
+        Deployment: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/deploy-128.png",
+            namespaced: true,
+            info: [],
+            relationships: [
+                {
+                    one: 'Deployment',
+                    many: 'ReplicaSet',
+                    one_label: 'owner_name',
+                    metric: 'kube_replicaset_owner',
+                    filters: ['owner_is_controller="true"', 'owner_kind="Deployment"'],
+                },
+            ],
+        },
         DaemonSet: {
             icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ds-128.png",
             namespaced: true,
@@ -79,7 +93,20 @@
         Namespace: {
             icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/ns-128.png",
             namespaced: false,
-            info: [],
+            info: [
+                {
+                    name: 'Phase',
+                    type: 'label',
+                    metric: 'kube_namespace_status_phase',
+                    label: 'phase',
+                    value: 1,
+                },
+                {
+                    name: 'Created On',
+                    type: 'datetime',
+                    metric: 'kube_namespace_created',
+                },
+            ],
             relationships: [
                 {
                     one: 'Namespace',

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -1,10 +1,57 @@
 {
+    info: {
+        ConfigMap: [
+            {
+                name: "Labels",
+                type: "labels",
+                prefix: "label_",
+                metric: "kube_configmap_labels"
+            },
+            {
+                name: "Annotations",
+                type: "labels",
+                prefix: "annotation_",
+                metrics: "kube_configmap_annotations",
+            },
+            {
+                name: "Created On",
+                type: "datetime",
+                metric: "kube_configmap_created"
+            },
+            {
+                name: "Resource Version",
+                type: "number",
+                metric: "kube_configmap_metadata_resource_version",
+            },
+        ],
+        Pod: [
+            {
+                name: "Labels",
+                type: "labels",
+                prefix: "label_",
+                metric: "kube_pod_labels"
+            },
+            {
+                name: "Annotations",
+                type: "labels",
+                prefix: "annotation_",
+                metrics: "kube_pod_annotations",
+            },
+        ],
+    },
+
     relationships: [
         {
             one: 'Namespace',
             many: 'Pod',
             metric: 'kube_pod_info',
         },
+        {
+            one: 'Namespace',
+            many: 'ConfigMap',
+            metric: 'kube_configmap_info',
+        },
+
         {
             one: 'Node',
             many: 'Pod',
@@ -14,13 +61,6 @@
             one: 'Pod',
             many: 'Persistentvolumeclaims',
             metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
-        },
-        {
-            one: 'ReplicaSet',
-            many: 'Pod',
-            one_label: 'owner_name',
-            metric: 'kube_pod_owner',
-            filters: ['owner_is_controller="true"', 'owner_kind="ReplicaSet"'],
         },
         {
             one: 'StatefulSet',

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -210,6 +210,13 @@
       namespaced: true,
       info: [
         {
+          name: 'Status',
+          type: 'label',
+          metric: 'kube_pod_status_phase',
+          label: 'phase',
+          value: 1,
+        },
+        {
           name: 'Pod IP',
           type: 'label',
           metric: 'kube_pod_info',
@@ -227,7 +234,18 @@
     ReplicaSet: {
       icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/rs-128.png',
       namespaced: true,
-      info: [],
+      info: [
+        {
+          name: 'Intended Replicas',
+          type: 'number',
+          metric: 'kube_replicaset_spec_replicas',
+        },
+        {
+          name: 'Current Replicas',
+          type: 'number',
+          metric: 'kube_replicaset_status_replicas',
+        },
+      ],
       relationships: [
         {
           one: 'ReplicaSet',
@@ -241,7 +259,23 @@
     StatefulSet: {
       icon: 'https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/sts-128.png',
       namespaced: true,
-      info: [],
+      info: [
+        {
+          name: 'Created On',
+          type: 'datetime',
+          metric: 'kube_statefulset_created',
+        },
+        {
+          name: 'Intended Replicas',
+          type: 'number',
+          metric: 'kube_statefulset_replicas',
+        },
+        {
+          name: 'Current Replicas',
+          type: 'number',
+          metric: 'kube_statefulset_status_replicas',
+        },
+      ],
       relationships: [
         {
           one: 'StatefulSet',

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -95,7 +95,38 @@
         },
         Node: {
             namespaced: false,
-            info: [],
+            info: [
+                {
+                    name: 'Internal IP',
+                    type: 'label',
+                    metric: 'kube_node_info',
+                    label: 'internal_ip',
+                },
+                {
+                    name: 'Pod CIDR',
+                    type: 'label',
+                    metric: 'kube_node_info',
+                    label: 'pod_cidr ',
+                },
+                {
+                    name: 'Kubelet Version',
+                    type: 'label',
+                    metric: 'kube_node_info',
+                    label: 'kubelet_version',
+                },
+                {
+                    name: 'KubeProxy Version',
+                    type: 'label',
+                    metric: 'kube_node_info',
+                    label: 'kubeproxy_version',
+                },
+                {
+                    name: 'Kernel Version',
+                    type: 'label',
+                    metric: 'kube_node_info',
+                    label: 'kernel_version',
+                },
+            ],
             relationships: [
                  {
                     one: 'Node',

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -51,7 +51,23 @@
         Deployment: {
             icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/deploy-128.png",
             namespaced: true,
-            info: [],
+            info: [
+                {
+                    name: "Created On",
+                    type: "datetime",
+                    metric: "kube_deployment_created",
+                },
+                {
+                    name: "Intended Replicas",
+                    type: "number",
+                    metric: "kube_deployment_spec_replicas",
+                },
+                {
+                    name: "Current Replicas",
+                    type: "number",
+                    metric: "kube_deployment_status_replicas",
+                },
+            ],
             relationships: [
                 {
                     one: 'Deployment',

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -1,0 +1,201 @@
+local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
+local layout = import 'github.com/grafana/grafonnet-lib/contrib/layout.libsonnet';
+
+local relationships = [
+    {
+        one: 'Namespace',
+        many: 'Pod',
+        metric: 'kube_pod_info',
+    },
+    {
+        one: 'Node',
+        many: 'Pod',
+        metric: 'kube_pod_info',
+    },
+    {
+        one: 'Pod',
+        many: 'Persistentvolumeclaims',
+        metric: 'kube_pod_spec_volumes_persistentvolumeclaims_info',
+    },
+    {
+        one: 'ReplicaSet',
+        many: 'Pod',
+        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="ReplicaSet"}',
+    },
+    {
+        one: 'StatefulSet',
+        many: 'Pod',
+        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="StatefulSet"}',
+    },
+    {
+        one: 'ReplicaSet',
+        many: 'Pod',
+        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="ReplicaSet"}',
+    },
+    {
+        one: 'Job',
+        many: 'Pod',
+        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="Job"}',
+    },
+    {
+        one: 'DaemonSet',
+        many: 'Pod',
+        metric: 'kube_pod_owner{owner_is_controller="true", owner_kind="DaemonSet"}',
+    },
+];
+
+local kinds = std.set(
+    [r.one for r in relationships] +
+    [r.many for r in relationships]
+);
+
+local textPanel(text) = {
+  type: 'text',
+  title: text,
+  gridPos: {
+    w: 8,
+    h: 1
+  },
+  transparent: true,
+  options: {
+    mode: "markdown",
+    content: ""
+  },
+};
+
+local labelPanel(query, label) = {
+  type: "stat",
+  gridPos: {
+    "w": 16,
+    "h": 1
+  },
+  transformations: [],
+  datasource: '$datasource',
+  targets: [
+    {
+      "expr": query,
+      "legendFormat": '{{%s}}' % label,
+      "interval": "",
+      "exemplar": false,
+      "refId": "A",
+      "datasource": "$datasource",
+      "instant": true,
+    }
+  ],
+  options: {
+    "reduceOptions": {
+      "values": true,
+      "calcs": [
+        "lastNotNull"
+      ],
+      "fields": ""
+    },
+    "orientation": "auto",
+    "textMode": "name",
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "text": {
+      "valueSize": 18
+    }
+  },
+  fieldConfig: {
+    "defaults": {
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "text",
+            "value": null
+          }
+        ]
+      },
+      "mappings": [],
+      "color": {
+        "mode": "thresholds"
+      }
+    },
+    "overrides": []
+  },
+};
+
+local manyToOne(d, many) =
+    std.foldl(function(d, r)
+        local oneLabel = std.asciiLower(r.one);
+        local manyLabel = std.asciiLower(r.many);
+
+        if r.many != many
+        then d
+        else d
+            .addPanel(textPanel(r.one))
+            .addPanel(labelPanel('group by (%s) (%s{%s="$%s"})' % [oneLabel, r.metric, manyLabel, manyLabel], oneLabel))
+            .nextRow(),
+    relationships, d);
+
+{
+  local dashboard(name) =
+    g.dashboard.new(title=name, refresh='5m', uid=std.md5(name))
+    .setTime(from='now-1h', to='now')
+    .addTemplate(
+      g.template.datasource.new(name='datasource', query='prometheus')
+      .setCurrent(text='default', value='default')
+    )
+    .addTemplate(
+      g.template.query.new(
+        allValue='.+',
+        datasource='${datasource}',
+        includeAll=true,
+        label='cluster',
+        name='cluster',
+        query='label_values(up{%(kubeStateMetricsSelector)s}, %(clusterLabel)s)' % $._config,
+        refresh=1,
+        regex='',
+      )
+      .setCurrent(selected=true, text=['All'], value=['$__all'])
+    )
+    .addTemplate(
+      g.template.query.new(
+        allValue='.+',
+        datasource='${datasource}',
+        includeAll=true,
+        label='namespace',
+        name='namespace',
+        query='label_values(kube_namespace_created{%(clusterLabel)s="$cluster"}, namespace)' % $._config.clusterLabel,
+        refresh=1,
+        regex='',
+      )
+      .setCurrent(selected=true, text=['All'], value=['$__all'])
+    ) + layout,
+
+    local dashboardForKind(kind) =
+        local kindLabel = std.asciiLower(kind);
+        local d =
+            dashboard('Explore / %s' % kind)
+            .addTemplate(
+                g.template.query.new(
+                    datasource='${datasource}',
+                    label=kindLabel,
+                    name=kindLabel,
+                    query='',
+                )
+            )
+            .addPanel({
+                collapsed: false,
+                datasource: null,
+                gridPos: {
+                    h: 1,
+                    w: 24,
+                },
+                id: 25,
+                panels: [],
+                title: kind,
+                type: 'row',
+            })
+            .nextRow();
+        manyToOne(d, kind),
+
+    grafanaDashboards: {
+        ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
+        for kind in std.trace(std.toString(kinds), kinds)
+    },
+}

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -199,6 +199,12 @@
                 },
             ],
         },
+        Persistentvolumeclaims: {
+            icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pvc-128.png",
+            namespaced: true,
+            info: [],
+            relationships: [],
+        },
         Pod: {
             icon: "https://github.com/kubernetes/community/raw/master/icons/png/resources/unlabeled/pod-128.png",
             namespaced: true,

--- a/dashboards/model/model.libsonnet
+++ b/dashboards/model/model.libsonnet
@@ -94,17 +94,17 @@
                 {
                     one: 'Namespace',
                     many: 'DaemonSet',
-                    metric: 'kube_daemonset_info',
+                    metric: 'kube_daemonset_labels',
                 },
                 {
                     one: 'Namespace',
                     many: 'Deployment',
-                    metric: 'kube_deployment_info',
+                    metric: 'kube_deployment_labels', // TODO no info metric?
                 },
                 {
                     one: 'Namespace',
                     many: 'StatefulSet',
-                    metric: 'kube_statefulset_info',
+                    metric: 'kube_statefulset_labels',
                 },
                 {
                     one: 'Namespace',

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -205,10 +205,10 @@ local addRelationships(kind) =
                   d),
     ]);
 
-local dashboardForKind(kind) =
+local dashboardForKind(kind, config) =
   local kindLabel = std.asciiLower(kind);
 
-  c.dashboard(kind).chain([
+  c.dashboard(kind, config).chain([
     if model.kinds[kind].namespaced
     then c.addTemplate('namespace'),
     headerPanel(kind),
@@ -222,8 +222,8 @@ local dashboardForKind(kind) =
 {
   grafanaDashboardFolder: 'Kubernetes Explore',
 
-  grafanaDashboards+: {
-    ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
+  grafanaDashboards+:: {
+    ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind, $._config)
     for kind in std.objectFields(model.kinds)
   },
 }

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -27,29 +27,29 @@ local headerPanel(kind) =
     });
 
 local headerPanel(kind) =
-    local kindLabel = std.asciiLower(kind);
-    local icon = model.kinds[kind].icon;
-    function(d)
-        d.addPanel({
-            "gridPos": {
-                "w": 24,
-                "h": 2
-            },
-            "type": "text",
-            "options": {
-                "mode": "html",
-                "content": |||
-                    <div style="padding: 0px;">
-                        <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
-                            <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
-                            <h1 style="margin-top: 5px;">%s: $%s</h1>
-                        </div>
-                    </div>
-                ||| % [icon, kind, kind, kindLabel],
-            },
-            "transparent": true,
-            "datasource": null
-        });
+  local kindLabel = std.asciiLower(kind);
+  local icon = model.kinds[kind].icon;
+  function(d)
+    d.addPanel({
+      gridPos: {
+        w: 24,
+        h: 2,
+      },
+      type: 'text',
+      options: {
+        mode: 'html',
+        content: |||
+          <div style="padding: 0px;">
+              <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
+                  <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
+                  <h1 style="margin-top: 5px;">%s: $%s</h1>
+              </div>
+          </div>
+        ||| % [icon, kind, kind, kindLabel],
+      },
+      transparent: true,
+      datasource: null,
+    });
 
 local infoPanel(kind, info) =
   local kindLabel = std.asciiLower(kind);

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -26,31 +26,6 @@ local headerPanel(kind) =
       datasource: null,
     });
 
-local headerPanel(kind) =
-  local kindLabel = std.asciiLower(kind);
-  local icon = model.kinds[kind].icon;
-  function(d)
-    d.addPanel({
-      gridPos: {
-        w: 24,
-        h: 2,
-      },
-      type: 'text',
-      options: {
-        mode: 'html',
-        content: |||
-          <div style="padding: 0px;">
-              <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
-                  <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
-                  <h1 style="margin-top: 5px;">%s: $%s</h1>
-              </div>
-          </div>
-        ||| % [icon, kind, kind, kindLabel],
-      },
-      transparent: true,
-      datasource: null,
-    });
-
 local infoPanel(kind, info) =
   local kindLabel = std.asciiLower(kind);
   local filters = [

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -222,7 +222,7 @@ local dashboardForKind(kind) =
 {
   grafanaDashboardFolder: 'Kubernetes Explore',
 
-  grafanaDashboards: {
+  grafanaDashboards+: {
     ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
     for kind in std.objectFields(model.kinds)
   },

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -30,9 +30,14 @@ local headerPanel(kind) =
 local infoPanel(kind, info) =
     local kindLabel = std.asciiLower(kind);
     {
-        'datetime': null,
-        'label': c.addLabelPanel('%s{%s="$%s"}' % [info.metric, kindLabel, kindLabel], info.label),
-        'number': null,
+        'datetime':
+            c.addDatetimePanel('%s{cluster="$cluster", %s="$%s"} * 1e3' % [info.metric, kindLabel, kindLabel]),
+        'label':
+            if 'value' in info
+            then c.addLabelPanel('%s{cluster="$cluster", %s="$%s"} == %d' % [info.metric, kindLabel, kindLabel, info.value], info.label)
+            else c.addLabelPanel('%s{cluster="$cluster", %s="$%s"}' % [info.metric, kindLabel, kindLabel], info.label),
+        'number':
+            c.addNumberPanel('%s{cluster="$cluster", %s="$%s"}' % [info.metric, kindLabel, kindLabel]),
     }[info.type];
 
 local infoRows(kind) =

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -26,6 +26,31 @@ local headerPanel(kind) =
       datasource: null,
     });
 
+local headerPanel(kind) =
+    local kindLabel = std.asciiLower(kind);
+    local icon = model.kinds[kind].icon;
+    function(d)
+        d.addPanel({
+            "gridPos": {
+                "w": 24,
+                "h": 2
+            },
+            "type": "text",
+            "options": {
+                "mode": "html",
+                "content": |||
+                    <div style="padding: 0px;">
+                        <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
+                            <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
+                            <h1 style=\"margin-top: 5px;\">%s: $%s</h1>
+                        </div>
+                    </div>
+                ||| % [icon, kind, kind, kindLabel],
+            },
+            "transparent": true,
+            "datasource": null
+        });
+
 local infoPanel(kind, info) =
   local kindLabel = std.asciiLower(kind);
   local filters = [

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -42,7 +42,7 @@ local headerPanel(kind) =
                     <div style="padding: 0px;">
                         <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
                             <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
-                            <h1 style=\"margin-top: 5px;\">%s: $%s</h1>
+                            <h1 style="margin-top: 5px;">%s: $%s</h1>
                         </div>
                     </div>
                 ||| % [icon, kind, kind, kindLabel],

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -1,0 +1,45 @@
+local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
+local model = import "model.libsonnet";
+local c = import "common.libsonnet";
+
+local manyToOne(many) =
+    function(d)
+        std.foldl(function(d, r)
+            local manyLabel = std.asciiLower(r.many);
+            local oneLabel =
+                if 'one_label' in r
+                then r.one_label
+                else std.asciiLower(r.one);
+            local manyFilter = '%s="$%s"' % [manyLabel, manyLabel];
+            local filters =
+                if 'filters' in r
+                then r.filters + [manyFilter]
+                else [manyFilter];
+            local query = 'group by (%s) (%s{%s})' % [oneLabel, r.metric, std.join(',', filters)];
+            local link = "/grafana/d/%s/explore-%s?var-%s=${__series.name}" % [std.md5(r.one), std.asciiLower(r.one), std.asciiLower(r.one)];
+
+            if r.many == many
+            then d.chain([
+                c.addTextPanel(r.one),
+                c.addLabelPanel(query, oneLabel, link=link),
+                c.nextRow,
+            ])
+            else d,
+        model.relationships, d);
+
+{
+    local dashboardForKind(kind) =
+        local kindLabel = std.asciiLower(kind);
+
+        c.dashboard(kind).chain([
+            c.addTemplate('namespace'),
+            c.addTemplate(kindLabel),
+            c.addRow('Related Objects'),
+            manyToOne(kind)
+        ]),
+
+    grafanaDashboards: {
+        ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
+        for kind in model.kinds
+    },
+}

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -1,5 +1,4 @@
 local c = import 'common.libsonnet';
-local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
 local model = import 'model.libsonnet';
 
 local headerPanel(kind) =

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -2,6 +2,35 @@ local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonn
 local model = import "model.libsonnet";
 local c = import "common.libsonnet";
 
+local infoPanel(kind, info) =
+    local kindLabel = std.asciiLower(kind);
+    {
+        'datetime': null,
+        'label': c.addLabelPanel('%s{%s="$%s"}' % [info.metric, kindLabel, kindLabel], info.label),
+        'number': null,
+    }[info.type];
+
+local infoRows(kind) =
+    function(d)
+        local kindLabel = std.asciiLower(kind);
+        local d2 = d.chain([
+            c.addTextPanel('Name'),
+            c.addLabelPanel('kube_%s_info{%s="$%s"}' % [kindLabel, kindLabel, kindLabel], kindLabel),
+            c.nextRow,
+            c.addTextPanel('Labels'),
+            c.addLabelTablePanel('kube_%s_labels{%s="$%s"}' % [kindLabel, kindLabel, kindLabel], "label_.+"),
+            c.nextRow,
+            c.addTextPanel('Annotations'),
+            c.addLabelTablePanel('kube_%s_annotations{%s="$%s"}' % [kindLabel, kindLabel, kindLabel], "annotations_.+"),
+            c.nextRow,
+        ]);
+        std.foldl(function(d, i)
+            d.chain([
+                c.addTextPanel(i.name),
+                infoPanel(kind, i),
+                c.nextRow,
+            ]), model.kinds[kind].info, d2);
+
 // eg manyToOne(pod) adds rows for namespace, node, statefulset etc...
 local manyToOne(many) =
     function(d)
@@ -11,11 +40,15 @@ local manyToOne(many) =
                 if 'one_label' in r
                 then r.one_label
                 else std.asciiLower(r.one);
-            local manyFilter = '%s="$%s"' % [manyLabel, manyLabel];
+            local namespaceFilter =
+                if model.kinds[r.one].namespaced
+                then ['namespace="$namespace"']
+                else [];
+            local manyFilter = ['%s="$%s"' % [manyLabel, manyLabel]];
             local filters =
                 if 'filters' in r
-                then r.filters + [manyFilter]
-                else [manyFilter];
+                then r.filters + namespaceFilter + manyFilter
+                else namespaceFilter + manyFilter;
             local query = 'group by (%s) (%s{%s})' % [oneLabel, r.metric, std.join(',', filters)];
             local link = "/grafana/d/%s/explore-%s?var-%s=${__series.name}" % [std.md5(r.one), std.asciiLower(r.one), std.asciiLower(r.one)];
 
@@ -59,8 +92,11 @@ local oneToMany(one) =
         local kindLabel = std.asciiLower(kind);
 
         c.dashboard(kind).chain([
-            c.addTemplate('namespace'),
+            if model.kinds[kind].namespaced
+            then c.addTemplate('namespace'),
             c.addTemplate(kindLabel),
+            c.addRow('Info'),
+            infoRows(kind),
             c.addRow('Related Objects'),
             manyToOne(kind),
             oneToMany(kind),
@@ -68,6 +104,6 @@ local oneToMany(one) =
 
     grafanaDashboards: {
         ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
-        for kind in model.kinds
+        for kind in std.objectFields(model.kinds)
     },
 }

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -23,7 +23,7 @@ local headerPanel(kind) =
         ||| % [icon, kind, kind, kindLabel],
       },
       transparent: true,
-      datasource: null,
+      datasource: '$datasource',
     });
 
 local infoPanel(kind, info) =

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -128,7 +128,7 @@ local addRelationships(kind) =
       'var-%s=${__field.labels.%s}' % [oneVar, oneLabel],
     ];
 
-    local link = '/d/%s/explore-%s?%s' % [std.md5(r.one), oneVar, std.join('&', linkVars)];
+    local link = '/d/%s/explore-%s?%s' % [std.md5('model-%s.json' % oneVar), oneVar, std.join('&', linkVars)];
 
     d.chain([
       c.addLinkPanel(r.one, r.one),
@@ -179,7 +179,7 @@ local addRelationships(kind) =
       'var-%s=${__data.fields.%s}' % [manyLabel, manyLabel],
     ];
 
-    local link = '/d/%s/explore-%s?%s' % [std.md5(r.many), manyLabel, std.join('&', linkVars)];
+    local link = '/d/%s/explore-%s?%s' % [std.md5('model-%s.json' % manyLabel), manyLabel, std.join('&', linkVars)];
 
     d.chain([
       c.addLinkPanel(r.many, r.many + '(s)', height=4),
@@ -210,9 +210,9 @@ local dashboardForKind(kind, config) =
 
   c.dashboard(kind, config).chain([
     if model.kinds[kind].namespaced
-    then c.addTemplate('namespace'),
+    then c.addTemplate('namespace', config),
     headerPanel(kind),
-    c.addTemplate(kindLabel),
+    c.addTemplate(kindLabel, config),
     c.addRow('Info'),
     infoRows(kind),
     c.addRow('Related Objects'),

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -53,16 +53,16 @@ local infoRows(kind) =
     local kindLabel = std.asciiLower(kind);
     local d2 = d.chain([
       c.nextRow,
-      c.addTextPanel('Labels'),
+      c.addTextPanel('## Labels'),
       c.addLabelTablePanel('kube_%s_labels{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], 'label_.+'),
       c.nextRow,
-      c.addTextPanel('Annotations'),
+      c.addTextPanel('## Annotations'),
       c.addLabelTablePanel('kube_%s_annotations{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], 'annotations_.+'),
       c.nextRow,
     ]);
     std.foldl(function(d, i)
       d.chain([
-        c.addTextPanel(i.name),
+        c.addTextPanel('## %s' % i.name),
         infoPanel(kind, i),
         c.nextRow,
       ]), model.kinds[kind].info, d2);

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -93,7 +93,7 @@ local oneToMany(one) =
                 if 'one_label' in r
                 then r.one_label
                 else std.asciiLower(r.one);
-            local oneFilter = '%s="$%s"' % [oneLabel, oneLabel];
+            local oneFilter = '%s="$%s"' % [oneLabel, std.asciiLower(r.one)];
             local filters =
                 if 'filters' in r
                 then r.filters + [oneFilter]

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -131,7 +131,7 @@ local addRelationships(kind) =
     local link = '/d/%s/explore-%s?%s' % [std.md5(r.one), oneVar, std.join('&', linkVars)];
 
     d.chain([
-      c.addTextPanel(r.one),
+      c.addLinkPanel(r.one, r.one),
       c.addLabelPanel(query, oneLabel, link=link),
       c.nextRow,
     ]);
@@ -182,7 +182,7 @@ local addRelationships(kind) =
     local link = '/d/%s/explore-%s?%s' % [std.md5(r.many), manyLabel, std.join('&', linkVars)];
 
     d.chain([
-      c.addTextPanel(r.many + '(s)', height=4),
+      c.addLinkPanel(r.many, r.many + '(s)', height=4),
       c.addTablePanel(query, manyLabel, link=link),
       c.nextRow,
     ]);

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -1,186 +1,188 @@
+local c = import 'common.libsonnet';
 local g = import 'github.com/grafana/grafonnet-lib/grafonnet-7.0/grafana.libsonnet';
-local model = import "model.libsonnet";
-local c = import "common.libsonnet";
+local model = import 'model.libsonnet';
 
 local headerPanel(kind) =
-    local kindLabel = std.asciiLower(kind);
-    local icon = model.kinds[kind].icon;
-    function(d)
-        d.addPanel({
-            "gridPos": {
-                "w": 24,
-                "h": 2
-            },
-            "type": "text",
-            "options": {
-                "mode": "html",
-                "content": |||
-                    <div style="padding: 0px;">
-                        <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
-                            <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
-                            <h1 style="margin-top: 5px;">%s: $%s</h1>
-                        </div>
-                    </div>
-                ||| % [icon, kind, kind, kindLabel],
-            },
-            "transparent": true,
-            "datasource": null
-        });
+  local kindLabel = std.asciiLower(kind);
+  local icon = model.kinds[kind].icon;
+  function(d)
+    d.addPanel({
+      gridPos: {
+        w: 24,
+        h: 2,
+      },
+      type: 'text',
+      options: {
+        mode: 'html',
+        content: |||
+          <div style="padding: 0px;">
+              <div style="display: flex; flex-direction: row; align-items: center; margin-top: 0px;">
+                  <img style="height: 48px; width: 48px; margin-right: 10px;" src="%s" alt="%s"/>
+                  <h1 style="margin-top: 5px;">%s: $%s</h1>
+              </div>
+          </div>
+        ||| % [icon, kind, kind, kindLabel],
+      },
+      transparent: true,
+      datasource: null,
+    });
 
 local infoPanel(kind, info) =
-    local kindLabel = std.asciiLower(kind);
-    local filters = [
-        'cluster="$cluster"',
-        if model.kinds[kind].namespaced
-        then 'namespace="$namespace"'
-        else null,
-        '%s="$%s"' % [kindLabel, kindLabel],
-    ];
-    local selector = std.join(',', [f for f in filters if f != null]);
-    {
-        'datetime':
-            c.addDatetimePanel('%s{%s} * 1e3' % [info.metric, selector]),
-        'label':
-            if 'value' in info
-            then c.addLabelPanel('%s{%s} == %d' % [info.metric, selector, info.value], info.label)
-            else c.addLabelPanel('%s{%s}' % [info.metric, selector], info.label),
-        'number':
-            c.addNumberPanel('%s{%s}' % [info.metric, selector]),
-    }[info.type];
+  local kindLabel = std.asciiLower(kind);
+  local filters = [
+    'cluster="$cluster"',
+    if model.kinds[kind].namespaced
+    then 'namespace="$namespace"'
+    else null,
+    '%s="$%s"' % [kindLabel, kindLabel],
+  ];
+  local selector = std.join(',', [f for f in filters if f != null]);
+  {
+    datetime:
+      c.addDatetimePanel('%s{%s} * 1e3' % [info.metric, selector]),
+    label:
+      if 'value' in info
+      then c.addLabelPanel('%s{%s} == %d' % [info.metric, selector, info.value], info.label)
+      else c.addLabelPanel('%s{%s}' % [info.metric, selector], info.label),
+    number:
+      c.addNumberPanel('%s{%s}' % [info.metric, selector]),
+  }[info.type];
 
 local infoRows(kind) =
-    function(d)
-        local kindLabel = std.asciiLower(kind);
-        local d2 = d.chain([
-            c.nextRow,
-            c.addTextPanel('Labels'),
-            c.addLabelTablePanel('kube_%s_labels{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], "label_.+"),
-            c.nextRow,
-            c.addTextPanel('Annotations'),
-            c.addLabelTablePanel('kube_%s_annotations{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], "annotations_.+"),
-            c.nextRow,
-        ]);
-        std.foldl(function(d, i)
-            d.chain([
-                c.addTextPanel(i.name),
-                infoPanel(kind, i),
-                c.nextRow,
-            ]), model.kinds[kind].info, d2);
+  function(d)
+    local kindLabel = std.asciiLower(kind);
+    local d2 = d.chain([
+      c.nextRow,
+      c.addTextPanel('Labels'),
+      c.addLabelTablePanel('kube_%s_labels{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], 'label_.+'),
+      c.nextRow,
+      c.addTextPanel('Annotations'),
+      c.addLabelTablePanel('kube_%s_annotations{cluster="$cluster", %s="$%s"}' % [kindLabel, kindLabel, kindLabel], 'annotations_.+'),
+      c.nextRow,
+    ]);
+    std.foldl(function(d, i)
+      d.chain([
+        c.addTextPanel(i.name),
+        infoPanel(kind, i),
+        c.nextRow,
+      ]), model.kinds[kind].info, d2);
 
 // addRelationships adds rows (linking the current king to other kind) to d.
 local addRelationships(kind) =
-    local addSingularLinks(d, r) =
-        local manyLabel = std.asciiLower(r.many);
+  local addSingularLinks(d, r) =
+    local manyLabel = std.asciiLower(r.many);
 
-        // Some relationships don't use the actual name of the type for
-        // the 'one' side of the link (they use owner_name).
-        local oneLabel =
-            if 'one_label' in r
-            then r.one_label
-            else std.asciiLower(r.one);
+    // Some relationships don't use the actual name of the type for
+    // the 'one' side of the link (they use owner_name).
+    local oneLabel =
+      if 'one_label' in r
+      then r.one_label
+      else std.asciiLower(r.one);
 
-        // If the 'one' side of the relationships (eg pod -> controller) is
-        // namespaced, we need to group by that label to enrich the link.
-        local groupLabels =
-            if model.kinds[r.one].namespaced
-            then ['namespace', oneLabel]
-            else [oneLabel];
+    // If the 'one' side of the relationships (eg pod -> controller) is
+    // namespaced, we need to group by that label to enrich the link.
+    local groupLabels =
+      if model.kinds[r.one].namespaced
+      then ['namespace', oneLabel]
+      else [oneLabel];
 
-        // I'm the 'many' side of the relationship; if I'm namespaced, we
-        // need to include that in the selectors.
-        local selectors =
-            [
-                'cluster="$cluster"',
-                '%s="$%s"' % [manyLabel, manyLabel],
-            ] +
-            (if model.kinds[r.many].namespaced
-            then ['namespace="$namespace"']
-            else []) +
-            (if 'filters' in r
-            then r.filters
-            else []);
+    // I'm the 'many' side of the relationship; if I'm namespaced, we
+    // need to include that in the selectors.
+    local selectors =
+      [
+        'cluster="$cluster"',
+        '%s="$%s"' % [manyLabel, manyLabel],
+      ] +
+      (if model.kinds[r.many].namespaced
+       then ['namespace="$namespace"']
+       else []) +
+      (if 'filters' in r
+       then r.filters
+       else []);
 
-        local query = 'group by (%s) (%s{%s})' % [std.join(',', groupLabels), r.metric, std.join(',', selectors)];
-        local link = "/d/%s/explore-%s?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-%s=${__series.name}" % [std.md5(r.one), std.asciiLower(r.one), std.asciiLower(r.one)];
+    local query = 'group by (%s) (%s{%s})' % [std.join(',', groupLabels), r.metric, std.join(',', selectors)];
+    local link = '/d/%s/explore-%s?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-%s=${__series.name}' % [std.md5(r.one), std.asciiLower(r.one), std.asciiLower(r.one)];
 
-        d.chain([
-            c.addTextPanel(r.one),
-            c.addLabelPanel(query, oneLabel, link=link),
-            c.nextRow,
-        ]);
-
-    local addListLinks(d, r) =
-        local manyLabel = std.asciiLower(r.many);
-
-        // Some relationships don't use the actual name of the type for the one side of the link (they use owner_name).
-        local oneLabel =
-            if 'one_label' in r
-            then r.one_label
-            else std.asciiLower(r.one);
-
-        // If the many (eg node -> pods) are namespace, we need to group by that label to enrich the link.
-        local groupLabels =
-            if model.kinds[r.many].namespaced
-            then ['namespace', manyLabel]
-            else [manyLabel];
-
-        // If the one (eg pod -> controller) is namespace, we need to include that in the selectors.
-        local selectors =
-            [
-                'cluster="$cluster"',
-                '%s="$%s"' % [oneLabel, std.asciiLower(r.one)],
-            ] +
-            (if model.kinds[r.one].namespaced
-            then ['namespace="$namespace"']
-            else []) +
-            (if 'filters' in r
-            then r.filters
-            else []);
-
-        local query = 'group by (%s) (%s{%s})' % [std.join(',', groupLabels), r.metric, std.join(',', selectors)];
-        local link = "/d/%s/explore-%s?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-%s=${__data.fields.%s}" % [std.md5(r.many), std.asciiLower(r.many), std.asciiLower(r.many), manyLabel];
-
-        d.chain([
-            c.addTextPanel(r.many + '(s)', height=4),
-            c.addTablePanel(query, manyLabel, link=link),
-            c.nextRow,
-        ]);
-
-    function(d)
-        d.chain([
-            function(d)
-                std.foldl(function(d, r)
-                        if r.many == kind
-                        then addSingularLinks(d, r)
-                        else d,
-                    model.relationships, d),
-            function(d)
-                std.foldl(function(d, r)
-                        if r.one == kind
-                        then addListLinks(d, r)
-                        else d,
-                    model.relationships, d),
-        ]);
-
-local dashboardForKind(kind) =
-    local kindLabel = std.asciiLower(kind);
-
-    c.dashboard(kind).chain([
-        if model.kinds[kind].namespaced
-        then c.addTemplate('namespace'),
-        headerPanel(kind),
-        c.addTemplate(kindLabel),
-        c.addRow('Info'),
-        infoRows(kind),
-        c.addRow('Related Objects'),
-        addRelationships(kind),
+    d.chain([
+      c.addTextPanel(r.one),
+      c.addLabelPanel(query, oneLabel, link=link),
+      c.nextRow,
     ]);
 
-{
-    grafanaDashboardFolder: "Kubernetes Explore",
+  local addListLinks(d, r) =
+    local manyLabel = std.asciiLower(r.many);
 
-    grafanaDashboards: {
-        ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
-        for kind in std.objectFields(model.kinds)
-    },
+    // Some relationships don't use the actual name of the type for the one side of the link (they use owner_name).
+    local oneLabel =
+      if 'one_label' in r
+      then r.one_label
+      else std.asciiLower(r.one);
+
+    // If the many (eg node -> pods) are namespace, we need to group by that label to enrich the link.
+    local groupLabels =
+      if model.kinds[r.many].namespaced
+      then ['namespace', manyLabel]
+      else [manyLabel];
+
+    // If the one (eg pod -> controller) is namespace, we need to include that in the selectors.
+    local selectors =
+      [
+        'cluster="$cluster"',
+        '%s="$%s"' % [oneLabel, std.asciiLower(r.one)],
+      ] +
+      (if model.kinds[r.one].namespaced
+       then ['namespace="$namespace"']
+       else []) +
+      (if 'filters' in r
+       then r.filters
+       else []);
+
+    local query = 'group by (%s) (%s{%s})' % [std.join(',', groupLabels), r.metric, std.join(',', selectors)];
+    local link = '/d/%s/explore-%s?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}&var-%s=${__data.fields.%s}' % [std.md5(r.many), std.asciiLower(r.many), std.asciiLower(r.many), manyLabel];
+
+    d.chain([
+      c.addTextPanel(r.many + '(s)', height=4),
+      c.addTablePanel(query, manyLabel, link=link),
+      c.nextRow,
+    ]);
+
+  function(d)
+    d.chain([
+      function(d)
+        std.foldl(function(d, r)
+                    if r.many == kind
+                    then addSingularLinks(d, r)
+                    else d,
+                  model.relationships,
+                  d),
+      function(d)
+        std.foldl(function(d, r)
+                    if r.one == kind
+                    then addListLinks(d, r)
+                    else d,
+                  model.relationships,
+                  d),
+    ]);
+
+local dashboardForKind(kind) =
+  local kindLabel = std.asciiLower(kind);
+
+  c.dashboard(kind).chain([
+    if model.kinds[kind].namespaced
+    then c.addTemplate('namespace'),
+    headerPanel(kind),
+    c.addTemplate(kindLabel),
+    c.addRow('Info'),
+    infoRows(kind),
+    c.addRow('Related Objects'),
+    addRelationships(kind),
+  ]);
+
+{
+  grafanaDashboardFolder: 'Kubernetes Explore',
+
+  grafanaDashboards: {
+    ['model-%s.json' % std.asciiLower(kind)]: dashboardForKind(kind)
+    for kind in std.objectFields(model.kinds)
+  },
 }

--- a/dashboards/model/object-dashboard.libsonnet
+++ b/dashboards/model/object-dashboard.libsonnet
@@ -43,7 +43,7 @@ local oneToMany(one) =
                 then r.filters + [oneFilter]
                 else [oneFilter];
             local query = 'group by (%s) (%s{%s})' % [manyLabel, r.metric, std.join(',', filters)];
-            local link = "/grafana/d/%s/explore-%s?var-%s=${__series.name}" % [std.md5(r.many), std.asciiLower(r.many), std.asciiLower(r.many)];
+            local link = "/grafana/d/%s/explore-%s?var-%s=${__data.fields.%s}" % [std.md5(r.many), std.asciiLower(r.many), std.asciiLower(r.many), manyLabel];
 
             if r.one == one
             then d.chain([

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -5,7 +5,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet-lib.git",
-          "subdir": "grafonnet"
+          "subdir": ""
         }
       },
       "version": "master"


### PR DESCRIPTION
This PR includes code to generate a series of interlinked dashboards that allow you to navigate your application's structure inside Kubernetes.  

https://user-images.githubusercontent.com/444037/139424696-a09a94e6-9dc0-424b-9512-5e7134afb2a8.mp4

This is very much a prototype right now.  I do not see this replacing the existing interlinked resource analysis dashboards, but rather complementing (and linking to) them.  If we decide to go in this direction, we might want to combine this with the some of the existing dashboards (eg the persistent volumes one)

WDYT?

TODO
- [ ] Add PersistentVolumes
- [ ] Add metrics
- [ ] Tighten up the dashboard layout a bit.
- [ ] Template out various things in line with the rest of the mixin