### PR TITLE
Satisfy the left join/on for all recording rules in k8s.rules

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -62,7 +62,7 @@
             record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_requests',
             expr: |||
               kube_pod_container_resource_requests{resource="memory",%(kubeStateMetricsSelector)s}  * on (namespace, pod, %(clusterLabel)s)
-              group_left() max by (namespace, pod) (
+              group_left() max by (namespace, pod, %(clusterLabel)s) (
                 (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
               )
             ||| % $._config,
@@ -85,7 +85,7 @@
             record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests',
             expr: |||
               kube_pod_container_resource_requests{resource="cpu",%(kubeStateMetricsSelector)s}  * on (namespace, pod, %(clusterLabel)s)
-              group_left() max by (namespace, pod) (
+              group_left() max by (namespace, pod, %(clusterLabel)s) (
                 (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
               )
             ||| % $._config,
@@ -108,7 +108,7 @@
             record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_limits',
             expr: |||
               kube_pod_container_resource_limits{resource="memory",%(kubeStateMetricsSelector)s}  * on (namespace, pod, %(clusterLabel)s)
-              group_left() max by (namespace, pod) (
+              group_left() max by (namespace, pod, %(clusterLabel)s) (
                 (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
               )
             ||| % $._config,
@@ -131,7 +131,7 @@
             record: 'cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits',
             expr: |||
               kube_pod_container_resource_limits{resource="cpu",%(kubeStateMetricsSelector)s}  * on (namespace, pod, %(clusterLabel)s)
-              group_left() max by (namespace, pod) (
+              group_left() max by (namespace, pod, %(clusterLabel)s) (
                (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
                )
             ||| % $._config,


### PR DESCRIPTION
I found that a handful of recording rules did not have the same labelset for the join/group query, and were subsequently not producing any output.

This fixes a few panels which did not have data in the namespace, node, and pod dashboards.