### PR TITLE
Add cluster label to aggregations in alert queries

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -75,7 +75,7 @@ local utils = import '../lib/utils.libsonnet';
           {
             alert: 'KubeAggregatedAPIErrors',
             expr: |||
-              sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+              sum by(name, namespace, %(clusterLabel)s)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
             ||| % $._config,
             labels: {
               severity: 'warning',
@@ -88,7 +88,7 @@ local utils = import '../lib/utils.libsonnet';
           {
             alert: 'KubeAggregatedAPIDown',
             expr: |||
-              (1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+              (1 - max by(name, namespace, %(clusterLabel)s)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
             ||| % $._config,
             'for': '5m',
             labels: {

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -11,7 +11,7 @@
           {
             alert: 'KubeVersionMismatch',
             expr: |||
-              count(count by (git_version) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
+              count by (%(clusterLabel)s) (count by (git_version, %(clusterLabel)s) (label_replace(kubernetes_build_info{%(notKubeDnsCoreDnsSelector)s},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
A handful of alerts did not include the cluster label when doing aggregations.

As a result, in a multi-cluster environment, it could be difficult to identify which cluster was triggering the alert. Also, in some cases (such as the KubeVersionMismatch), differences between clusters would be mistakenly reported as alerts.

This resolves (portions of? possibly all?) #695

I tested the ones that I changed, which we received feedback on. I *believe* all the other alert queries are fine from a cursory review. They do not seem to have aggregations, which would remove the cluster label if present.

It's possible I still missed some tho.