### PR TITLE
fix: revert failed pods marked as NotReady

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -33,7 +33,7 @@
             expr: |||
               sum by (namespace, pod, %(clusterLabel)s) (
                 max by(namespace, pod, %(clusterLabel)s) (
-                  kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown|Failed"}
+                  kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown"}
                 ) * on(namespace, pod, %(clusterLabel)s) group_left(owner_kind) topk by(namespace, pod, %(clusterLabel)s) (
                   1, max by(namespace, pod, owner_kind, %(clusterLabel)s) (kube_pod_owner{owner_kind!="Job"})
                 )


### PR DESCRIPTION
This reverts what I think is the correct behavior. 

`GracefulNodeShutdown` features (enabled by default with 1.21) terminates pods on nodes and set they `phase` to `Failed`. However, these are evicted and should not be taken as failures. See https://github.com/kubernetes/kubernetes/issues/113278.

See details in the history:

Initial issue https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/215
Added https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/1
Reverted https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/70
Added https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/221
Reverted https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/296
Added https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/784

I guess this query could be enhanced to support these previous use cases, however, changing it like it was done previously alerts on default Kubernetes behavior.