### PR TITLE
Fix dashboard uid overriding by grafanaDashboardIDs map

### DIFF
--- a/dashboards/defaults.libsonnet
+++ b/dashboards/defaults.libsonnet
@@ -6,7 +6,7 @@
   // of the file name and set the timezone to be 'default'.
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
-      uid: std.md5(filename),
+      uid: std.get(kubernetesMixin._config.grafanaDashboardIDs, filename, default=std.md5(filename)),
       timezone: kubernetesMixin._config.grafanaK8s.grafanaTimezone,
       refresh: kubernetesMixin._config.grafanaK8s.refresh,
       tags: kubernetesMixin._config.grafanaK8s.dashboardTags,

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -20,19 +20,19 @@ local template = grafana.template;
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-namespace.json', default=std.md5('k8s-resources-namespace.json')) },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
           alias: 'Pods',
           linkTooltip: 'Drill down to pods',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-namespace.json', default=std.md5('k8s-resources-namespace.json')) },
           decimals: 0,
         },
         'Value #B': {
           alias: 'Workloads',
           linkTooltip: 'Drill down to workloads',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workloads-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-workloads-namespace.json', default=std.md5('k8s-resources-workloads-namespace.json')) },
           decimals: 0,
         },
       };
@@ -55,7 +55,7 @@ local template = grafana.template;
       local networkTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-namespace.json', default=std.md5('k8s-resources-namespace.json')) },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -96,7 +96,7 @@ local template = grafana.template;
       local storageIOTableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-namespace.json', default=std.md5('k8s-resources-namespace.json')) },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -7,7 +7,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
         local tableStyles = {
           [$._config.clusterLabel]: {
             alias: 'Cluster',
-            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-cluster.json') },
+            link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-cluster.json', default=std.md5('k8s-resources-cluster.json')) },
           },
         };
 

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -32,7 +32,7 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-pod.json', default=std.md5('k8s-resources-pod.json')) },
         },
       };
 
@@ -48,7 +48,7 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-pod.json', default=std.md5('k8s-resources-pod.json')) },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {
@@ -97,7 +97,7 @@ local template = grafana.template;
       local storageIOTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-pod.json', default=std.md5('k8s-resources-pod.json')) },
           linkTooltip: 'Drill down to pods',
         },
         'Value #A': {

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -52,7 +52,7 @@ local template = grafana.template;
       local tableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-workload.json', default=std.md5('k8s-resources-workload.json')) },
         },
         workload_type: {
           alias: 'Workload Type',
@@ -95,7 +95,7 @@ local template = grafana.template;
       local networkTableStyles = {
         workload: {
           alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-workload.json', default=std.md5('k8s-resources-workload.json')) },
           linkTooltip: 'Drill down to pods',
         },
         workload_type: {

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -56,7 +56,7 @@ local template = grafana.template;
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-pod.json', default=std.md5('k8s-resources-pod.json')) },
         },
       };
 
@@ -96,7 +96,7 @@ local template = grafana.template;
       local networkTableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-pod.json', default=std.md5('k8s-resources-pod.json')) },
         },
         'Value #A': {
           alias: 'Current Receive Bandwidth',

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -11,7 +11,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-windows-namespace.json', default=std.md5('k8s-resources-windows-namespace.json')) },
         },
       };
 
@@ -138,7 +138,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-windows-pod.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-windows-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-resources-windows-pod.json', default=std.md5('k8s-resources-windows-pod.json')) },
         },
       };
 
@@ -377,7 +377,7 @@ local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libson
       ),
 
     'k8s-windows-cluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(uid)s/k8s-windows-node-rsrc-use' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-windows-node-rsrc-use.json') };
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-windows-node-rsrc-use' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.get($._config.grafanaDashboardIDs, 'k8s-windows-node-rsrc-use.json', default=std.md5('k8s-windows-node-rsrc-use.json')) };
 
       dashboard.new(
         '%(dashboardNamePrefix)sUSE Method / Cluster(Windows)' % $._config.grafanaK8s,


### PR DESCRIPTION
Hi!
I've noticed that values defined in grafanaDashboardIDs don't apply during the generation of dashboards; the UIDs always equal the MD5 hash of the file name. We have multiple instances of dashboards (due to various versions of Kubernetes releases) and would like to have different UIDs for each release.