### PR TITLE
Adding support for datasource_regex in resources dashboards

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -131,6 +131,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Cluster' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         (g.row('Headlines') +

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -14,6 +14,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         g.dashboard(
           '%(dashboardNamePrefix)sCompute Resources /  Multi-Cluster' % $._config.grafanaK8s,
           uid=($._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
+          datasource_regex=$._config.datasourceFilterRegex,
         ).addRow(
           (g.row('Headlines') +
            {

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -132,6 +132,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Namespace (Pods)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         (g.row('Headlines') +

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -39,6 +39,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Node (Pods)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-node.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         g.row('CPU Usage')

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -103,6 +103,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Pod' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         g.row('CPU Usage')

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -164,6 +164,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         g.row('CPU Usage')

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -156,6 +156,7 @@ local template = grafana.template;
       g.dashboard(
         '%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-workload.json']),
+        datasource_regex=$._config.datasourceFilterRegex,
       )
       .addRow(
         g.row('CPU Usage')


### PR DESCRIPTION
Dashboards created in `dashboards/resources` does not support `datasourceFilterRegex` field present in `config.libsonnet`. This will be resolved with this change.