### PR TITLE
Dashboards: Fix deeplinks

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -217,7 +217,7 @@ local annotation = grafana.annotation;
           style=newStyle(
             alias='Namespace',
             link=true,
-            linkUrl='d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=$__cell',
+            linkUrl='d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=${__value.text}',
           ),
         ) + {
 

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -207,7 +207,7 @@ local singlestat = grafana.singlestat;
           style=newStyle(
             alias='Pod',
             link=true,
-            linkUrl='d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell'
+            linkUrl='d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=${__value.text}'
           ),
         ) + {
 

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -210,7 +210,7 @@ local annotation = grafana.annotation;
           style=newStyle(
             alias='Workload',
             link=true,
-            linkUrl='d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell'
+            linkUrl='d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=${__value.text}'
           ),
         ) + {
 

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -20,19 +20,19 @@ local template = grafana.template;
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
           alias: 'Pods',
           linkTooltip: 'Drill down to pods',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           decimals: 0,
         },
         'Value #B': {
           alias: 'Workloads',
           linkTooltip: 'Drill down to workloads',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workloads-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workloads-namespace.json') },
           decimals: 0,
         },
       };
@@ -55,7 +55,7 @@ local template = grafana.template;
       local networkTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -96,7 +96,7 @@ local template = grafana.template;
       local storageIOTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=${__data.fields.namespace}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -7,7 +7,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         local tableStyles = {
           [$._config.clusterLabel]: {
             alias: 'Cluster',
-            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-cluster.json') },
+            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-cluster.json') },
           },
         };
 

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -32,7 +32,7 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 
@@ -48,7 +48,7 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -97,7 +97,7 @@ local template = grafana.template;
       local storageIOTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -52,7 +52,7 @@ local template = grafana.template;
       local tableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=${__value.text}&var-type=${__value.text}_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
         },
         workload_type: {
           alias: 'Workload Type',
@@ -95,7 +95,7 @@ local template = grafana.template;
       local networkTableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=${__value.text}&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
           linkTooltip: 'Drill down to pods',
         },
         workload_type: {

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -56,7 +56,7 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
       };
 
@@ -96,7 +96,7 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -11,12 +11,12 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-namespace.json') },
         },
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Cluster(Windows)' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sCompute Resources / Cluster (Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-cluster.json']),
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
@@ -138,12 +138,12 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=${__value.text}' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-pod.json') },
         },
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Namespace(Windows)' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sCompute Resources / Namespace (Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-namespace.json']),
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
@@ -247,7 +247,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sCompute Resources / Pod(Windows)' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sCompute Resources / Pod (Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-resources-windows-pod.json']),
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
@@ -378,7 +378,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-windows-node-rsrc-use' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-windows-node-rsrc-use.json') };
 
       dashboard.new(
-        '%(dashboardNamePrefix)sUSE Method / Cluster(Windows)' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sUSE Method / Cluster (Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-windows-cluster-rsrc-use.json']),
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(
@@ -473,7 +473,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
 
     'k8s-windows-node-rsrc-use.json':
       dashboard.new(
-        '%(dashboardNamePrefix)sUSE Method / Node(Windows)' % $._config.grafanaK8s,
+        '%(dashboardNamePrefix)sUSE Method / Node (Windows)' % $._config.grafanaK8s,
         uid=($._config.grafanaDashboardIDs['k8s-windows-node-rsrc-use.json']),
         tags=($._config.grafanaK8s.dashboardTags),
       ).addTemplate(


### PR DESCRIPTION
Since Grafana has a new Table panel (since Grafana 7), the deeplink `$__cell` isn't working anymore. (at least in Grafana 10.2)