### PR TITLE
Storage panel disk selector query fix.

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -98,7 +98,7 @@
 
     // This list of disk device names is referenced in various expressions.
     diskDevices: ['mmcblk.p.+', 'nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
-    diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+    diskDeviceSelector: 'device=~"(/dev/)?(%s)"' % std.join('|', self.diskDevices),
 
     // Certain workloads (e.g. KubeVirt/CDI) will fully utilise the persistent volume they claim
     // the size of the PV will never grow since they consume the entirety of the volume by design.

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -102,17 +102,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #D': {
           alias: 'Throughput(Read)',

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -103,17 +103,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #D': {
           alias: 'Throughput(Read)',

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -74,17 +74,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 0,
         },
         'Value #D': {
           alias: 'Throughput(Read)',


### PR DESCRIPTION
According to the [PR that introduces container storage utilization](https://github.com/google/cadvisor/pull/1642), the device label would have always included the full device path (I.E. `/dev/.*`). So, I'm not sure how these queries ever worked?

In any case, the update for the default config *should* support labels with the previous expected format, or the (observed) actual format in the cluster(s) I have access to.

Also updated the storage utilization table(s) so that they render. The *real* solution for this would be to use the new table visualization, but that will be for another, larger PR sometime in the future.