### PR TITLE
fix(dashboards): Port compute/namespace (workloads) dashboard to new grafonnet

### DIFF
--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -1,129 +1,102 @@
-local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
-local g = import 'github.com/grafana/jsonnet-libs/grafana-builder/grafana.libsonnet';
-local template = grafana.template;
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local prometheus = g.query.prometheus;
+local stat = g.panel.stat;
+local table = g.panel.table;
+local timeSeries = g.panel.timeSeries;
+local var = g.dashboard.variable;
 
 {
+  local statPanel(title, unit, query) =
+    stat.new(title)
+    + stat.options.withColorMode('none')
+    + stat.standardOptions.withUnit(unit)
+    + stat.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
+    + stat.queryOptions.withTargets([
+      prometheus.new('${datasource}', query)
+      + prometheus.withInstant(true),
+    ]),
+
+  local tsPanel =
+    timeSeries {
+      new(title):
+        timeSeries.new(title)
+        + timeSeries.options.legend.withShowLegend()
+        + timeSeries.options.legend.withAsTable()
+        + timeSeries.options.legend.withDisplayMode('table')
+        + timeSeries.options.legend.withPlacement('right')
+        + timeSeries.options.legend.withCalcs(['lastNotNull'])
+        + timeSeries.options.tooltip.withMode('single')
+        + timeSeries.fieldConfig.defaults.custom.withShowPoints('never')
+        + timeSeries.fieldConfig.defaults.custom.withFillOpacity(10)
+        + timeSeries.fieldConfig.defaults.custom.withSpanNulls(true)
+        + timeSeries.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval),
+    },
+
   grafanaDashboards+:: {
-
-    local clusterTemplate =
-      template.new(
-        name='cluster',
-        datasource='$datasource',
-        query='label_values(up{%(kubeStateMetricsSelector)s}, %(clusterLabel)s)' % $._config,
-        current='',
-        hide=if $._config.showMultiCluster then '' else '2',
-        refresh=2,
-        includeAll=false,
-        sort=1
-      ),
-
-    local typeTemplate =
-      template.new(
-        name='type',
-        datasource='$datasource',
-        query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}, workload_type)' % $._config.clusterLabel,
-        current='',
-        hide='',
-        refresh=2,
-        includeAll=true,
-        sort=0
-      ) + {
-        auto: false,
-        auto_count: 30,
-        auto_min: '10s',
-        definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}, workload_type)' % $._config.clusterLabel,
-        skipUrlSync: false,
-      },
-
-    local namespaceTemplate =
-      template.new(
-        name='namespace',
-        datasource='$datasource',
-        query='label_values(kube_pod_info{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}, namespace)' % $._config,
-        current='',
-        hide='',
-        refresh=2,
-        includeAll=false,
-        multi=false,
-        sort=1
-      ),
-
     'k8s-resources-workloads-namespace.json':
