### PR TITLE
Change ordering of workload type and workload in `Compute Resources /Workload`

### DIFF
--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -29,11 +29,11 @@ local template = grafana.template;
         sort=1
       ),
 
-    local workloadTemplate =
+    local workloadTypeTemplate =
       template.new(
-        name='workload',
+        name='type',
         datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload)' % $._config.clusterLabel,
+        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload_type)' % $._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -41,11 +41,11 @@ local template = grafana.template;
         sort=1
       ),
 
-    local workloadTypeTemplate =
+    local workloadTemplate =
       template.new(
-        name='type',
+        name='workload',
         datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload"}, workload_type)' % $._config.clusterLabel,
+        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type="$type"}, workload)' % $._config.clusterLabel,
         current='',
         hide='',
         refresh=2,
@@ -315,7 +315,7 @@ local template = grafana.template;
         )
       ) + {
         templating+: {
-          list+: [clusterTemplate, namespaceTemplate, workloadTemplate, workloadTypeTemplate],
+          list+: [clusterTemplate, namespaceTemplate, workloadTypeTemplate, workloadTemplate],
         },
       },
   },


### PR DESCRIPTION
Prior to this change, `Compute Resources / Workload` dashboard had
`namespace > workload > type` as filters where `type` mearly used as
a label rather a filter.

This commit brings a change in the UX, now the filtering order has changed to
`namespace > type > workload` and all of those filters are actually
functions like a filter.

For example, from now on the user should able to select namespace, then select
the type of workload and finally the actual workload.

### Before
<img width="1593" alt="Screenshot 2021-11-26 at 7 19 10 PM" src="https://user-images.githubusercontent.com/3874763/143594149-af133a58-cfdc-4693-8c02-a3554be75f7e.png">

### After
<img width="1607" alt="Screenshot 2021-11-26 at 7 42 37 PM" src="https://user-images.githubusercontent.com/3874763/143594196-43de82c2-6b1f-4ad3-8bfc-67063799e1ef.png">

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>