### PR TITLE
dashboards: use defaults.libsonnet for setting common values

### DIFF
--- a/dashboards/apiserver.libsonnet
+++ b/dashboards/apiserver.libsonnet
@@ -281,6 +281,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }

--- a/dashboards/controller-manager.libsonnet
+++ b/dashboards/controller-manager.libsonnet
@@ -191,6 +191,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }

--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -8,15 +8,24 @@
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
       timezone: kubernetesMixin._config.grafanaK8s.grafanaTimezone,
+      refresh: kubernetesMixin._config.grafanaK8s.refresh,
+      tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
 
-      // Modify tooltip to only show a single value
       rows: [
         row {
           panels: [
             panel {
+              // Modify tooltip to only show a single value
               tooltip+: {
                 shared: false,
               },
+              // Modify legend to always show as table on right side
+              legend+: {
+                alignAsTable: true,
+                rightSide: true,
+              },
+              // Set minimum time interval for all panels
+              interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval,
             }
             for panel in super.panels
           ],

--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -351,7 +351,6 @@ local statPanel = grafana.statPanel;
       .addPanel(requestDuration, gridPos={ h: 7, w: 24, x: 0, y: 70 })
       .addPanel(memory, gridPos={ h: 7, w: 8, x: 0, y: 77 })
       .addPanel(cpu, gridPos={ h: 7, w: 8, x: 8, y: 77 })
-      .addPanel(goroutines, gridPos={ h: 7, w: 8, x: 16, y: 77 })
-      + { refresh: $._config.grafanaK8s.refresh },
+      .addPanel(goroutines, gridPos={ h: 7, w: 8, x: 16, y: 77 }),
   },
 }

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -167,6 +167,6 @@ local gauge = promgrafonnet.gauge;
         row.new()
         .addPanel(inodesGraph)
         .addPanel(inodeGauge)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }

--- a/dashboards/proxy.libsonnet
+++ b/dashboards/proxy.libsonnet
@@ -197,6 +197,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -140,8 +140,7 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - sum(avg by (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", %(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])))' % $._config) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          g.statPanel('1 - sum(avg by (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", %(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])))' % $._config)
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +
@@ -324,9 +323,9 @@ local template = grafana.template;
           },
         )
       ) + {
-        tags: $._config.grafanaK8s.dashboardTags,
-        templating+: { list+: [clusterTemplate] },
-        refresh: $._config.grafanaK8s.refresh,
+        templating+: {
+          list+: [clusterTemplate],
+        },
       },
   },
 }

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -100,6 +100,6 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
               'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
             })
           )
-        ) + { tags: $._config.grafanaK8s.dashboardTags, refresh: $._config.grafanaK8s.refresh },
+        ),
     } else {},
 }

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -285,8 +285,7 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          ),
         )
       )
       .addRow(
@@ -365,6 +364,10 @@ local template = grafana.template;
             },
           },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + {
+        templating+: {
+          list+: [clusterTemplate, namespaceTemplate],
+        },
+      },
   },
 }

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -101,6 +101,10 @@ local template = grafana.template;
             'Value #H': { alias: 'Memory Usage (Swap)', unit: 'bytes' },
           })
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, refresh: $._config.grafanaK8s.refresh, templating+: { list+: [clusterTemplate, nodeTemplate] } },
+      ) + {
+        templating+: {
+          list+: [clusterTemplate, nodeTemplate],
+        },
+      },
   },
 }

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -259,13 +259,13 @@ local template = grafana.template;
           g.panel('Receive Bandwidth') +
           g.queryPanel('sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Transmit Bandwidth') +
           g.queryPanel('sum(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('Bps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('Bps') },
         )
       )
       .addRow(
@@ -274,13 +274,13 @@ local template = grafana.template;
           g.panel('Rate of Received Packets') +
           g.queryPanel('sum(irate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('pps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('pps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets') +
           g.queryPanel('sum(irate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('pps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('pps') },
         )
       )
       .addRow(
@@ -289,13 +289,13 @@ local template = grafana.template;
           g.panel('Rate of Received Packets Dropped') +
           g.queryPanel('sum(irate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('pps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('pps') },
         )
         .addPanel(
           g.panel('Rate of Transmitted Packets Dropped') +
           g.queryPanel('sum(irate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('pps'), interval: $._config.grafanaK8s.minimumTimeInterval },
+          { yaxes: g.yaxes('pps') },
         )
       )
       .addRow(
@@ -343,6 +343,10 @@ local template = grafana.template;
             },
           },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, podTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + {
+        templating+: {
+          list+: [clusterTemplate, namespaceTemplate, podTemplate],
+        },
+      },
   },
 }

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -282,8 +282,7 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          ),
         )
       )
       .addRow(
@@ -377,7 +376,11 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('pps') },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, typeTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + {
+        templating+: {
+          list+: [clusterTemplate, namespaceTemplate, typeTemplate],
+        },
+      },
 
   },
 }

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -219,8 +219,7 @@ local template = grafana.template;
           g.tablePanel(
             networkColumns,
             networkTableStyles
-          ) +
-          { interval: $._config.grafanaK8s.minimumTimeInterval },
+          ),
         )
       )
       .addRow(
@@ -314,6 +313,10 @@ local template = grafana.template;
           g.stack +
           { yaxes: g.yaxes('pps') },
         )
-      ) + { tags: $._config.grafanaK8s.dashboardTags, templating+: { list+: [clusterTemplate, namespaceTemplate, workloadTemplate, workloadTypeTemplate] }, refresh: $._config.grafanaK8s.refresh },
+      ) + {
+        templating+: {
+          list+: [clusterTemplate, namespaceTemplate, workloadTemplate, workloadTypeTemplate],
+        },
+      },
   },
 }

--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -181,6 +181,6 @@ local singlestat = grafana.singlestat;
         .addPanel(memory)
         .addPanel(cpu)
         .addPanel(goroutines)
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -557,6 +557,6 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
-      ) + { refresh: $._config.grafanaK8s.refresh },
+      ),
   },
 }


### PR DESCRIPTION
To make dashboards coherent it would be good to reset some fields to common values. Since we do have `defaults.libsonnet` it looks like a good place to include such common values.

Changes from this PR:
- move setting dashboard refresh rate to `defaults.libsonnet`
- move setting dashboard tags  to `defaults.libsonnet`
- set `minimumTimeInterval` for all panels
- move all legend parts of all panels to the right