### PR TITLE
Fix 'Storage IO' dashboard graphs

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -98,7 +98,7 @@
 
     // This list of disk device names is referenced in various expressions.
     diskDevices: ['mmcblk.p.+', 'nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
-    diskDeviceSelector: 'device=~"(/dev.+)|%s"' % std.join('|', self.diskDevices),
+    diskDeviceSelector: 'device=~".*(%s)"' % std.join('|', self.diskDevices),
 
     // Certain workloads (e.g. KubeVirt/CDI) will fully utilise the persistent volume they claim
     // the size of the PV will never grow since they consume the entirety of the volume by design.


### PR DESCRIPTION
Removed unwanted fields from Storage IO queries.

Corrected the 'device' regular expression as the new device's results
start with '/dev/'. The new regex is backward compatible.
Removing the condition `%(containerfsSelector)` as the label/field is not present in (any of) the `container_fs_*` query results.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>