### PR TITLE
Add separate lint target for alerts, jsonnet and dashboards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: ${{ env.golang-version }}
     - run: make --always-make generate && git diff --exit-code
-  lint:
+  jsonnet-lint:
     runs-on: ubuntu-latest
     name: Jsonnet linter
     steps:
@@ -26,7 +26,29 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.golang-version }}
-    - run: make --always-make lint
+    - run: make --always-make jsonnet-lint
+  dashboards-lint:
+    runs-on: ubuntu-latest
+    name: Grafana dashboard linter
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.golang-version }}
+    - run: make --always-make dashboards-lint
+  alerts-lint:
+    runs-on: ubuntu-latest
+    name: Alerts linter
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.golang-version }}
+    - run: make --always-make alerts-lint
   fmt:
     runs-on: ubuntu-latest
     name: Jsonnet formatter


### PR DESCRIPTION
This commit refactors makefile lint targets into specific/small
targets and also adds dedicated Github actions for better error message
readability.

Also fixes https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/741

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>