### PR TITLE
Set defaults for panels outside of rows

### DIFF
--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -11,28 +11,35 @@
       refresh: kubernetesMixin._config.grafanaK8s.refresh,
       tags: kubernetesMixin._config.grafanaK8s.dashboardTags,
 
+      local setPanelDefaults = function(panel)
+        panel {
+          // Modify tooltip to only show a single value
+          tooltip+: {
+            shared: false,
+          },
+          // Modify legend to always show as table on right side
+          legend+: {
+            alignAsTable: true,
+            rightSide: true,
+          },
+          // Set minimum time interval for all panels
+          interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval,
+        },
+
       rows: [
         row {
           panels: [
-            panel {
-              // Modify tooltip to only show a single value
-              tooltip+: {
-                shared: false,
-              },
-              // Modify legend to always show as table on right side
-              legend+: {
-                alignAsTable: true,
-                rightSide: true,
-              },
-              // Set minimum time interval for all panels
-              interval: kubernetesMixin._config.grafanaK8s.minimumTimeInterval,
-            }
+            setPanelDefaults(panel)
             for panel in super.panels
           ],
         }
         for row in super.rows
       ],
 
+      [if 'panels' in grafanaDashboards[filename] then 'panels']: [
+        setPanelDefaults(panel)
+        for panel in super.panels
+      ],
     }
     for filename in std.objectFields(grafanaDashboards)
   },


### PR DESCRIPTION
Some dashboards, such as kubelet, have panels outside of rows. The way panel defaults were set previously meant that config such as the minimum interval would not be set for these panels.