### PR TITLE
"Compute Resources / Namespace (Workloads)" dashboard is broken

### DIFF
--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -39,7 +39,7 @@ local template = grafana.template;
       template.new(
         name='namespace',
         datasource='$datasource',
-        query='label_values(kube_pod_info{%(kubeStateMetricsSelector)s}, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
+        query='label_values(kube_pod_info{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
         current='',
         hide='',
         refresh=2,


### PR DESCRIPTION
Extra "}" added as part of #675 which breaks the namespace label query.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>