### PR TITLE
Add transformation to CPU Utilization to make cluster name the label

### DIFF
--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -23,6 +23,19 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
           .addPanel(
             g.panel('CPU Utilisation') +
             g.statPanel('cluster:node_cpu:ratio_rate5m')
+            + {
+              transformations: [
+                {
+                  id: 'labelsToFields',
+                  options: {
+                    keepLabels: [
+                      '%(clusterLabel)s' % $._config,
+                    ],
+                    valueLabel: '%(clusterLabel)s' % $._config,
+                  },
+                },
+              ],
+            }
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +


### PR DESCRIPTION
Currently the stat panel used for CPU Utilization uses the entire query as the label for cluster you cannot easy see the cluster name nor the value of utilization. This change uses the user provided clusterLabel as part of the transformation to allow for easier readability.