### PR TITLE
:bug: Avoid duplicate into the same recording rule

### DIFF
--- a/rules/kube_apiserver.libsonnet
+++ b/rules/kube_apiserver.libsonnet
@@ -273,10 +273,9 @@
           {
             record: 'code_verb:apiserver_request_total:increase1h',
             expr: |||
-              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
-            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, code],
+              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2..|3..|4..|5.."}[1h]))
+            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector],
           }
-          for code in ['2..', '3..', '4..', '5..']
         ],
       },
     ],


### PR DESCRIPTION
This PR remove few duplicates Prometheus Rules in the kube-apiserver-availability rules group.

It's easy to verify, using promtool check rules <my_rule_file.yaml>

BEFORE :

```bash
$ promtool check rules tmp/rules/test-kube-apiserver-availability.rules.yaml
Checking /tmp/rules/test-kube-apiserver-availability.rules.yaml
  FAILED:
lint error 1 duplicate rule(s) found.
Metric: code_verb:apiserver_request_total:increase1h
Label(s):
Might cause inconsistency while recording expressions
```
AFTER :

```bash
$ promtool check rules tmp/rules/test-kube-apiserver-availability.rules.yaml
Checking /tmp/rules/test-kube-apiserver-availability.rules.yaml
  SUCCESS: 13 rules found
```