### PR TITLE
Updates for latest dashboard and recording rule linting

### DIFF
--- a/.lint
+++ b/.lint
@@ -1,4 +1,7 @@
-exclusions:
+exclusions:    
+  panel-job-instance-rule:
+    reason: Poorly deprecated rule name for job, see target-job-rule and target-instance-rule below.
+    
   template-job-rule:
     reason: Job is hardcoded in the mixin config.    
   template-instance-rule:

--- a/.lint
+++ b/.lint
@@ -1,3 +1,14 @@
 exclusions:
- template-job-rule:
- panel-job-instance-rule:
+  template-job-rule:
+    reason: Job is hardcoded in the mixin config.    
+  template-instance-rule:
+    reason: These dashboards are either cluster wide, or global. As such 'cluster' takes the place of 'instance', or no instance filtering is necessary.
+  target-job-rule:
+    reason: Job is hardcoded in the mixin config, and is therefore a =, not =~.
+  target-instance-rule:    
+    reason: These dashboards are either cluster wide, or global. As such 'cluster' takes the place of 'instance', or no instance filtering is necessary.
+
+  panel-units-rule:
+    reason: Maybe this should only warn, and maybe mixtool shouldn't consider warnings errors?
+  panel-title-description-rule:
+    reason: Maybe this should only warn, and maybe mixtool shouldn't consider warnings errors?

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -60,7 +60,7 @@
             },
             annotations: {
               description: 'Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.',
-              summary: 'Deployment generation mismatch due to possible roll-back',
+              summary: 'Deployment generation mismatch due to possible roll-back.',
             },
             'for': '15m',
             alert: 'KubeDeploymentGenerationMismatch',
@@ -120,7 +120,7 @@
             },
             annotations: {
               description: 'StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.',
-              summary: 'StatefulSet generation mismatch due to possible roll-back',
+              summary: 'StatefulSet generation mismatch due to possible roll-back.',
             },
             'for': '15m',
             alert: 'KubeStatefulSetGenerationMismatch',
@@ -200,7 +200,7 @@
             },
             annotations: {
               description: 'pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on container {{ $labels.container}} has been in waiting state for longer than 1 hour.',
-              summary: 'Pod container waiting longer than 1 hour',
+              summary: 'Pod container waiting longer than 1 hour.',
             },
             'for': '1h',
             alert: 'KubeContainerWaiting',
@@ -247,7 +247,7 @@
             },
             annotations: {
               description: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than {{ "%(kubeJobTimeoutDuration)s" | humanizeDuration }} to complete.' % $._config,
-              summary: 'Job did not complete in time',
+              summary: 'Job did not complete in time.',
             },
           },
           {
@@ -301,7 +301,7 @@
             },
             annotations: {
               description: 'HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }} has been running at max replicas for longer than 15 minutes.',
-              summary: 'HPA is running at max replicas',
+              summary: 'HPA is running at max replicas.',
             },
             'for': '15m',
             alert: 'KubeHpaMaxedOut',

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -35,7 +35,7 @@ local utils = import '../lib/utils.libsonnet';
               long: '%(long)s' % w,
             },
             annotations: {
-              description: 'The API server is burning too much error budget.',
+              description: 'The API server in Cluster {{ $labels.%(clusterLabel)s }}, is burning too much error budget.' % $._config,
               summary: 'The API server is burning too much error budget.',
             },
             'for': '%(for)s' % w,
@@ -55,7 +55,7 @@ local utils = import '../lib/utils.libsonnet';
               severity: 'warning',
             },
             annotations: {
-              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationWarningSeconds)),
+              description: 'A client certificate used to authenticate to kubernetes apiserver in Cluster {{ $labels.%s }}, is expiring in less than %s.' % [$._config.clusterLabel, (utils.humanizeSeconds($._config.certExpirationWarningSeconds))],
               summary: 'Client certificate is about to expire.',
             },
           },
