### PR TITLE
alerts/app_alerts: Fix `KubeJobFailed` alert repetitive triggering when `kube-state-metrics` pods restart

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -253,7 +253,9 @@
           {
             alert: 'KubeJobFailed',
             expr: |||
-              kube_job_failed{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}  > 0
+              sum without (instance) (
+                kube_job_failed{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              )  > 0
             ||| % $._config,
             'for': '15m',
             labels: {


### PR DESCRIPTION
`kube_job_failed` metric contains instance label that shows IP of `kube-state-metrics` source. If source changes, the alertmanager thinks that a new incident occurred and sends alert for old jobs again