### PR TITLE
fix(dashboards): Port compute/workload dashboard to new grafonnet

### DIFF
--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -1,129 +1,116 @@
-local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
-local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
-local template = grafana.template;
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local prometheus = g.query.prometheus;
+local stat = g.panel.stat;
+local table = g.panel.table;
+local timeSeries = g.panel.timeSeries;
+local var = g.dashboard.variable;
 
 {
+  local statPanel(title, unit, query) =
+    stat.new(title)
+    + stat.options.withColorMode('none')
+    + stat.standardOptions.withUnit(unit)
+    + stat.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
+    + stat.queryOptions.withTargets([
+      prometheus.new('${datasource}', query)
+      + prometheus.withInstant(true),
+    ]),
+
+  local tsPanel =
+    timeSeries {
+      new(title):
+        timeSeries.new(title)
+        + timeSeries.options.legend.withShowLegend()
+        + timeSeries.options.legend.withAsTable()
+        + timeSeries.options.legend.withDisplayMode('table')
+        + timeSeries.options.legend.withPlacement('right')
+        + timeSeries.options.legend.withCalcs(['lastNotNull'])
+        + timeSeries.options.tooltip.withMode('single')
+        + timeSeries.fieldConfig.defaults.custom.withShowPoints('never')
+        + timeSeries.fieldConfig.defaults.custom.withFillOpacity(10)
+        + timeSeries.fieldConfig.defaults.custom.withSpanNulls(true)
+        + timeSeries.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval),
+    },
+
   grafanaDashboards+:: {
-    local clusterTemplate =
-      template.new(
-        name='cluster',
-        datasource='$datasource',
-        query='label_values(up{%(kubeStateMetricsSelector)s}, %(clusterLabel)s)' % $._config,
-        current='',
-        hide=if $._config.showMultiCluster then '' else '2',
-        refresh=2,
-        includeAll=false,
-        sort=1
-      ),
-
-    local namespaceTemplate =
-      template.new(
-        name='namespace',
-        datasource='$datasource',
-        query='label_values(kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
-        current='',
-        hide='',
-        refresh=2,
-        includeAll=false,
-        multi=false,
-        sort=1
-      ),
-
-    local workloadTypeTemplate =
-      template.new(
-        name='type',
-        datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}, workload_type)' % $._config.clusterLabel,
-        current='',
-        hide='',
-        refresh=2,
-        includeAll=true,
-        sort=0
-      ),
-
-    local workloadTemplate =
-      template.new(
-        name='workload',
-        datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}, workload)' % $._config.clusterLabel,
-        current='',
-        hide='',
-        refresh=2,
-        includeAll=false,
-        sort=1
-      ),
     'k8s-resources-workload.json':
