### PR TITLE
dashboards/resources: add max CPU and memory capacity to node dashboards

### DIFF
--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -44,8 +44,29 @@ local template = grafana.template;
         g.row('CPU Usage')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", node=~"$node"}) by (pod)' % $._config, '{{pod}}') +
-          g.stack,
+          g.queryPanel([
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", node=~"$node", resource="cpu"})' % $._config,
+            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{%(clusterLabel)s="$cluster", node=~"$node"}) by (pod)' % $._config,
+          ], [
+            'max capacity',
+            '{{pod}}',
+          ]) +
+          g.stack +
+          {
+            seriesOverrides: [
+              {
+                alias: 'max capacity',
+                color: '#F2495C',
+                fill: 0,
+                hideTooltip: true,
+                legend: true,
+                linewidth: 2,
+                stack: false,
+                hiddenSeries: true,
+                dashes: true,
+              },
+            ],
+          },
         )
       )
       .addRow(
@@ -72,9 +93,30 @@ local template = grafana.template;
         .addPanel(
           g.panel('Memory Usage (w/o cache)') +
           // Like above, without page cache
-          g.queryPanel('sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node", container!=""}) by (pod)' % $._config, '{{pod}}') +
+          g.queryPanel([
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", node=~"$node", resource="memory"})' % $._config,
+            'sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node", container!=""}) by (pod)' % $._config,
+          ], [
+            'max capacity',
+            '{{pod}}',
+          ]) +
           g.stack +
-          { yaxes: g.yaxes('bytes') },
+          { yaxes: g.yaxes('bytes') } +
+          {
+            seriesOverrides: [
+              {
+                alias: 'max capacity',
+                color: '#F2495C',
+                fill: 0,
+                hideTooltip: true,
+                legend: true,
+                linewidth: 2,
+                stack: false,
+                hiddenSeries: true,
+                dashes: true,
+              },
+            ],
+          },
         )
       )
       .addRow(


### PR DESCRIPTION
This adds a dashed line (hidden by default) to CPU and Memory panels in node dashboard (similar to how `limits` lines are done for pod dashboards). It should improve MTTR in cases where node goes down due to memory exhaustion.

How it looks on dashboard opening:
![Screenshot from 2021-11-19 12-37-06](https://user-images.githubusercontent.com/3531758/142616640-79b839ac-c1ef-4406-b875-4181e2b49800.png)

How it looks after selecting `max capacity` from legend:
![Screenshot from 2021-11-19 12-37-32](https://user-images.githubusercontent.com/3531758/142616691-36d8808d-88ac-46e8-b41b-247a8255e9a4.png)
