### PR TITLE
feat: Add KubeJobFailing alert

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -67,6 +67,11 @@ This page collects this repositories alerts and begins the process of describing
 + *Severity*: warning
 + *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
 
+##### Alert Name: "KubeJobFailing"
++ *Message*: `Job {{ $labels.namespace }}/{{ $labels.job_name }} is failing to complete.`
++ *Severity*: warning
++ *Action*: Check the job using `kubectl describe job <job>` and look at the pod logs using `kubectl logs <pod>` for further information.
+
 ### Group Name: "kubernetes-resources"
 ##### Alert Name: "KubeCPUOvercommit"
 + *Message*: `Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.`

--- a/tests.yaml
+++ b/tests.yaml
@@ -1041,6 +1041,28 @@ tests:
 
 - interval: 1m
   input_series:
+  - series: 'kube_job_status_start_time{container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", job_name="job1", namespace="ns1", service="kube-state-metrics"}'
+    values: '1610638100+1x20'
+  - series: 'kube_job_owner{container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", job_name="job1", namespace="ns1", owner_is_controller="false", owner_kind="ConfigMap", owner_name="job1owner", service="kube-state-metrics"}'
+    values: '1+0x20'
+  - series: 'kube_job_status_failed{container="kube-rbac-proxy-main", endpoint="https-main", job="kube-state-metrics", job_name="job1", namespace="ns1", service="kube-state-metrics"}'
+    values: '1+0x20'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeJobFailing
+    exp_alerts:
+    - exp_labels:
+        namespace: ns1
+        job_name: job1
+        owner_name: job1owner
+        severity: warning
+      exp_annotations:
+        summary: "Job is failing to complete."
+        description: "Job ns1/job1 is failing to complete."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailing"
+
+- interval: 1m
+  input_series:
   - series: 'kube_job_status_start_time{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
     values: '0+0x200 _x500 0+0x40'
   - series: 'kube_job_status_active{namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'


### PR DESCRIPTION
As a community member, I want an alert that fires if the Kubernetes Job is consecutively failing, so that I can enable on-call personnel to make a better priority-focused decision.

This PR proposes adding a new KubeJobFailing alert to solve the problem mentioned in the previous line.

I was not able to find Contributors guide in this repository as such please let me know which steps are required.