### PR TITLE
PROPOSAL: Example of how to add support for joining labels into alerts from kube_XXX_labels

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -10,7 +10,7 @@
   local wrap_rule_for_labels(rule) =
     // Detect Kind of rule from name unless hidden `kind field is passed in the rule`
     local kind =
-      if std.objectHas(rule, 'kind') then rule.kind
+      if 'kind' in rule then rule.kind
       else if std.startsWith(rule.alert, 'KubePod') then 'pod'
       else if std.startsWith(rule.alert, 'KubeStateful') then 'statefulset'
       else if std.startsWith(rule.alert, 'KubeDeploy') then 'deployment'

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -12,9 +12,9 @@
         name: 'kubernetes-apps',
         rules: [
           {
-            expr: |||
+            expr: (if std.length($._config.pods_join_labels) > 0 then '(' else '') + |||
               max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", %(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}[5m]) >= 1
-            ||| % $._config,
+            ||| % $._config + (if std.length($._config.pods_join_labels) > 0 then ') * on (pod,namespace) group_left(%s) kube_pod_labels' % std.join(',', $._config.pods_join_labels) else ''),
             labels: {
               severity: 'warning',
             },

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -17,7 +17,7 @@
       else if std.startsWith(rule.alert, 'KubeDaemon') then 'daemonset'
       else null;
 
-    local labels = { join_labels: $._config['%ss_join_labels' % std.toString(kind)], on_labels: [kind, 'namespace'], metric: 'kube_%s_labels' % kind };
+    local labels = { join_labels: $._config['%ss_join_labels' % std.toString(kind)], on_labels: [kind, 'namespace'], metric: 'kube_%s_labels' % std.toString(kind) };
 
     // Failed to identify kind - return raw rule
     if kind == null then rule

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -32,9 +32,8 @@
   prometheusAlerts+:: {
     groups+: [
       {
-        local group = self,
         name: 'kubernetes-apps',
-        rules: [wrap_rule_for_labels(rule) for rule in group.rules_],
+        rules: [wrap_rule_for_labels(rule) for rule in self.rules_],
         rules_:: [
           {
             expr: |||

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -15,12 +15,12 @@
       else if std.startsWith(rule.alert, 'KubeStateful') then 'statefulset'
       else if std.startsWith(rule.alert, 'KubeDeploy') then 'deployment'
       else if std.startsWith(rule.alert, 'KubeDaemon') then 'daemonset'
-      else null;
+      else 'none';
 
-    local labels = { join_labels: $._config['%ss_join_labels' % std.toString(kind)], on_labels: [kind, 'namespace'], metric: 'kube_%s_labels' % std.toString(kind) };
+    local labels = { join_labels: $._config['%ss_join_labels' % kind], on_labels: [kind, 'namespace'], metric: 'kube_%s_labels' % kind };
 
     // Failed to identify kind - return raw rule
-    if kind == null then rule
+    if kind == 'none' then rule
     // No join labels passed in the config - return raw rule
     else if std.length(labels.join_labels) == 0 then rule
     // Wrap expr with join group left

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -33,9 +33,11 @@
     containerfsSelector: 'container!=""',
 
     // List of labels to join for different type of metrics
-    pods_join_labels: [],
-    deployments_join_labels: [],
-    statefulsets_join_labels: [],
+    common_join_labels: [],
+    pods_join_labels: $._config.common_join_labels,
+    deployments_join_labels: $._config.common_join_labels,
+    statefulsets_join_labels: $._config.common_join_labels,
+    daemonsets_join_labels: $._config.common_join_labels,
 
     // Grafana dashboard IDs are necessary for stable links for dashboards
     grafanaDashboardIDs: {

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -32,6 +32,11 @@
     windowsExporterSelector: 'job="kubernetes-windows-exporter"',
     containerfsSelector: 'container!=""',
 
+    // List of labels to join for different type of metrics
+    pods_join_labels: [],
+    deployments_join_labels: [],
+    statefulsets_join_labels: [],
+
     // Grafana dashboard IDs are necessary for stable links for dashboards
     grafanaDashboardIDs: {
       'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -38,6 +38,9 @@
     deployments_join_labels: $._config.common_join_labels,
     statefulsets_join_labels: $._config.common_join_labels,
     daemonsets_join_labels: $._config.common_join_labels,
+    horizontalpodautoscalers_join_labels: $._config.common_join_labels,
+    jobs_join_labels: $._config.common_join_labels,
+    persistentvolumeclaims_join_labels: $._config.common_join_labels,
 
     // Grafana dashboard IDs are necessary for stable links for dashboards
     grafanaDashboardIDs: {

--- a/lib/utils.libsonnet
+++ b/lib/utils.libsonnet
@@ -15,4 +15,48 @@
     if s > 60 * 60 * 24
     then '%.1f days' % (s / 60 / 60 / 24)
     else '%.1f hours' % (s / 60 / 60),
+
+  // Handle adding `group left` to join labels into rule by wrapping the rule in () * on(xxx) group_left(xxx) kube_xxx_labels
+  // If kind of rule is not defined try to detect rule type by alert name
+  wrap_rule_for_labels(rule, config):
+    // Detect Kind of rule from name unless hidden `kind field is passed in the rule`
+    local kind =
+      if 'kind' in rule then rule.kind
+      // Handle Alerts
+      else if std.objectHas(rule, 'alert') then
+        if std.startsWith(rule.alert, 'KubePod') then 'pod'
+        else if std.startsWith(rule.alert, 'KubeContainer') then 'pod'
+        else if std.startsWith(rule.alert, 'KubeStateful') then 'statefulset'
+        else if std.startsWith(rule.alert, 'KubeDeploy') then 'deployment'
+        else if std.startsWith(rule.alert, 'KubeDaemon') then 'daemonset'
+        else if std.startsWith(rule.alert, 'KubePod') then 'pod'
+        else if std.startsWith(rule.alert, 'KubeHpa') then 'horizontalpodautoscaler'
+        else if std.startsWith(rule.alert, 'KubeJob') then 'job'
+        else if std.startsWith(rule.alert, 'KubePersistentVolume') then 'persistentvolumeclaim'
+        else 'none'
+      // Handle Recording Rules - TODO
+      //else if std.objectHas(rule, 'record') then
+      else 'none';
+
+    local labels = {
+      join_labels: config['%ss_join_labels' % kind],
+      on_labels: ['%s' % (if kind == 'job' then 'job_name' else kind), 'namespace'],  // is job the only exception due to the job label being used for other purposes in prometheus ?
+      metric: 'kube_%s_labels' % kind,
+    };
+
+    // Failed to identify kind - return raw rule
+    if kind == 'none' then rule
+    // No join labels passed in the config - return raw rule
+    else if std.length(labels.join_labels) == 0 then rule
+    // Wrap expr with join group left
+    else
+      rule {
+        local expr = super.expr,
+        expr: '(%(expr)s) * on (%(on)s) group_left(%(join)s) %(metric)s' % {
+          expr: expr,
+          on: std.join(',', labels.on_labels),
+          join: std.join(',', labels.join_labels),
+          metric: labels.metric,
+        },
+      },
 }


### PR DESCRIPTION
Issue description https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/791


this is really to start the conversation and see if this is something we might like before i add it to all rules 

test of rendering rules : 

#### Default Rendering

`jsonnet -e '( import "mixin.libsonnet").prometheusAlerts' | jq '.groups[] | select(.name=="kubernetes-apps").rules | .[0],.[2],.[4],.[7]'` 

```
{
  "alert": "KubePodCrashLooping",
  "annotations": {
    "description": "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: \"CrashLoopBackOff\").",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping",
    "summary": "Pod is crash looping."
  },
  "expr": "max_over_time(kube_pod_container_status_waiting_reason{reason=\"CrashLoopBackOff\", job=\"kube-state-metrics\"}[5m]) >= 1\n",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeDeploymentGenerationMismatch",
  "annotations": {
    "description": "Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch",
    "summary": "Deployment generation mismatch due to possible roll-back"
  },
  "expr": "kube_deployment_status_observed_generation{job=\"kube-state-metrics\"}\n  !=\nkube_deployment_metadata_generation{job=\"kube-state-metrics\"}\n",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeStatefulSetReplicasMismatch",
  "annotations": {
    "description": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch",
    "summary": "Deployment has not matched the expected number of replicas."
  },
  "expr": "(\n  kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\"}\n    !=\n  kube_statefulset_status_replicas{job=\"kube-state-metrics\"}\n) and (\n  changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\"}[10m])\n    ==\n  0\n)\n",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeDaemonSetRolloutStuck",
  "annotations": {
    "description": "DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} has not finished or progressed for at least 15 minutes.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck",
    "summary": "DaemonSet rollout is stuck."
  },
  "expr": "(\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\"}[5m])\n    ==\n  0\n)\n",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}

```

#### Rendering with join labels

`jsonnet -e '( import "mixin.libsonnet"){ _config+: { common_join_labels: ["label_example_com_owner"] } }.prometheusAlerts' | jq '.groups[] | select(.name=="kubernetes-apps").rules | .[0],.[2],.[4],.[7]'`

```
{
  "alert": "KubePodCrashLooping",
  "annotations": {
    "description": "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: \"CrashLoopBackOff\").",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping",
    "summary": "Pod is crash looping."
  },
  "expr": "(max_over_time(kube_pod_container_status_waiting_reason{reason=\"CrashLoopBackOff\", job=\"kube-state-metrics\"}[5m]) >= 1\n) * on (pod,namespace) group_left(label_example_com_owner) kube_pod_labels",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeDeploymentGenerationMismatch",
  "annotations": {
    "description": "Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch",
    "summary": "Deployment generation mismatch due to possible roll-back"
  },
  "expr": "(kube_deployment_status_observed_generation{job=\"kube-state-metrics\"}\n  !=\nkube_deployment_metadata_generation{job=\"kube-state-metrics\"}\n) * on (deployment,namespace) group_left(label_example_com_owner) kube_deployment_labels",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeStatefulSetReplicasMismatch",
  "annotations": {
    "description": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch",
    "summary": "Deployment has not matched the expected number of replicas."
  },
  "expr": "((\n  kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\"}\n    !=\n  kube_statefulset_status_replicas{job=\"kube-state-metrics\"}\n) and (\n  changes(kube_statefulset_status_replicas_updated{job=\"kube-state-metrics\"}[10m])\n    ==\n  0\n)\n) * on (statefulset,namespace) group_left(label_example_com_owner) kube_statefulset_labels",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}
{
  "alert": "KubeDaemonSetRolloutStuck",
  "annotations": {
    "description": "DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} has not finished or progressed for at least 15 minutes.",
    "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck",
    "summary": "DaemonSet rollout is stuck."
  },
  "expr": "((\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_status_updated_number_scheduled{job=\"kube-state-metrics\"}[5m])\n    ==\n  0\n)\n) * on (daemonset,namespace) group_left(label_example_com_owner) kube_daemonset_labels",
  "for": "15m",
  "labels": {
    "severity": "warning"
  }
}

```