@@ -68,7 +68,7 @@ local utils = import '../lib/utils.libsonnet';
               severity: 'critical',
             },
             annotations: {
-              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationCriticalSeconds)),
+              description: 'A client certificate used to authenticate to kubernetes apiserver in Cluster {{ $labels.%(clusterLabel)s }}, is expiring in less than %s.' % [$._config.clusterLabel, (utils.humanizeSeconds($._config.certExpirationWarningSeconds))],
               summary: 'Client certificate is about to expire.',
             },
           },
@@ -102,6 +102,7 @@ local utils = import '../lib/utils.libsonnet';
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeAPI',
             selector:: $._config.kubeApiserverSelector,
+            clusterLabel:: $._config.clusterLabel,
           },
           {
             alert: 'KubeAPITerminatedRequests',
@@ -112,8 +113,8 @@ local utils = import '../lib/utils.libsonnet';
               severity: 'warning',
             },
             annotations: {
-              description: 'The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.',
-              summary: 'The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.',
+              description: 'The kubernetes apiserver in Cluster {{ $labels.%(clusterLabel)s }}, has terminated {{ $value | humanizePercentage }} of its incoming requests.' % $._config,
+              summary: 'The kubernetes apiserver has terminated more than 20% of its incoming requests.',
             },
             'for': '5m',
           },

--- a/alerts/kube_controller_manager.libsonnet
+++ b/alerts/kube_controller_manager.libsonnet
@@ -11,6 +11,7 @@
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeControllerManager',
             selector:: $._config.kubeControllerManagerSelector,
+            clusterLabel:: $._config.clusterLabel,
           },
         ],
       },

--- a/alerts/kube_proxy.libsonnet
+++ b/alerts/kube_proxy.libsonnet
@@ -11,6 +11,7 @@
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeProxy',
             selector:: $._config.kubeProxySelector,
+            clusterLabel:: $._config.clusterLabel,
           },
         ],
       },

--- a/alerts/kube_scheduler.libsonnet
+++ b/alerts/kube_scheduler.libsonnet
@@ -11,6 +11,7 @@
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeScheduler',
             selector:: $._config.kubeSchedulerSelector,
+            clusterLabel:: $._config.clusterLabel,
           },
         ],
       },

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -194,6 +194,7 @@
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'Kubelet',
             selector:: $._config.kubeletSelector,
+            clusterLabel:: $._config.clusterLabel,
           },
         ],
       },

--- a/lib/absent_alert.libsonnet
+++ b/lib/absent_alert.libsonnet
@@ -12,7 +12,7 @@
     severity: 'critical',
   },
   annotations: {
-    description: '%s has disappeared from Prometheus target discovery.' % absentAlert.componentName,
+    description: '%(componentName)s in Cluster {{ $labels.%(clusterLabel)s }}, has disappeared from Prometheus target discovery.' % absentAlert,
     summary: 'Target disappeared from Prometheus target discovery.',
   },
 }

--- a/tests.yaml
+++ b/tests.yaml
@@ -1056,7 +1056,7 @@ tests:
         job_name: job1
         severity: warning
       exp_annotations:
-        summary: "Job did not complete in time"
+        summary: "Job did not complete in time."
         description: "Job ns1/job1 is taking more than 12h 0m 0s to complete."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -1087,8 +1087,8 @@ tests:
     - exp_labels:
         severity: warning
       exp_annotations:
-        summary: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
-        description: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
+        summary: "The kubernetes apiserver has terminated more than 20% of its incoming requests."
+        description: "The kubernetes apiserver in Cluster , has terminated 33.33% of its incoming requests."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
 
 - interval: 1m


### PR DESCRIPTION
These changes accommodate the latest linting rules that are rolled up into mixtool.

Mostly, this is with regard to alerting rules which should follow the [mixin standards for alerts](https://monitoring.mixins.dev/#guidelines-for-alert-names-labels-and-annotations).