### PR TITLE
Set the default link prefix to an empty string. A dot breaks the react router.

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -69,7 +69,7 @@
 
       // For links between grafana dashboards, you need to tell us if your grafana
       // servers under some non-root path.
-      linkPrefix: '.',
+      linkPrefix: '',
 
       // The default refresh time for all dashboards, default to 10s
       refresh: '10s',


### PR DESCRIPTION
This PR simply sets the prefix to an empty string, rather than a dot.

If the default config is used, and no prefix is defined, the `.` breaks the grafana react router and links between dashboards are broken. This results in the first click of the link returning a 404, but if you refresh your browser, it successfully loads the desired dashboard.

By supplying an empty prefix, things work as expected, without the 404/refresh loop.