-      local tableStyles = {
-        pod: {
-          alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
-        },
+      local variables = {
+        datasource:
+          var.datasource.new('datasource', 'prometheus')
+          + var.datasource.withRegex($._config.datasourceFilterRegex)
+          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.datasource.generalOptions.withLabel('Data source')
+          + {
+            current: {
+              selected: true,
+              text: $._config.datasourceName,
+              value: $._config.datasourceName,
+            },
+          },
+
+        cluster:
+          var.query.new('cluster')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            $._config.clusterLabel,
+            'up{%(kubeStateMetricsSelector)s}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('cluster')
+          + var.query.refresh.onTime()
+          + (
+            if $._config.showMultiCluster
+            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+            else var.query.generalOptions.showOnDashboard.withNothing()
+          )
+          + var.query.withSort(type='alphabetical'),
+
+        namespace:
+          var.query.new('namespace')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'namespace',
+            'kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('namespace')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
+
+        workload_type:
+          var.query.new('type')
+          + var.query.selectionOptions.withIncludeAll()
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'workload_type',
+            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('workload_type')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
+
+        workload:
+          var.query.new('workload')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'workload',
+            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('workload')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
       };
 
-      local networkColumns = [
-        |||
-          (sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-      ];
-
-      local networkTableStyles = {
+      local links = {
         pod: {
-          alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-pod.json') },
-        },
-        'Value #A': {
-          alias: 'Current Receive Bandwidth',
-          unit: 'Bps',
-        },
-        'Value #B': {
-          alias: 'Current Transmit Bandwidth',
-          unit: 'Bps',
-        },
-        'Value #C': {
-          alias: 'Rate of Received Packets',
-          unit: 'pps',
-        },
-        'Value #D': {
-          alias: 'Rate of Transmitted Packets',
-          unit: 'pps',
-        },
-        'Value #E': {
-          alias: 'Rate of Received Packets Dropped',
-          unit: 'pps',
-        },
-        'Value #F': {
-          alias: 'Rate of Transmitted Packets Dropped',
-          unit: 'pps',
+          title: 'Drill down to pods',
+          url: '%(prefix)s/d/%(uid)s/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}' % {
+            uid: $._config.grafanaDashboardIDs['k8s-resources-pod.json'],
+            prefix: $._config.grafanaK8s.linkPrefix,
+          },
         },
       };
-
 
       local cpuUsageQuery = |||
         sum(
@@ -153,172 +140,458 @@ local template = grafana.template;
       local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
       local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
 
-      g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-workload.json']),
-        datasource_regex=$._config.datasourceFilterRegex,
-        datasource=$._config.datasourceName,
-      )
-      .addRow(
-        g.row('CPU Usage')
-        .addPanel(
-          g.panel('CPU Usage') +
-          g.queryPanel(cpuUsageQuery, '{{pod}}') +
-          g.stack,
-        )
-      )
-      .addRow(
-        g.row('CPU Quota')
-        .addPanel(
-          g.panel('CPU Quota') +
-          g.tablePanel([
-            cpuUsageQuery,
-            cpuRequestsQuery,
-            cpuUsageQuery + '/' + cpuRequestsQuery,
-            cpuLimitsQuery,
-            cpuUsageQuery + '/' + cpuLimitsQuery,
-          ], tableStyles {
-            'Value #A': { alias: 'CPU Usage' },
-            'Value #B': { alias: 'CPU Requests' },
-            'Value #C': { alias: 'CPU Requests %', unit: 'percentunit' },
-            'Value #D': { alias: 'CPU Limits' },
-            'Value #E': { alias: 'CPU Limits %', unit: 'percentunit' },
-          })
-        )
-      )
-      .addRow(
-        g.row('Memory Usage')
-        .addPanel(
-          g.panel('Memory Usage') +
-          g.queryPanel(memUsageQuery, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('bytes') },
-        )
-      )
-      .addRow(
-        g.row('Memory Quota')
-        .addPanel(
-          g.panel('Memory Quota') +
-          g.tablePanel([
-            memUsageQuery,
-            memRequestsQuery,
-            memUsageQuery + '/' + memRequestsQuery,
-            memLimitsQuery,
-            memUsageQuery + '/' + memLimitsQuery,
-          ], tableStyles {
-            'Value #A': { alias: 'Memory Usage', unit: 'bytes' },
-            'Value #B': { alias: 'Memory Requests', unit: 'bytes' },
-            'Value #C': { alias: 'Memory Requests %', unit: 'percentunit' },
-            'Value #D': { alias: 'Memory Limits', unit: 'bytes' },
-            'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
-          })
-        )
-      )
-      .addRow(
-        g.row('Current Network Usage')
-        .addPanel(
-          g.panel('Current Network Usage') +
-          g.tablePanel(
-            networkColumns,
-            networkTableStyles
-          ),
-        )
-      )
-      .addRow(
-        g.row('Bandwidth')
-        .addPanel(
-          g.panel('Receive Bandwidth') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-        .addPanel(
-          g.panel('Transmit Bandwidth') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Average Container Bandwidth by Pod')
-        .addPanel(
-          g.panel('Average Container Bandwidth by Pod: Received') +
-          g.queryPanel(|||
-            (avg(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-        .addPanel(
-          g.panel('Average Container Bandwidth by Pod: Transmitted') +
-          g.queryPanel(|||
-            (avg(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Rate of Packets')
-        .addPanel(
-          g.panel('Rate of Received Packets') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-        .addPanel(
-          g.panel('Rate of Transmitted Packets') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-      )
-      .addRow(
-        g.row('Rate of Packets Dropped')
-        .addPanel(
-          g.panel('Rate of Received Packets Dropped') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-        .addPanel(
-          g.panel('Rate of Transmitted Packets Dropped') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-          ||| % $._config, '{{pod}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-      ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate, workloadTypeTemplate, workloadTemplate],
-        },
-      },
+      local networkColumns = [
+        |||
+          (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+        ||| % $._config,
+      ];
+
+      local panels = [
+        tsPanel.new('CPU Usage')
+        + tsPanel.gridPos.withW(24)
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', cpuUsageQuery)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        table.new('CPU Quota')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', cpuUsageQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuUsageQuery + '/' + cpuRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuUsageQuery + '/' + cpuLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'pod',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              pod: 5,
+              'Value #A': 6,
+              'Value #B': 7,
+              'Value #C': 8,
+              'Value #D': 9,
+              'Value #E': 10,
+            },
+            renameByName: {
+              pod: 'Pod',
+              'Value #A': 'CPU Usage',
+              'Value #B': 'CPU Requests',
+              'Value #C': 'CPU Requests %',
+              'Value #D': 'CPU Limits',
+              'Value #E': 'CPU Limits %',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/%/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'percentunit',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Pod',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.pod],
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Memory Usage')
+        + tsPanel.gridPos.withW(24)
+        + tsPanel.standardOptions.withUnit('bytes')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', memUsageQuery)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        table.new('Memory Quota')
+        + table.gridPos.withW(24)
+        + table.standardOptions.withUnit('bytes')
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', memUsageQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memUsageQuery + '/' + memRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memUsageQuery + '/' + memLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'pod',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              pod: 8,
+              'Value #A': 9,
+              'Value #B': 10,
+              'Value #C': 11,
+              'Value #D': 12,
+              'Value #E': 13,
+            },
+            renameByName: {
+              pod: 'Pod',
+              'Value #A': 'Memory Usage',
+              'Value #B': 'Memory Requests',
+              'Value #C': 'Memory Requests %',
+              'Value #D': 'Memory Limits',
+              'Value #E': 'Memory Limits %',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/%/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'percentunit',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Pod',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.pod],
+              },
+            ],
+          },
+        ]),
+
+        table.new('Current Network Usage')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', networkColumns[0])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[1])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[2])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[3])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[4])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[5])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'pod',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              pod: 6,
+              'Value #A': 7,
+              'Value #B': 8,
+              'Value #C': 9,
+              'Value #D': 10,
+              'Value #E': 11,
+              'Value #F': 12,
+            },
+            renameByName: {
+              pod: 'Pod',
+              'Value #A': 'Current Receive Bandwidth',
+              'Value #B': 'Current Transmit Bandwidth',
+              'Value #C': 'Rate of Received Packets',
+              'Value #D': 'Rate of Transmitted Packets',
+              'Value #E': 'Rate of Received Packets Dropped',
+              'Value #F': 'Rate of Transmitted Packets Dropped',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Bandwidth/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'Bps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Packets/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'pps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Pod',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.pod],
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Receive Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Transmit Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Pod: Received')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Pod: Transmitted')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+      ];
+
+      g.dashboard.new('%(dashboardNamePrefix)sCompute Resources / Workload' % $._config.grafanaK8s)
+      + g.dashboard.withUid($._config.grafanaDashboardIDs['k8s-resources-workload.json'])
+      + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
+      + g.dashboard.withEditable(false)
+      + g.dashboard.time.withFrom('now-1h')
+      + g.dashboard.time.withTo('now')
+      + g.dashboard.withRefresh($._config.grafanaK8s.refresh)
+      + g.dashboard.withVariables([variables.datasource, variables.cluster, variables.namespace, variables.workload_type, variables.workload])
+      + g.dashboard.withPanels(g.util.grid.wrapPanels(panels, panelWidth=12, panelHeight=7)),
   },
 }


### PR DESCRIPTION
Part of:

- #898 

Following on from:

- #912

**BEFORE**

<img width="1528" alt="Screenshot 2024-04-25 at 15 00 46" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/50178e08-09cc-427c-b9c1-cdc3e8a2b2eb">

**AFTER**

<img width="1528" alt="Screenshot 2024-04-25 at 15 00 22" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/980aaa42-8957-4e51-ba52-0bce248db3e8">

