### PR TITLE
Create alert for OOMKill events inside containers

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -1113,7 +1113,7 @@ tests:
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
         summary: "Pod is crash looping."
   - eval_time: 20m
-    alertname: KubePodCrashLooping   # alert fired for a period of 5 minutes after resolution because the alert looks back at the last 5 minutes of data and the range vector doesn't take stale samples into account 
+    alertname: KubePodCrashLooping   # alert fired for a period of 5 minutes after resolution because the alert looks back at the last 5 minutes of data and the range vector doesn't take stale samples into account
     exp_alerts:
       - exp_labels:
           severity: "warning"
@@ -1214,3 +1214,25 @@ tests:
         description: 'Cluster has overcommitted memory resource requests for Namespaces.'
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
         summary: "Cluster has overcommitted memory resource requests."
+
+- interval: 1m
+  input_series:
+  - series: 'container_oom_events_total{container="dbserver", namespace="default", pod="dbserver-128fnk319a-alq1x"}'
+    values: '0 0 0 0 0 0 0'
+  - series: 'container_oom_events_total{container="webserver", namespace="default", pod="webserver-69755ddb67-dn2v5"}'
+    values: '0 2 2 4 4 4 4'
+  alert_rule_test:
+  - eval_time: 5m
+    alertname: KubeContainerOOMEvents
+  - eval_time: 6m
+    alertname: KubeContainerOOMEvents
+    exp_alerts:
+    - exp_labels:
+        container: webserver
+        namespace: default
+        pod: webserver-69755ddb67-dn2v5
+        severity: warning
+      exp_annotations:
+        summary: Processes are being OOMKilled
+        description: Processes are being killed by the Out Of Memory (OOM) Killer inside the "webserver" container in pod default/webserver-69755ddb67-dn2v5.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontaineroomevents


### PR DESCRIPTION
Helps with #759, second attempt of #760. Also may be related to #112 and may supersede #800?

In Kubernetes 1.24, kubelet started exposing a metric that counts OOMKill events for specific containers, [container_oom_events_total](https://github.com/kubernetes/kubernetes/pull/108004), which I used for this alert.

This alert will fire if there are any of these OOMKill events in a container. Multi-process containers like webservers that have multiple "worker" process could silently be OOMKilled without this. I have personally seen a pod running Gunicorn throw a 100% error rate due to OOMKills that 1) didn't show up in app-level monitoring, since the workers died before recording stats, and 2) didn't show up in any existing `kubernetes-mixin` alerts since PID1 never died.

IMO this alert might be better than #800 since it's more granular (at the container and process level). The `OOMKilled` pod status may be incorrect since it just checks if `exit_code == 137`, which is caused by any SIGKILL, not just the OOMKiller.

Open to suggestions!
