### PR TITLE
Add alert for unavailable pods in a DaemonSet

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -192,6 +192,20 @@
             'for': '15m',
           },
           {
+            alert: 'KubeDaemonSetUnavailable',
+            expr: |||
+              kube_daemonset_status_desired_number_scheduled{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} - kube_daemonset_status_number_available{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'A number of pods of daemonset {{ $labels.namespace }}/{{ $labels.daemonset }} have been unavailable for at least 5 minutes.',
+              summary: 'DaemonSet is partially unavailable.',
+            },
+            'for': '5m',
+          },
+          {
             expr: |||
               sum by (namespace, pod, container, %(clusterLabel)s) (kube_pod_container_status_waiting_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}) > 0
             ||| % $._config,

--- a/runbook.md
+++ b/runbook.md
@@ -57,6 +57,10 @@ This page collects this repositories alerts and begins the process of describing
 + *Message*: `A number of pods of daemonset {{$labels.namespace}}/{{$labels.daemonset}} are running where they are not supposed to run.`
 + *Severity*: warning
 
+##### Alert Name: "KubeDaemonSetUnavailable"
++ *Message*: `A number of pods of daemonset {{ $labels.namespace }}/{{ $labels.daemonset }} have been unavailable for at least 5 minutes.`
++ *Severity*: warning
+
 ##### Alert Name: "KubeJobNotCompleted"
 + *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than {{ "%(kubeJobTimeoutDuration)s" | humanizeDuration }} to complete.`
 + *Severity*: warning

--- a/tests.yaml
+++ b/tests.yaml
@@ -905,6 +905,37 @@ tests:
     alertname: KubeDaemonSetRolloutStuck
 
 - interval: 1m
+  # Pods in daemonset unavailable
+  input_series:
+  - series: 'kube_daemonset_status_number_available{job="kube-state-metrics",namespace="monitoring",daemonset="node-exporter"}'
+    values: '4 3 4 4 3 3 3 3 3 3 4 4'
+  - series: 'kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics",namespace="monitoring",daemonset="node-exporter"}'
+    values: '4 4 4 4 4 4 4 4 4 4 4 4'
+  alert_rule_test:
+  - eval_time: 1m
+    alertname: KubeDaemonSetUnavailable
+  - eval_time: 5m
+    alertname: KubeDaemonSetUnavailable
+  - eval_time: 6m
+    alertname: KubeDaemonSetUnavailable
+  - eval_time: 7m
+    alertname: KubeDaemonSetUnavailable
+  - eval_time: 8m
+    alertname: KubeDaemonSetUnavailable
+  - eval_time: 9m
+    alertname: KubeDaemonSetUnavailable
+    exp_alerts:
+    - exp_labels:
+        job: kube-state-metrics
+        namespace: monitoring
+        daemonset: node-exporter
+        severity: warning
+      exp_annotations:
+        summary: "DaemonSet is partially unavailable."
+        description: 'A number of pods of daemonset monitoring/node-exporter have been unavailable for at least 5 minutes.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetunavailable
+
+- interval: 1m
   input_series:
   - series: 'kubelet_certificate_manager_client_ttl_seconds{job="kubelet",namespace="monitoring",node="minikube"}'
     values: '86400-60x1'


### PR DESCRIPTION
As DaemonSet typically keep track of critical components I think it would be beneficial if there would be an alert for any of them being unavailable.