### PR TITLE
Rename KubeJobCompletion to KubeJobNotCompleted and fix alert expression

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -235,9 +235,11 @@
             'for': '15m',
           },
           {
-            alert: 'KubeJobCompletion',
+            alert: 'KubeJobNotCompleted',
             expr: |||
-              kube_job_spec_completions{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_job_status_succeeded{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
+              time() - kube_job_status_start_time{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                and
+              kube_job_status_active{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0
             ||| % $._config,
             'for': '12h',
             labels: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -106,5 +106,8 @@
     // so that specific storage alerts will not fire.With the default selector, adding a label `exclude-from-alerts: 'true'`
     // to the PVC will have the desired effect.
     pvExcludedSelector: 'label_excluded_from_alerts="true"',
+
+    // Default timeout value for k8s Jobs. The jobs which are active beyond this duration would trigger KubeJobNotCompleted alert.
+    kubeJobTimeoutDuration: 12 * 60 * 60,
   },
 }

--- a/runbook.md
+++ b/runbook.md
@@ -57,8 +57,8 @@ This page collects this repositories alerts and begins the process of describing
 + *Message*: `A number of pods of daemonset {{$labels.namespace}}/{{$labels.daemonset}} are running where they are not supposed to run.`
 + *Severity*: warning
 
-##### Alert Name: "KubeJobCompletion"
-+ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 1h to complete.`
+##### Alert Name: "KubeJobNotCompleted"
++ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12h to complete.`
 + *Severity*: warning
 + *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
 

--- a/runbook.md
+++ b/runbook.md
@@ -58,7 +58,7 @@ This page collects this repositories alerts and begins the process of describing
 + *Severity*: warning
 
 ##### Alert Name: "KubeJobNotCompleted"
-+ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12h to complete.`
++ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than {{ "%(kubeJobTimeoutDuration)s" | humanizeDuration }} to complete.`
 + *Severity*: warning
 + *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -846,30 +846,22 @@ tests:
 - interval: 1m
   input_series:
   - series: 'kube_job_status_start_time{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
-    values: '0+0x740'
+    values: '0+0x200 _x500 0+0x40'
   - series: 'kube_job_status_active{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
-    values: '1+0x740'
-  promql_expr_test:
-  - eval_time: 12h
-    expr: time() - kube_job_status_start_time and kube_job_status_active > 0
-    exp_samples:
-    - value: 43200
-      labels: '{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '1x200 _x500 1x40'
   alert_rule_test:
   - eval_time: 6h
     alertname: KubeJobNotCompleted
-  - eval_time: 12h
+  - eval_time: 12h1m
     alertname: KubeJobNotCompleted
     exp_alerts:
     - exp_labels:
         namespace: ns1
         job_name: job1
         severity: warning
-        instance: instance1
-        job: kube-state-metrics
       exp_annotations:
         summary: "Job did not complete in time"
-        description: "Job ns1/job1 is taking more than 12 hours to complete."
+        description: "Job ns1/job1 is taking more than 12h 0m 0s to complete."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
 
 - interval: 1m

--- a/tests.yaml
+++ b/tests.yaml
@@ -845,6 +845,47 @@ tests:
 
 - interval: 1m
   input_series:
+  - series: 'kube_job_status_start_time{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '0+0x740'
+  - series: 'kube_job_status_active{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '1+0x740'
+  promql_expr_test:
+  - eval_time: 12h
+    expr: time() - kube_job_status_start_time and kube_job_status_active > 0
+    exp_samples:
+    - value: 43200
+      labels: '{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+  alert_rule_test:
+  - eval_time: 6h
+    alertname: KubeJobNotCompleted
+  - eval_time: 12h
+    alertname: KubeJobNotCompleted
+    exp_alerts:
+    - exp_labels:
+        namespace: ns1
+        job_name: job1
+        severity: warning
+        instance: instance1
+        job: kube-state-metrics
+      exp_annotations:
+        summary: "Job did not complete in time"
+        description: "Job ns1/job1 is taking more than 12 hours to complete."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
+
+- interval: 1m
+  input_series:
+  - series: 'kube_job_status_start_time{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '0+0x740'
+  - series: 'kube_job_status_active{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '1+0x710 0x30'
+  alert_rule_test:
+  - eval_time: 6h
+    alertname: KubeJobNotCompleted
+  - eval_time: 12h
+    alertname: KubeJobNotCompleted
+
+- interval: 1m
+  input_series:
   - series: 'apiserver_request_terminations_total{job="kube-apiserver",apiserver="kube-apiserver"}'
     values: '1+1x10'
   - series: 'apiserver_request_total{job="kube-apiserver",apiserver="kube-apiserver"}'


### PR DESCRIPTION
* KubeJobCompletion sounds like an info rather than a warning.

* Existing expression is not accounting the failed jobs which leads to false positive firing of alert.

Co-authored-by: W. Trevor King <wking@redhat.com>
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>