-      local tableStyles = {
-        workload: {
-          alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
-        },
-        workload_type: {
-          alias: 'Workload Type',
-        },
+      local variables = {
+        datasource:
+          var.datasource.new('datasource', 'prometheus')
+          + var.datasource.withRegex($._config.datasourceFilterRegex)
+          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.datasource.generalOptions.withLabel('Data source')
+          + {
+            current: {
+              selected: true,
+              text: $._config.datasourceName,
+              value: $._config.datasourceName,
+            },
+          },
+
+        cluster:
+          var.query.new('cluster')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            $._config.clusterLabel,
+            'up{%(kubeStateMetricsSelector)s}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('cluster')
+          + var.query.refresh.onTime()
+          + (
+            if $._config.showMultiCluster
+            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+            else var.query.generalOptions.showOnDashboard.withNothing()
+          )
+          + var.query.withSort(type='alphabetical'),
+
+        namespace:
+          var.query.new('namespace')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'namespace',
+            'kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('namespace')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
+
+        workload_type:
+          var.query.new('type')
+          + var.query.selectionOptions.withIncludeAll()
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'workload_type',
+            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('workload_type')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
       };
 
-      local networkColumns = [
-        |||
-          (sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(irate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (namespace,pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-      ];
-
-      local networkTableStyles = {
+      local links = {
         workload: {
-          alias: 'Workload',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type' % { prefix: $._config.grafanaK8s.linkPrefix, uid: std.md5('k8s-resources-workload.json') },
-          linkTooltip: 'Drill down to pods',
-        },
-        workload_type: {
-          alias: 'Workload Type',
-        },
-        'Value #A': {
-          alias: 'Current Receive Bandwidth',
-          unit: 'Bps',
-        },
-        'Value #B': {
-          alias: 'Current Transmit Bandwidth',
-          unit: 'Bps',
-        },
-        'Value #C': {
-          alias: 'Rate of Received Packets',
-          unit: 'pps',
-        },
-        'Value #D': {
-          alias: 'Rate of Transmitted Packets',
-          unit: 'pps',
-        },
-        'Value #E': {
-          alias: 'Rate of Received Packets Dropped',
-          unit: 'pps',
-        },
-        'Value #F': {
-          alias: 'Rate of Transmitted Packets Dropped',
-          unit: 'pps',
+          title: 'Drill down to workloads',
+          url: '%(prefix)s/d/%(uid)s/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}' % {
+            uid: $._config.grafanaDashboardIDs['k8s-resources-workload.json'],
+            prefix: $._config.grafanaK8s.linkPrefix,
+          },
         },
       };
 
@@ -161,228 +134,634 @@ local template = grafana.template;
       local memoryQuotaRequestsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'requests.memory');
       local memoryQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu', 'limits.memory');
 
-      g.dashboard(
-        '%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % $._config.grafanaK8s,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json']),
-        datasource_regex=$._config.datasourceFilterRegex,
-        datasource=$._config.datasourceName,
-      )
-      .addRow(
-        g.row('CPU Usage')
-        .addPanel(
-          g.panel('CPU Usage') +
-          g.queryPanel([cpuUsageQuery, cpuQuotaRequestsQuery, cpuQuotaLimitsQuery], ['{{workload}} - {{workload_type}}', 'quota - requests', 'quota - limits']) +
-          g.stack + {
-            seriesOverrides: [
-              {
-                alias: 'quota - requests',
-                color: '#F2495C',
-                dashes: true,
-                fill: 0,
-                hideTooltip: true,
-                legend: true,
-                linewidth: 2,
-                stack: false,
-                hiddenSeries: true,
-              },
-              {
-                alias: 'quota - limits',
-                color: '#FF9830',
-                dashes: true,
-                fill: 0,
-                hideTooltip: true,
-                legend: true,
-                linewidth: 2,
-                stack: false,
-                hiddenSeries: true,
-              },
-            ],
-          },
-        )
-      )
-      .addRow(
-        g.row('CPU Quota')
-        .addPanel(
-          g.panel('CPU Quota') +
-          g.tablePanel([
-            podCountQuery,
-            cpuUsageQuery,
-            cpuRequestsQuery,
-            cpuUsageQuery + '/' + cpuRequestsQuery,
-            cpuLimitsQuery,
-            cpuUsageQuery + '/' + cpuLimitsQuery,
-          ], tableStyles {
-            'Value #A': { alias: 'Running Pods', decimals: 0 },
-            'Value #B': { alias: 'CPU Usage' },
-            'Value #C': { alias: 'CPU Requests' },
-            'Value #D': { alias: 'CPU Requests %', unit: 'percentunit' },
-            'Value #E': { alias: 'CPU Limits' },
-            'Value #F': { alias: 'CPU Limits %', unit: 'percentunit' },
-          })
-        )
-      )
-      .addRow(
-        g.row('Memory Usage')
-        .addPanel(
-          g.panel('Memory Usage') +
-          g.queryPanel([memUsageQuery, memoryQuotaRequestsQuery, memoryQuotaLimitsQuery], ['{{workload}} - {{workload_type}}', 'quota - requests', 'quota - limits']) +
-          g.stack +
-          {
-            yaxes: g.yaxes('bytes'),
-            seriesOverrides: [
-              {
-                alias: 'quota - requests',
-                color: '#F2495C',
-                dashes: true,
-                fill: 0,
-                hideTooltip: true,
-                legend: true,
-                linewidth: 2,
-                stack: false,
-                hiddenSeries: true,
-              },
-              {
-                alias: 'quota - limits',
-                color: '#FF9830',
-                dashes: true,
-                fill: 0,
-                hideTooltip: true,
-                legend: true,
-                linewidth: 2,
-                stack: false,
-                hiddenSeries: true,
-              },
-            ],
-          },
-        )
-      )
-      .addRow(
-        g.row('Memory Quota')
-        .addPanel(
-          g.panel('Memory Quota') +
-          g.tablePanel([
-            podCountQuery,
-            memUsageQuery,
-            memRequestsQuery,
-            memUsageQuery + '/' + memRequestsQuery,
-            memLimitsQuery,
-            memUsageQuery + '/' + memLimitsQuery,
-          ], tableStyles {
-            'Value #A': { alias: 'Running Pods', decimals: 0 },
-            'Value #B': { alias: 'Memory Usage', unit: 'bytes' },
-            'Value #C': { alias: 'Memory Requests', unit: 'bytes' },
-            'Value #D': { alias: 'Memory Requests %', unit: 'percentunit' },
-            'Value #E': { alias: 'Memory Limits', unit: 'bytes' },
-            'Value #F': { alias: 'Memory Limits %', unit: 'percentunit' },
-          })
-        )
-      )
-      .addRow(
-        g.row('Current Network Usage')
-        .addPanel(
-          g.panel('Current Network Usage') +
-          g.tablePanel(
-            networkColumns,
-            networkTableStyles
-          ),
-        )
-      )
-      .addRow(
-        g.row('Bandwidth')
-        .addPanel(
-          g.panel('Receive Bandwidth') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-        .addPanel(
-          g.panel('Transmit Bandwidth') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Average Container Bandwidth by Workload')
-        .addPanel(
-          g.panel('Average Container Bandwidth by Workload: Received') +
-          g.queryPanel(|||
-            (avg(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-        .addPanel(
-          g.panel('Average Container Bandwidth by Workload: Transmitted') +
-          g.queryPanel(|||
-            (avg(irate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Rate of Packets')
-        .addPanel(
-          g.panel('Rate of Received Packets') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-        .addPanel(
-          g.panel('Rate of Transmitted Packets') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-      )
-      .addRow(
-        g.row('Rate of Packets Dropped')
-        .addPanel(
-          g.panel('Rate of Received Packets Dropped') +
-          g.queryPanel(|||
-            (sum(irate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-        .addPanel(
-          g.panel('Rate of Transmitted Packets Dropped') +
-          g.queryPanel(|||
-            (sum(irate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config, '{{workload}}') +
-          g.stack +
-          { yaxes: g.yaxes('pps') },
-        )
-      ) + {
-        templating+: {
-          list+: [clusterTemplate, namespaceTemplate, typeTemplate],
-        },
-      },
+      local networkColumns = [
+        |||
+          (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+        |||
+          (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+        ||| % $._config,
+      ];
 
+      local panels = [
+        tsPanel.new('CPU Usage')
+        + tsPanel.gridPos.withW(24)
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', cpuUsageQuery)
+          + prometheus.withLegendFormat('{{workload}} - {{workload_type}}'),
+
+          prometheus.new('${datasource}', cpuQuotaRequestsQuery)
+          + prometheus.withLegendFormat('quota - requests'),
+
+          prometheus.new('${datasource}', cpuQuotaLimitsQuery)
+          + prometheus.withLegendFormat('quota - limits'),
+        ])
+        + tsPanel.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byFrameRefID',
+              options: 'B',
+            },
+            properties: [
+              {
+                id: 'custom.lineStyle',
+                value: {
+                  fill: 'dash',
+                },
+              },
+              {
+                id: 'custom.lineWidth',
+                value: 2,
+              },
+              {
+                id: 'color',
+                value: {
+                  mode: 'fixed',
+                  fixedColor: 'red',
+                },
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byFrameRefID',
+              options: 'C',
+            },
+            properties: [
+              {
+                id: 'custom.lineStyle',
+                value: {
+                  fill: 'dash',
+                },
+              },
+              {
+                id: 'custom.lineWidth',
+                value: 2,
+              },
+              {
+                id: 'color',
+                value: {
+                  mode: 'fixed',
+                  fixedColor: 'orange',
+                },
+              },
+            ],
+          },
+        ]),
+
+        table.new('CPU Quota')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', podCountQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuUsageQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuUsageQuery + '/' + cpuRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', cpuUsageQuery + '/' + cpuLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'workload',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+              'workload_type 2': true,
+              'workload_type 3': true,
+              'workload_type 4': true,
+              'workload_type 5': true,
+              'workload_type 6': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              workload: 6,
+              'workload_type 1': 7,
+              'Value #A': 8,
+              'Value #B': 9,
+              'Value #C': 10,
+              'Value #D': 11,
+              'Value #E': 12,
+              'Value #F': 13,
+              'workload_type 2': 14,
+              'workload_type 3': 15,
+              'workload_type 4': 16,
+              'workload_type 5': 17,
+              'workload_type 6': 18,
+            },
+            renameByName: {
+              workload: 'Workload',
+              'workload_type 1': 'Type',
+              'Value #A': 'Running Pods',
+              'Value #B': 'CPU Usage',
+              'Value #C': 'CPU Requests',
+              'Value #D': 'CPU Requests %',
+              'Value #E': 'CPU Limits',
+              'Value #F': 'CPU Limits %',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/%/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'percentunit',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Workload',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.workload],
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Running Pods',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'none',
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Memory Usage')
+        + tsPanel.gridPos.withW(24)
+        + tsPanel.standardOptions.withUnit('bytes')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', memUsageQuery)
+          + prometheus.withLegendFormat('{{workload}} - {{workload_type}}'),
+          prometheus.new('${datasource}', memoryQuotaRequestsQuery)
+          + prometheus.withLegendFormat('quota - requests'),
+          prometheus.new('${datasource}', memoryQuotaLimitsQuery)
+          + prometheus.withLegendFormat('quota - limits'),
+        ])
+        + tsPanel.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byFrameRefID',
+              options: 'B',
+            },
+            properties: [
+              {
+                id: 'custom.lineStyle',
+                value: {
+                  fill: 'dash',
+                },
+              },
+              {
+                id: 'custom.lineWidth',
+                value: 2,
+              },
+              {
+                id: 'color',
+                value: {
+                  mode: 'fixed',
+                  fixedColor: 'red',
+                },
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byFrameRefID',
+              options: 'C',
+            },
+            properties: [
+              {
+                id: 'custom.lineStyle',
+                value: {
+                  fill: 'dash',
+                },
+              },
+              {
+                id: 'custom.lineWidth',
+                value: 2,
+              },
+              {
+                id: 'color',
+                value: {
+                  mode: 'fixed',
+                  fixedColor: 'orange',
+                },
+              },
+            ],
+          },
+        ]),
+
+        table.new('Memory Quota')
+        + table.gridPos.withW(24)
+        + table.standardOptions.withUnit('bytes')
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', podCountQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memUsageQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memUsageQuery + '/' + memRequestsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', memUsageQuery + '/' + memLimitsQuery)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'workload',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+              'workload_type 2': true,
+              'workload_type 3': true,
+              'workload_type 4': true,
+              'workload_type 5': true,
+              'workload_type 6': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              workload: 6,
+              'workload_type 1': 7,
+              'Value #A': 8,
+              'Value #B': 9,
+              'Value #C': 10,
+              'Value #D': 11,
+              'Value #E': 12,
+              'Value #F': 13,
+              'workload_type 2': 14,
+              'workload_type 3': 15,
+              'workload_type 4': 16,
+              'workload_type 5': 17,
+              'workload_type 6': 18,
+            },
+            renameByName: {
+              workload: 'Workload',
+              'workload_type 1': 'Type',
+              'Value #A': 'Running Pods',
+              'Value #B': 'Memory Usage',
+              'Value #C': 'Memory Requests',
+              'Value #D': 'Memory Requests %',
+              'Value #E': 'Memory Limits',
+              'Value #F': 'Memory Limits %',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/%/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'percentunit',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Workload',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.workload],
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Running Pods',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'none',
+              },
+            ],
+          },
+        ]),
+
+        table.new('Current Network Usage')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', networkColumns[0])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[1])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[2])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[3])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[4])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', networkColumns[5])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'workload',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              workload: 6,
+              'Value #A': 7,
+              'Value #B': 8,
+              'Value #C': 9,
+              'Value #D': 10,
+              'Value #E': 11,
+              'Value #F': 12,
+            },
+            renameByName: {
+              workload: 'Workload',
+              'Value #A': 'Current Receive Bandwidth',
+              'Value #B': 'Current Transmit Bandwidth',
+              'Value #C': 'Rate of Received Packets',
+              'Value #D': 'Rate of Transmitted Packets',
+              'Value #E': 'Rate of Received Packets Dropped',
+              'Value #F': 'Rate of Transmitted Packets Dropped',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Bandwidth/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'Bps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Packets/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'pps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Workload',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.workload],
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Receive Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Transmit Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Workload: Received')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Workload: Transmitted')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              * on (namespace,pod)
+              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+      ];
+
+      g.dashboard.new('%(dashboardNamePrefix)sCompute Resources / Namespace (Workloads)' % $._config.grafanaK8s)
+      + g.dashboard.withUid($._config.grafanaDashboardIDs['k8s-resources-workloads-namespace.json'])
+      + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
+      + g.dashboard.withEditable(false)
+      + g.dashboard.time.withFrom('now-1h')
+      + g.dashboard.time.withTo('now')
+      + g.dashboard.withRefresh($._config.grafanaK8s.refresh)
+      + g.dashboard.withVariables([variables.datasource, variables.cluster, variables.namespace, variables.workload_type])
+      + g.dashboard.withPanels(g.util.grid.wrapPanels(panels, panelWidth=12, panelHeight=7)),
   },
 }


### PR DESCRIPTION
Part of:

- #898 

Following on from:

- #913

**BEFORE**

<img width="1528" alt="Screenshot 2024-04-25 at 15 39 25" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/42277c3c-109b-4fff-af59-e2a41bd6a2cb">

**AFTER**

<img width="1528" alt="Screenshot 2024-04-25 at 15 50 26" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/430ea419-3767-4693-9341-02432cf322c0">


