### PR TITLE
Update diskDeviceSelector to include cadvisor device

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -98,7 +98,7 @@
 
     // This list of disk device names is referenced in various expressions.
     diskDevices: ['mmcblk.p.+', 'nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
-    diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+    diskDeviceSelector: 'device=~"(/dev.+)|%s"' % std.join('|', self.diskDevices),
 
     // Certain workloads (e.g. KubeVirt/CDI) will fully utilise the persistent volume they claim
     // the size of the PV will never grow since they consume the entirety of the volume by design.


### PR DESCRIPTION
I had added deviceDeviceSelector in container_fs* queries as part of [kubernetes-mixin PR](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/737) since [diskDeviceSelector](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/config.libsonnet#L100-L101) includes only node_exporter label values this commit tries to add cadvisor device as well

@paulfantom I am not sure if this is the right way but `diskDeviceSelector: 'device=~"(/dev/)?%s"' % std.join('|', self.diskDevices),` was not working.  wdyt?