### PR TITLE
Exclude long-running requests from cluster_quantile:apiserver_request_duration_seconds:histogram_quantile

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -117,7 +117,7 @@
               record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
               expr: |||
                 histogram_quantile(0.99, sum by (%s, le, resource) (rate(apiserver_request_duration_seconds_bucket{%s}[5m]))) > 0
-              ||| % [$._config.clusterLabel, std.join(',', [$._config.kubeApiserverSelector, verb.selector])],
+              ||| % [$._config.clusterLabel, std.join(',', [$._config.kubeApiserverSelector, verb.selector, $._config.kubeApiserverNonStreamingSelector])],
               labels: {
                 verb: verb.type,
                 quantile: '0.99',

--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -124,17 +124,6 @@
               },
             }
             for verb in verbs
-          ] + [
-            {
-              record: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile',
-              expr: |||
-                histogram_quantile(%(quantile)s, sum(rate(apiserver_request_duration_seconds_bucket{%(kubeApiserverSelector)s,subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, %(podLabel)s))
-              ||| % ({ quantile: quantile } + $._config),
-              labels: {
-                quantile: quantile,
-              },
-            }
-            for quantile in ['0.99', '0.9', '0.5']
           ],
       },
       {


### PR DESCRIPTION
Follow-up PR to https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/740 updating the `cluster_quantile:apiserver_request_duration_seconds:histogram_quantile` with the new kubeApiserverNonStreamingSelector.

I also removed the `cluster_quantile:apiserver_request_duration_seconds:histogram_quantile` that only has the `quantile` label since it wasn't used anywhere and wasn't bringing any value.

