### PR TITLE
rules: prevent rule duplication

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -273,8 +273,11 @@
           {
             record: 'code_verb:apiserver_request_total:increase1h',
             expr: |||
-              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
+              sum by (%s, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
             ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, code],
+            labels: {
+              code: code,
+            },
           }
           for code in ['2..', '3..', '4..', '5..']
         ],


### PR DESCRIPTION
Current code results in lack of aggregation across code types and thus in potentially incorrect alerts. Additionally it results in duplicated recording rules as reported by `promtool`. Change from this PR should fix those issues.

Part of `code_verb:apiserver_request_total:increase1h{code=~"4.."}` query result before PR:
```
code_verb:apiserver_request_total:increase1h{code="400", verb="GET"} | 0
code_verb:apiserver_request_total:increase1h{code="400", verb="POST"} | 0
code_verb:apiserver_request_total:increase1h{code="404", verb="DELETE"} | 123.02524454488642
code_verb:apiserver_request_total:increase1h{code="404", verb="GET"} | 87.73111701151736
code_verb:apiserver_request_total:increase1h{code="404", verb="PATCH"} | 9.075632794294899
code_verb:apiserver_request_total:increase1h{code="409", verb="PATCH"} | 0
code_verb:apiserver_request_total:increase1h{code="409", verb="POST"} | 0
code_verb:apiserver_request_total:increase1h{code="409", verb="PUT"} | 48.40337490290613
code_verb:apiserver_request_total:increase1h{code="422", verb="PATCH"} | 0
code_verb:apiserver_request_total:increase1h{code="422", verb="POST"} | 0
code_verb:apiserver_request_total:increase1h{code="422", verb="PUT"} | 0
code_verb:apiserver_request_total:increase1h{code="429", verb="POST"} | 0
```

I would expect to get an aggregation by HTTP code type (not particular code) and by HTTP request type (verb) instead. As implemented in this PR and presented below:
```
code_verb:apiserver_request_total:increase1h{code="4..", verb="DELETE"} | 127.05885912012859
code_verb:apiserver_request_total:increase1h{code="4..", verb="GET"} | 81.6806951486541
code_verb:apiserver_request_total:increase1h{code="4..", verb="PATCH"} | 10.084036438105443
code_verb:apiserver_request_total:increase1h{code="4..", verb="POST"} | 0
code_verb:apiserver_request_total:increase1h{code="4..", verb="PUT"} | 48.40337490290613
```