### PR TITLE
Fix grouping failure when promehteus returns 2 identical pods

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -34,7 +34,7 @@
           {
             record: 'node_namespace_pod_container:container_memory_rss',
             expr: |||
-              container_memory_rss{%(cadvisorSelector)s, image!=""}
+              topk by (pod, container) (1, container_memory_rss{%(cadvisorSelector)s, image!=""})
               * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
                 max by(namespace, pod, node) (kube_pod_info{node!=""})
               )


### PR DESCRIPTION
Sometimes prometheus will return 2 pods with the exact same name and labels.
The query I modified, then breaks because it becomes ambiguous when more then
one pod is returned from the left side. By adding topk we mitigate this issue
and force selection of only 1 pod (the one with higher memory consumption).
![image](https://user-images.githubusercontent.com/89029422/176736026-2825eb89-c2cf-4d96-ac8c-9374675f022a.png)

It's worth mentioning we are running on AKS with substantial amount of spot nodes