### PR TITLE
use recording rule metric for cluster cpu utilization

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -140,7 +140,7 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('1 - sum(avg by (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal", %(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])))' % $._config)
+          g.statPanel('cluster:node_cpu:ratio{%(clusterLabel)s="$cluster"}' % $._config)
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -140,7 +140,7 @@ local template = grafana.template;
          })
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.statPanel('cluster:node_cpu:ratio{%(clusterLabel)s="$cluster"}' % $._config)
+          g.statPanel('cluster:node_cpu:ratio_rate5m{%(clusterLabel)s="$cluster"}' % $._config)
         )
         .addPanel(
           g.panel('CPU Requests Commitment') +

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -22,7 +22,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
            })
           .addPanel(
             g.panel('CPU Utilisation') +
-            g.statPanel('cluster:node_cpu:ratio')
+            g.statPanel('cluster:node_cpu:ratio_rate5m')
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -22,7 +22,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
            })
           .addPanel(
             g.panel('CPU Utilisation') +
-            g.statPanel('1 - sum(avg by (mode) (rate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode=~"idle|iowait|steal"}[%(grafanaIntervalVar)s])))' % $._config)
+            g.statPanel('cluster:node_cpu:ratio')
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +

--- a/rules/node.libsonnet
+++ b/rules/node.libsonnet
@@ -52,6 +52,14 @@
               ) by (%(clusterLabel)s)
             ||| % $._config,
           },
+          {
+            // This rule gives cpu utilization per cluster
+            record: 'cluster:node_cpu:ratio_rate5m',
+            expr: |||
+              sum(rate(node_cpu_seconds_total{%(nodeExporterSelector)s,mode!="idle",mode!="iowait",mode!="steal"}[5m])) /
+              count(sum(node_cpu_seconds_total{%(nodeExporterSelector)s}) by (%(clusterLabel)s, instance, cpu))
+            ||| % $._config,
+          },
         ],
       },
     ],


### PR DESCRIPTION
- Updates cluster resources dashboards to use precomputed `cluster:node_cpu:ratio_rate5m` metric. the current query is slower to evaluate on clusters having many nodes with multi-core cpus ( cores >= 64 ).

cc @povilasv @paulfantom 