### PR TITLE
dashboard: namespace selector must appear before workload selector

### DIFF
--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -376,7 +376,7 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('pps') },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, typeTemplate, namespaceTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, typeTemplate] }, refresh: $._config.grafanaK8s.refresh },
 
   },
 }


### PR DESCRIPTION
From the UX perspective, it is always better to place dependent(workload) selector after the source(namespace) selector.

## Before fix
<img width="682" alt="Screenshot 2021-11-19 at 12 40 08 PM" src="https://user-images.githubusercontent.com/3874763/142580296-23f32e56-a76d-4288-9553-c501c9af0c53.png">

## After fix
<img width="688" alt="Screenshot 2021-11-19 at 12 46 41 PM" src="https://user-images.githubusercontent.com/3874763/142581089-5eb4480b-688b-472e-91ac-5106cf056ff0.png">

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>