### PR TITLE
Make datasource configurable on remaining dashboards

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -4,6 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -323,8 +332,8 @@ local template = grafana.template;
           },
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate],
         },
       },
   },

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -1,8 +1,19 @@
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
+local template = grafana.template;
 
 {
   grafanaDashboards+::
     if $._config.showMultiCluster then {
+      local datasource = template.datasource(
+        name='datasource',
+        query='prometheus',
+        current=$._config.datasourceName,
+        hide='',
+        label='Data Source',
+        regex=$._config.datasourceFilterRegex,
+        refresh=1,
+      ),
       'k8s-resources-multicluster.json':
         local tableStyles = {
           [$._config.clusterLabel]: {
@@ -100,6 +111,11 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
               'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
             })
           )
-        ),
+        )
+        + {
+          templating: {
+            list+: [datasource],
+          },
+        },
     } else {},
 }

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -4,6 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -364,8 +373,8 @@ local template = grafana.template;
           },
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate, namespaceTemplate],
         },
       },
   },

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -4,6 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -144,8 +153,8 @@ local template = grafana.template;
           })
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate, nodeTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate, nodeTemplate],
         },
       },
   },

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -4,6 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -344,8 +353,8 @@ local template = grafana.template;
           },
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate, podTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate, namespaceTemplate, podTemplate],
         },
       },
   },

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -4,7 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
-
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -377,8 +385,8 @@ local template = grafana.template;
           { yaxes: g.yaxes('pps') },
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate, typeTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate, namespaceTemplate, typeTemplate],
         },
       },
 

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -4,6 +4,15 @@ local template = grafana.template;
 
 {
   grafanaDashboards+:: {
+    local datasource = template.datasource(
+      name='datasource',
+      query='prometheus',
+      current=$._config.datasourceName,
+      hide='',
+      label='Data Source',
+      regex=$._config.datasourceFilterRegex,
+      refresh=1,
+    ),
     local clusterTemplate =
       template.new(
         name='cluster',
@@ -314,8 +323,8 @@ local template = grafana.template;
           { yaxes: g.yaxes('pps') },
         )
       ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate, workloadTypeTemplate, workloadTemplate],
+        templating: {
+          list+: [datasource, clusterTemplate, namespaceTemplate, workloadTypeTemplate, workloadTemplate],
         },
       },
   },


### PR DESCRIPTION
[datasourceName](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/eb707bf721dc702baeac2827345e531d6fd207e1/config.libsonnet#L90) and [datasourceFilterRegex](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/eb707bf721dc702baeac2827345e531d6fd207e1/config.libsonnet#L93) allow configuring the datasource on most dashboards. This merge request extends it to the rest of the dashboards.


The original feature was introduce in https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/666