### PR TITLE
Improve KubeAggregatedAPIErrors alert in high availability scenarios

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -75,7 +75,7 @@ local utils = import '../lib/utils.libsonnet';
           {
             alert: 'KubeAggregatedAPIErrors',
             expr: |||
-              sum by(name, namespace, %(clusterLabel)s)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+              max by(name, namespace, %(clusterLabel)s)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
             ||| % $._config,
             labels: {
               severity: 'warning',


### PR DESCRIPTION
KubeAggregatedAPIErrors was alerting based on the number of errors
returned by all the instances of an aggregated API which made it more
likely to fire the more instances the API had. To improve that we need
to alert at the instance level rather than at the API level by changing
the aggregation function from a `sum` to a `max`.

/cc @simonpasquier 