### PR TITLE
fix: multi-cluster resources wrong cpu util display

### DIFF
--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -24,7 +24,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
            })
           .addPanel(
             g.panel('CPU Utilisation') +
-            g.statPanel('cluster:node_cpu:ratio_rate5m')
+            g.statPanel('sum(cluster:node_cpu:ratio_rate5m)')
           )
           .addPanel(
             g.panel('CPU Requests Commitment') +


### PR DESCRIPTION
the cpu utilisation on the multi-cluster resources dashboard is broken with more then one cluster
![Screenshot 2024-02-22 at 13 20 49](https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/15877419/8fae9a1d-c42e-4202-bbb0-ad8f47638c3e)
