### PR TITLE
Update KubePodNotReady alert query to reduce noise

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -31,12 +31,10 @@
             // label exists for 2 values. This avoids "many-to-many matching
             // not allowed" errors when joining with kube_pod_status_phase.
             expr: |||
-              sum by (namespace, pod, %(clusterLabel)s) (
+              sum by (namespace, controller, %(clusterLabel)s) (
                 max by(namespace, pod, %(clusterLabel)s) (
                   kube_pod_status_phase{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, phase=~"Pending|Unknown|Failed"}
-                ) * on(namespace, pod, %(clusterLabel)s) group_left(owner_kind) topk by(namespace, pod, %(clusterLabel)s) (
-                  1, max by(namespace, pod, owner_kind, %(clusterLabel)s) (kube_pod_owner{owner_kind!="Job"})
-                )
+                ) * on(namespace, pod, %(clusterLabel)s) group_left(controller) label_replace(kube_pod_owner,"controller","$1","owner_name","(.*)")
               ) > 0
             ||| % $._config,
             labels: {


### PR DESCRIPTION
This change updates the alert query for KubePodNotReady. 
This alert query shows high noise since it is aggregating at the pod level. This happens when we use this alert to run on a very large cluster with many pods. The aggregation is now being done at the "controller" level, rather than the "pod" level to significantly reduce the count of alerts for large scale clusters.  We have also updated the query logic also to make it simpler. 

Below are the details(original vs. new) of the counts of the alert on a large scale cluster.

alertName                             new     orig
Default/KubePodNotReady   14       206