### PR TITLE
Remove false alarm on a volume with infinite inodes

### DIFF
--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -76,6 +76,8 @@
               ) < 0.03
               and
               kubelet_volume_stats_inodes_used{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
+              and
+              kubelet_volume_stats_inodes_free{%(prefixedNamespaceSelector)s%(kubeletSelector)s} > 0
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_access_mode{%(prefixedNamespaceSelector)s access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)


### PR DESCRIPTION
On some storage systems, such as a CephFS filesystem, the underlying storage doesn't have any limit on inodes.

If the kubelet_volume_stats_inodes_free metric is always zero, then the KubePersistentVolumeInodesFillingUp alert will always fire.

This patch adds a simple conditional to ensure that the kubelet_volume_stats_inodes_free is meaningful for the volume and thus fixing the false alert on this edge case.