### PR TITLE
Split k8s.rules group into three groups

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -58,6 +58,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.container_resource',
+        rules: [
           {
             record: 'cluster:namespace:pod_memory:active:kube_pod_container_resource_requests',
             expr: |||
@@ -150,6 +155,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.pod_owner',
+        rules: [
           // workload aggregation for deployments
           {
             record: 'namespace_workload_pod:kube_pod_owner:relabel',


### PR DESCRIPTION
In order to prevent missed deadlines of some rules affecting the entire group, split the k8s.rules group into three groups. Similar to #632.