### PR TITLE
Clarify node template variable in kubelet dash

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -322,7 +322,7 @@ local statPanel = grafana.statPanel;
           'instance',
           '$datasource',
           'label_values(up{%(kubeletSelector)s,%(clusterLabel)s="$cluster"}, instance)' % $._config,
-          label='Data Source',
+          label='instance',
           refresh='time',
           includeAll=true,
           sort=1,


### PR DESCRIPTION
Can use `node` as well.. 