### PR TITLE
Add ability to mark expected expected 'full volumes' via PVC label

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -28,6 +28,8 @@
               kubelet_volume_stats_used_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_access_mode{%(prefixedNamespaceSelector)s access_mode="ReadOnlyMany"} == 1
+              unless on(namespace, persistentvolumeclaim)
+              kube_persistentvolumeclaim_labels{%(prefixedNamespaceSelector)s%(pvExcludedSelector)s} == 1
             ||| % $._config,
             'for': '1m',
             labels: {
@@ -52,6 +54,8 @@
               predict_linear(kubelet_volume_stats_available_bytes{%(prefixedNamespaceSelector)s%(kubeletSelector)s}[%(volumeFullPredictionSampleTime)s], 4 * 24 * 3600) < 0
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_access_mode{%(prefixedNamespaceSelector)s access_mode="ReadOnlyMany"} == 1
+              unless on(namespace, persistentvolumeclaim)
+              kube_persistentvolumeclaim_labels{%(prefixedNamespaceSelector)s%(pvExcludedSelector)s} == 1
             ||| % $._config,
             'for': '1h',
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -98,5 +98,12 @@
     // This list of disk device names is referenced in various expressions.
     diskDevices: ['mmcblk.p.+', 'nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
     diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+
+    // Certain workloads (e.g. KubeVirt/CDI) will fully utilise the persistent volume they claim
+    // the size of the PV will never grow since they consume the entirety of the volume by design.
+    // This selector allows an admin to 'pre-mark' the PVC of such a workload (or for any other use case)
+    // so that specific storage alerts will not fire.With the default selector, adding a label `exclude-from-alerts: 'true'`
+    // to the PVC will have the desired effect.
+    pvExcludedSelector: 'label_excluded_from_alerts="true"',
   },
 }

--- a/tests.yaml
+++ b/tests.yaml
@@ -76,6 +76,29 @@ tests:
   - eval_time: 4m
     alertname: KubePersistentVolumeFillingUp
 
+  # Don't alert when PVC has been labelled as fully utilised
+- interval: 1m
+  input_series:
+    - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '1024 512 64 16'
+    - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '1024 1024 1024 1024'
+    - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '16 64 512 1024'
+    - series: 'kube_persistentvolumeclaim_access_mode{job="ksm",namespace="monitoring",persistentvolumeclaim="somepvc", access_mode="ReadWriteOnce", service="kube-state-metrics"}'
+      values: '1 1 1 1'
+    - series: 'kube_persistentvolumeclaim_labels{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc",label_excluded_from_alerts="true"}'
+      values: '1 1 1 1'
+  alert_rule_test:
+    - eval_time: 1m
+      alertname: KubePersistentVolumeFillingUp
+    - eval_time: 2m
+      alertname: KubePersistentVolumeFillingUp
+    - eval_time: 3m
+      alertname: KubePersistentVolumeFillingUp
+    - eval_time: 4m
+      alertname: KubePersistentVolumeFillingUp
+
 - interval: 1m
   input_series:
   - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
@@ -159,6 +182,22 @@ tests:
   alert_rule_test:
   - eval_time: 61m
     alertname: KubePersistentVolumeFillingUp
+
+- interval: 1m
+  input_series:
+    - series: 'kubelet_volume_stats_available_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '1024-10x61'
+    - series: 'kubelet_volume_stats_capacity_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '32768+0x61'
+    - series: 'kubelet_volume_stats_used_bytes{job="kubelet",namespace="monitoring",persistentvolumeclaim="somepvc"}'
+      values: '1024+10x61'
+    - series: 'kube_persistentvolumeclaim_access_mode{job="ksm",namespace="monitoring",persistentvolumeclaim="somepvc", access_mode="ReadWriteOnce", service="kube-state-metrics"}'
+      values: '1x61'
+    - series: 'kube_persistentvolumeclaim_labels{job="ksm",namespace="monitoring",persistentvolumeclaim="somepvc",label_excluded_from_alerts="true"}'
+      values: '1x61'
+  alert_rule_test:
+    - eval_time: 61m
+      alertname: KubePersistentVolumeFillingUp
 
 - interval: 1m
   input_series:


### PR DESCRIPTION
Fixes #710 

Certain workloads, by design will provision a persistent volume that is
entirely 'full' from the outset. Such an example is KubeVirt CDI
where the file is a disk image, and the underlying PV will be the exact
size of the allocated file. This causes the KubePersistentVolumeFillingUp
storage alerts to fire as soon as they are evaluated, despite the fact
that the data in the volume has reached its maximum size.

This change provides a mechanism which allows cluster admin
to label the PVC in advance and avoid the alerts from ever
firing in these known situations.