### PR TITLE
KubeVersionMismatch for multiple clusters

### DIFF
--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -11,7 +11,7 @@
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (git_version) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
+              count(count by (git_version, %(clusterLabel)s) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*")) > 1) > 1
             ||| % $._config,
             'for': '15m',
             labels: {

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -18,8 +18,8 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'There are {{ $value }} different semantic versions of Kubernetes components running.',
-              summary: 'Different semantic versions of Kubernetes components running.',
+              description: 'There are {{ $value }} clusters with different semantic versions of Kubernetes components running.',
+              summary: 'Clusters with different semantic versions of Kubernetes components running.',
             },
           },
           {


### PR DESCRIPTION
I noticed that the alter was fired when I added a new cluster with different kube version even when each cluster had consistent versions within itself.

The alert expression was modified to fire only when there are multiple versions of kube components within the same cluster. 

This changes the meaning of the alert a bit, as before the alert was fired if any cluster had a different kube component version and after this change the alert won't fire as long as each cluster is consistent within itself.