### PR TITLE
Fix IOPS panel

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -101,18 +101,18 @@ local template = grafana.template;
         },
         'Value #A': {
           alias: 'IOPS(Reads)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #D': {
           alias: 'Throughput(Read)',

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -102,18 +102,18 @@ local template = grafana.template;
         },
         'Value #A': {
           alias: 'IOPS(Reads)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #D': {
           alias: 'Throughput(Read)',

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -73,18 +73,18 @@ local template = grafana.template;
         },
         'Value #A': {
           alias: 'IOPS(Reads)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #B': {
           alias: 'IOPS(Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #C': {
           alias: 'IOPS(Reads + Writes)',
-          unit: 'short',
-          decimals: -1,
+          unit: 'iops',
+          decimals: 3,
         },
         'Value #D': {
           alias: 'Throughput(Read)',


### PR DESCRIPTION
In modern Grafana version, the panel does not work:

<img width="1270" alt="image" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1560587/28d6962b-e76f-43b7-9262-af426302d7af">
