### PR TITLE
Use kube_namespace_status_phase metric as namespace selector in dashboards

### DIFF
--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -20,7 +20,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_namespace_created{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
+        query='label_values(kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
         current='',
         hide='',
         refresh=2,

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -20,7 +20,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_namespace_created{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
+        query='label_values(kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
         current='',
         hide='',
         refresh=2,

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -20,7 +20,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_namespace_created{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
+        query='label_values(kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
         current='',
         hide='',
         refresh=2,


### PR DESCRIPTION
After https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/669 , dashboards are using `kube_namespace_created` metrics for namespace variables, however it is not enabled on [ksm-lite addon](https://github.com/prometheus-operator/kube-prometheus/blame/3b1f268d519455165418ab047decbab1cdd92684/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet#L19).

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>