### PR TITLE
replace -1 decimals with 'auto'

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -102,17 +102,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #D': {
           alias: 'Throughput(Read)',
@@ -297,7 +297,7 @@ local template = grafana.template;
           g.panel('IOPS(Reads+Writes)') +
           g.queryPanel('ceil(sum by(namespace) (rate(container_fs_reads_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace!=""}[%(grafanaIntervalVar)s]) + rate(container_fs_writes_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster", namespace!=""}[%(grafanaIntervalVar)s])))' % $._config, '{{namespace}}') +
           g.stack +
-          { yaxes: g.yaxes('short'), decimals: -1 },
+          { yaxes: g.yaxes('short'), decimals: 'auto' },
 
         )
         .addPanel(

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -103,17 +103,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #D': {
           alias: 'Throughput(Read)',
@@ -338,7 +338,7 @@ local template = grafana.template;
           g.panel('IOPS(Reads+Writes)') +
           g.queryPanel('ceil(sum by(pod) (rate(container_fs_reads_total{%(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]) + rate(container_fs_writes_total{%(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])))' % $._config, '{{pod}}') +
           g.stack +
-          { yaxes: g.yaxes('short'), decimals: -1 },
+          { yaxes: g.yaxes('short'), decimals: 'auto' },
 
         )
         .addPanel(

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -74,17 +74,17 @@ local template = grafana.template;
         'Value #A': {
           alias: 'IOPS(Reads)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
           unit: 'short',
-          decimals: -1,
+          decimals: 'auto',
         },
         'Value #D': {
           alias: 'Throughput(Read)',
@@ -304,7 +304,7 @@ local template = grafana.template;
           g.panel('IOPS') +
           g.queryPanel(['ceil(sum by(pod) (rate(container_fs_reads_total{%(cadvisorSelector)s, %(diskDeviceSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % $._config, 'ceil(sum by(pod) (rate(container_fs_writes_total{%(cadvisorSelector)s, %(diskDeviceSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster",namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % $._config], ['Reads', 'Writes']) +
           g.stack +
-          { yaxes: g.yaxes('short'), decimals: -1 },
+          { yaxes: g.yaxes('short'), decimals: 'auto' },
         )
         .addPanel(
           g.panel('ThroughPut') +
@@ -319,7 +319,7 @@ local template = grafana.template;
           g.panel('IOPS(Reads+Writes)') +
           g.queryPanel('ceil(sum by(container) (rate(container_fs_reads_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[%(grafanaIntervalVar)s]) + rate(container_fs_writes_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}[%(grafanaIntervalVar)s])))' % $._config, '{{container}}') +
           g.stack +
-          { yaxes: g.yaxes('short'), decimals: -1 },
+          { yaxes: g.yaxes('short'), decimals: 'auto' },
         )
         .addPanel(
           g.panel('ThroughPut(Read+Write)') +


### PR DESCRIPTION
On grafana v10.0.1 the values with -1 decimals don't show up without any error indication.

I don't know what was the meaning of -1 but these are all short unit values so I assume ~no~ auto decimals is the intended behavior.