### PR TITLE
add alert KubePodNotScheduled.

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -50,6 +50,15 @@
             alert: 'KubePodNotReady',
           },
           {
+            expr: 'last_over_time(kube_pod_status_unschedulable[5m]) == 1',
+            'for': '30m',
+            alert: 'KubePodNotScheduled',
+            annotations: {
+              description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} cannot be scheduled for longer than 30 minutes.',
+              summary: 'Pod cannot be scheduled.',
+            },
+          },
+          {
             expr: |||
               kube_deployment_status_observed_generation{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 !=


### PR DESCRIPTION
This PR adds an alert for pods cannot be scheduled for longer than 30 minutes. 

The alert `KubePodNotReady` includes the case that the pod is not even able to be scheduled. This is not the same case as a pod fails to start. So we may need this new alert to separate these 2 different cases.

Here is a patch on the alert `KubePodNotReady` to exclude unschedulable pods from the alert: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/802