### PR TITLE
Add -e flag to `go list` command to fix `make` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(BIN_DIR):
 
 $(TOOLING): $(BIN_DIR)
 	@echo Installing tools from hack/tools.go
-	@cd scripts && go list -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
+	@cd scripts && go list -e -mod=mod -tags tools -f '{{ range .Imports }}{{ printf "%s\n" .}}{{end}}' ./ | xargs -tI % go build -mod=mod -o $(BIN_DIR) %
 
 ########################################
 # "check-with-upstream" workflow checks.


### PR DESCRIPTION
Fixes https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/900

This adds the flag `-e` to the `go list` command in Makefile, to mitigate errors like

```
tools.go:9:2: import "github.com/google/go-jsonnet/cmd/jsonnet" is a program, not an importable package
tools.go:9:2: import "github.com/google/go-jsonnet/cmd/jsonnet" is a program, not an importable package
```