### PR TITLE
Fix matcher for apiserver burn rate calculation not matching `resource` correctly

### DIFF
--- a/rules/kube_apiserver-availability.libsonnet
+++ b/rules/kube_apiserver-availability.libsonnet
@@ -69,7 +69,7 @@
                   -
                   (
                     (
-                      sum by (%(clusterLabel)s) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%(SLODays)s{%(kubeApiserverReadSelector)s,scope=~"resource|",le="%(kubeApiserverReadResourceLatency)s"})
+                      sum by (%(clusterLabel)s) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%(SLODays)s{%(kubeApiserverReadSelector)s,scope="resource",le="%(kubeApiserverReadResourceLatency)s"})
                       or
                       vector(0)
                     )
@@ -98,7 +98,7 @@
                 (
                   # too slow
                   (
-                    sum by (%(clusterLabel)s) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%(SLODays)s{%(kubeApiserverReadSelector)s,scope=~"resource|",le="%(kubeApiserverReadResourceLatency)s"})
+                    sum by (%(clusterLabel)s) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%(SLODays)s{%(kubeApiserverReadSelector)s,scope="resource",le="%(kubeApiserverReadResourceLatency)s"})
                     or
                     vector(0)
                   )

--- a/rules/kube_apiserver-burnrate.libsonnet
+++ b/rules/kube_apiserver-burnrate.libsonnet
@@ -14,7 +14,7 @@
                   -
                   (
                     (
-                      sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope=~"resource|",le="%(kubeApiserverReadResourceLatency)s"}[%(window)s]))
+                      sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope="resource",le="%(kubeApiserverReadResourceLatency)s"}[%(window)s]))
                       or
                       vector(0)
                     )


### PR DESCRIPTION
The current behaviour (`scope=~"resource|"`) does not appear to return anything, and so will always return `vector(0)`. While this is the intended behaviour _when there is no `resource` scope_, in normal operations where there _is_ a `resource` scope it will also return `vector()`. This makes the burn rate calculation go into negative numbers as so, which makes the availability numbers return a value `>1%` :

<img width="1476" alt="Screenshot 2024-04-26 at 16 20 13" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/a52b1367-b67a-489d-bf77-420fdaecc7cb">

<img width="1467" alt="Screenshot 2024-04-26 at 16 23 32" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/04d93370-75f3-4495-9a70-5f408552fe78">

When you change the matcher to `scope="resource"` :

<img width="1470" alt="Screenshot 2024-04-26 at 16 21 23" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/17415363-1b77-460b-bad2-66ed10ac6ccf">

<img width="1459" alt="Screenshot 2024-04-26 at 16 23 42" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/0e8391f5-5e2e-4703-908d-ded451a4e129">

This is also true for other things with the `scope=~"resource|"`. E.g. the error burndown:

<img width="1468" alt="Screenshot 2024-04-26 at 16 28 53" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/a118f12c-86d7-42a0-9648-506156b372cf">

and after fixing the query:

<img width="1466" alt="Screenshot 2024-04-26 at 16 29 04" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/1196058/13812fe8-2cfb-4b4e-b2a5-f10666eb2568">

