### PR TITLE
Add cluster labels to kubelet rules

### DIFF
--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -11,7 +11,7 @@
           {
             record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile',
             expr: |||
-              histogram_quantile(%(quantile)s, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{%(kubeletSelector)s})
+              histogram_quantile(%(quantile)s, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (%(clusterLabel)s, instance, le) * on(%(clusterLabel)s, instance) group_left(node) kubelet_node_name{%(kubeletSelector)s})
             ||| % ({ quantile: quantile } + $._config),
             labels: {
               quantile: quantile,


### PR DESCRIPTION
This change fixes an error in one of the kubelet rules which could error due to a one to many join. This error occurs if you have multiple clusters with nodes that have identical IPs. Adding the cluster labels differentiates the time series and solves the problem.