### PR TITLE
Add a Cache Usage panel in node resources dashboard

### DIFF
--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -120,6 +120,16 @@ local template = grafana.template;
             ],
           },
         )
+        .addPanel(
+          g.panel('Cache Usage') +
+          g.queryPanel([
+            'sum(node_namespace_pod_container:container_memory_cache{%(clusterLabel)s="$cluster", node=~"$node", container!=""}) by (pod)' % $._config,
+          ], [
+            '{{pod}}',
+          ]) +
+          g.stack +
+          { yaxes: g.yaxes('bytes') },
+        )
       )
       .addRow(
         g.row('Memory Quota')


### PR DESCRIPTION
This PR adds a "Cache Usage" panel to the "Memory Usage" rows in the node resources dashboard, e.g.:

![Screenshot from 2024-03-02 18-37-16](https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/16444/5fce4f67-d376-4954-b8c5-0dd2c1bbb1f3)

