### PR TITLE
add prometheus rule for OOMKilled pods

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -38,7 +38,7 @@
             },
             annotations: {
               description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) got OOMKilled',
-              summary: 'Pod got OOMKilled.',
+              summary: 'Pod was OOMKilled.',
             },
             'for': '15m',
             alert: 'KubePodOOMKilled',

--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -37,7 +37,7 @@
               severity: 'warning',
             },
             annotations: {
-              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) got OOMKilled',
+              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) was OOMKilled',
               summary: 'Pod was OOMKilled.',
             },
             'for': '15m',


### PR DESCRIPTION
Signed-off-by: DavidSpek <vanderspek.david@gmail.com>

This PR adds a prometheus rule to catch pods that have been OOMKilled.
Happy to improve or change the expression if anybody has suggestions.