### PR TITLE
fix: calculate average CPU util

### DIFF
--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -63,7 +63,7 @@ local var = g.dashboard.variable;
             statPanel(
               'CPU Utilisation',
               'none',
-              'cluster:node_cpu:ratio_rate5m'
+              'sum(cluster:node_cpu:ratio_rate5m) / count(cluster:node_cpu:ratio_rate5m)'
             ),
 
             statPanel(


### PR DESCRIPTION
With this, the average CPU utilization across clusters is calculated instead of listing the CPU util per cluster.
This fixes the visuals of the panel and brings it in line with the other panels in the row, which all display an average.