### PR TITLE
fix(dashboards): Port networking/namespace (pods) dashboard to new grafonnet

### DIFF
--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -1,464 +1,312 @@
-local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
-local dashboard = grafana.dashboard;
-local row = grafana.row;
-local prometheus = grafana.prometheus;
-local template = grafana.template;
-local graphPanel = grafana.graphPanel;
-local tablePanel = grafana.tablePanel;
-local annotation = grafana.annotation;
-local singlestat = grafana.singlestat;
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local gauge = g.panel.gauge;
+local prometheus = g.query.prometheus;
+local table = g.panel.table;
+local timeSeries = g.panel.timeSeries;
+local var = g.dashboard.variable;
 
 {
+  local tsPanel =
+    timeSeries {
+      new(title):
+        timeSeries.new(title)
+        + timeSeries.options.legend.withShowLegend()
+        + timeSeries.options.legend.withAsTable()
+        + timeSeries.options.legend.withDisplayMode('table')
+        + timeSeries.options.legend.withPlacement('right')
+        + timeSeries.options.tooltip.withMode('single')
+        + timeSeries.fieldConfig.defaults.custom.withShowPoints('never')
+        + timeSeries.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval),
+    },
+
   grafanaDashboards+:: {
-
     'namespace-by-pod.json':
+      local variables = {
+        datasource:
+          var.datasource.new('datasource', 'prometheus')
+          + var.datasource.withRegex($._config.datasourceFilterRegex)
+          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.datasource.generalOptions.withLabel('Data source')
+          + {
+            current: {
+              selected: true,
+              text: $._config.datasourceName,
+              value: $._config.datasourceName,
+            },
+          },
 
-      local newStyle(
-        alias,
-        colorMode=null,
-        colors=[],
-        dateFormat='YYYY-MM-DD HH:mm:ss',
-        decimals=2,
-        link=false,
-        linkTooltip='Drill down',
-        linkUrl='',
-        thresholds=[],
-        type='number',
-        unit='short'
-            ) = {
-        alias: alias,
-        colorMode: colorMode,
-        colors: colors,
-        dateFormat: dateFormat,
-        decimals: decimals,
-        link: link,
-        linkTooltip: linkTooltip,
-        linkUrl: linkUrl,
-        thresholds: thresholds,
-        type: type,
-        unit: unit,
+        cluster:
+          var.query.new('cluster')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            $._config.clusterLabel,
+            'up{%(cadvisorSelector)s}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('cluster')
+          + var.query.refresh.onTime()
+          + (
+            if $._config.showMultiCluster
+            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+            else var.query.generalOptions.showOnDashboard.withNothing()
+          )
+          + var.query.withSort(type='alphabetical'),
+
+        namespace:
+          var.query.new('namespace')
+          + var.query.selectionOptions.withIncludeAll(true, '.+')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'namespace',
+            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
+          )
+          + var.query.generalOptions.withCurrent('kube-system')
+          + var.query.generalOptions.withLabel('namespace')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
+
       };
 
-      local newGaugePanel(gaugeTitle, gaugeQuery) =
-        local target =
-          prometheus.target(
-            gaugeQuery,
-          ) + {
-            instant: null,
-            intervalFactor: 1,
-          };
-
-        singlestat.new(
-          title=gaugeTitle,
-          datasource='$datasource',
-          format='time_series',
-          height=9,
-          span=12,
-          min_span=12,
-          decimals=0,
-          valueName='current'
-        ).addTarget(target) + {
-          timeFrom: null,
-          timeShift: null,
-          type: 'gauge',
-          options: {
-            fieldOptions: {
-              calcs: [
-                'last',
-              ],
-              defaults: {
-                max: 10000000000,  // 10GBs
-                min: 0,
-                title: '$namespace',
-                unit: 'Bps',
-              },
-              mappings: [],
-              override: {},
-              thresholds: [
-                {
-                  color: 'dark-green',
-                  index: 0,
-                  value: null,  // 0GBs
-                },
-                {
-                  color: 'dark-yellow',
-                  index: 1,
-                  value: 5000000000,  // 5GBs
-                },
-                {
-                  color: 'dark-red',
-                  index: 2,
-                  value: 7000000000,  // 7GBs
-                },
-              ],
-              values: false,
-            },
+      local links = {
+        pod: {
+          title: 'Drill down',
+          url: '%(prefix)s/d/%(uid)s/kubernetes-networking-pod?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-pod=${__data.fields.Pod}' % {
+            uid: $._config.grafanaDashboardIDs['pod-total.json'],
+            prefix: $._config.grafanaK8s.linkPrefix,
           },
-        };
-
-      local newGraphPanel(graphTitle, graphQuery, graphFormat='Bps') =
-        local target =
-          prometheus.target(
-            graphQuery
-          ) + {
-            intervalFactor: 1,
-            legendFormat: '{{pod}}',
-            step: 10,
-          };
-
-        graphPanel.new(
-          title=graphTitle,
-          span=12,
-          datasource='$datasource',
-          fill=2,
-          linewidth=2,
-          min_span=12,
-          format=graphFormat,
-          min=0,
-          max=null,
-          x_axis_mode='time',
-          x_axis_values='total',
-          lines=true,
-          stack=true,
-          legend_show=true,
-          nullPointMode='connected'
-        ).addTarget(target) + {
-          legend+: {
-            hideEmpty: true,
-            hideZero: true,
-          },
-          paceLength: 10,
-          tooltip+: {
-            sort: 2,
-          },
-        };
-
-      local newTablePanel(tableTitle, colQueries) =
-        local buildTarget(index, colQuery) =
-          prometheus.target(
-            colQuery,
-            format='table',
-            instant=true,
-          ) + {
-            legendFormat: '',
-            step: 10,
-            refId: std.char(65 + index),
-          };
-
-        local targets = std.mapWithIndex(buildTarget, colQueries);
-
-        tablePanel.new(
-          title=tableTitle,
-          span=24,
-          min_span=24,
-          datasource='$datasource',
-        )
-        .addColumn(
-          field='Time',
-          style=newStyle(
-            alias='Time',
-            type='hidden',
-          )
-        )
-        .addColumn(
-          field='Value #A',
-          style=newStyle(
-            alias='Bandwidth Received',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #B',
-          style=newStyle(
-            alias='Bandwidth Transmitted',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #C',
-          style=newStyle(
-            alias='Rate of Received Packets',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #D',
-          style=newStyle(
-            alias='Rate of Transmitted Packets',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #E',
-          style=newStyle(
-            alias='Rate of Received Packets Dropped',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #F',
-          style=newStyle(
-            alias='Rate of Transmitted Packets Dropped',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='pod',
-          style=newStyle(
-            alias='Pod',
-            link=true,
-            linkUrl='d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell'
-          ),
-        ) + {
-
-          fill: 1,
-          fontSize: '100%',
-          lines: true,
-          linewidth: 1,
-          nullPointMode: 'null as zero',
-          renderer: 'flot',
-          scroll: true,
-          showHeader: true,
-          spaceLength: 10,
-          sort: {
-            col: 0,
-            desc: false,
-          },
-          targets: targets,
-        };
-
-      local clusterTemplate =
-        template.new(
-          name='cluster',
-          datasource='$datasource',
-          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
-          hide=if $._config.showMultiCluster then '' else '2',
-          refresh=2
-        );
-
-      local namespaceTemplate =
-        template.new(
-          name='namespace',
-          datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
-          allValues='.+',
-          current='kube-system',
-          hide='',
-          refresh=2,
-          includeAll=true,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
-          skipUrlSync: false,
-        };
-
-      local resolutionTemplate =
-        template.new(
-          name='resolution',
-          datasource='$datasource',
-          query='30s,5m,1h',
-          current='5m',
-          hide='',
-          refresh=2,
-          includeAll=false,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          skipUrlSync: false,
-          type: 'interval',
-          options: [
-            {
-              selected: false,
-              text: '30s',
-              value: '30s',
-            },
-            {
-              selected: true,
-              text: '5m',
-              value: '5m',
-            },
-            {
-              selected: false,
-              text: '1h',
-              value: '1h',
-            },
-          ],
-        };
-
-      local intervalTemplate =
-        template.new(
-          name='interval',
-          datasource='$datasource',
-          query='4h',
-          current='5m',
-          hide=2,
-          refresh=2,
-          includeAll=false,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          skipUrlSync: false,
-          type: 'interval',
-          options: [
-            {
-              selected: true,
-              text: '4h',
-              value: '4h',
-            },
-          ],
-        };
-
-      //#####  Current Bandwidth Row ######
-
-      local currentBandwidthRow =
-        row.new(
-          title='Current Bandwidth'
-        );
-
-      //#####  Bandwidth Row ######
-
-      local bandwidthRow =
-        row.new(
-          title='Bandwidth'
-        );
-
-      //##### Packet  Row ######
-      // collapsed, so row must include panels
-      local packetRow =
-        row.new(
-          title='Packets',
-          collapse=true,
-        );
-
-      //##### Error Row ######
-      // collapsed, so row must include panels
-      local errorRow =
-        row.new(
-          title='Errors',
-          collapse=true,
-        );
-
-      dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Namespace (Pods)' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
-        editable=true,
-        schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
-        time_from='now-1h',
-        time_to='now',
-      )
-      .addTemplate(
-        {
-          current: {
-            selected: true,
-            text: $._config.datasourceName,
-            value: $._config.datasourceName,
-          },
-          hide: 0,
-          label: 'Data source',
-          name: 'datasource',
-          options: [],
-          query: 'prometheus',
-          refresh: 1,
-          regex: $._config.datasourceFilterRegex,
-          type: 'datasource',
         },
-      )
-      .addTemplate(clusterTemplate)
-      .addTemplate(namespaceTemplate)
-      .addTemplate(resolutionTemplate)
-      .addTemplate(intervalTemplate)
-      .addAnnotation(annotation.default)
-      .addPanel(currentBandwidthRow, gridPos={ h: 1, w: 24, x: 0, y: 0 })
-      .addPanel(
-        newGaugePanel(
-          gaugeTitle='Current Rate of Bytes Received',
-          gaugeQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 0, y: 1 }
-      )
-      .addPanel(
-        newGaugePanel(
-          gaugeTitle='Current Rate of Bytes Transmitted',
-          gaugeQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution]))' % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 12, y: 1 }
-      )
-      .addPanel(
-        newTablePanel(
-          tableTitle='Current Status',
-          colQueries=[
-            'sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            'sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-          ]
-        ),
-        gridPos={ h: 9, w: 24, x: 0, y: 10 }
-      )
-      .addPanel(bandwidthRow, gridPos={ h: 1, w: 24, x: 0, y: 19 })
-      .addPanel(
-        newGraphPanel(
-          graphTitle='Receive Bandwidth',
-          graphQuery='sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 0, y: 20 }
-      )
-      .addPanel(
-        newGraphPanel(
-          graphTitle='Transmit Bandwidth',
-          graphQuery='sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 12, y: 20 }
-      )
-      .addPanel(
-        packetRow
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Received Packets',
-            graphQuery='sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 10, w: 12, x: 0, y: 30 }
-        )
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Transmitted Packets',
-            graphQuery='sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 10, w: 12, x: 12, y: 30 }
-        ),
-        gridPos={ h: 1, w: 24, x: 0, y: 29 }
-      )
-      .addPanel(
-        errorRow
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Received Packets Dropped',
-            graphQuery='sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 10, w: 12, x: 0, y: 40 }
-        )
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Transmitted Packets Dropped',
-            graphQuery='sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[$interval:$resolution])) by (pod)' % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 10, w: 12, x: 12, y: 40 }
-        ),
-        gridPos={ h: 1, w: 24, x: 0, y: 30 }
-      ),
+      };
+
+      local panels = [
+        gauge.new('Current Rate of Bytes Received')
+        + gauge.standardOptions.withDisplayName('$namespace')
+        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withMin(0)
+        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.thresholds.withSteps([
+          {
+            color: 'dark-green',
+            index: 0,
+            value: null,  // 0GBs
+          },
+          {
+            color: 'dark-yellow',
+            index: 1,
+            value: 5000000000,  // 5GBs
+          },
+          {
+            color: 'dark-red',
+            index: 2,
+            value: 7000000000,  // 7GBs
+          },
+        ])
+        + gauge.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))' % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        gauge.new('Current Rate of Bytes Transmitted')
+        + gauge.standardOptions.withDisplayName('$namespace')
+        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withMin(0)
+        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.thresholds.withSteps([
+          {
+            color: 'dark-green',
+            index: 0,
+            value: null,  // 0GBs
+          },
+          {
+            color: 'dark-yellow',
+            index: 1,
+            value: 5000000000,  // 5GBs
+          },
+          {
+            color: 'dark-red',
+            index: 2,
+            value: 7000000000,  // 7GBs
+          },
+        ])
+        + gauge.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))' % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        table.new('Current Network Usage')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', 'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+
+          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+
+          prometheus.new('${datasource}', 'sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+
+          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+
+          prometheus.new('${datasource}', 'sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+
+          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'pod',
+            mode: 'outer',
+          }),
+
+          table.queryOptions.transformation.withId('organize')
+          + table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              pod: 6,
+              'Value #A': 7,
+              'Value #B': 8,
+              'Value #C': 9,
+              'Value #D': 10,
+              'Value #E': 11,
+              'Value #F': 12,
+            },
+            renameByName: {
+              pod: 'Pod',
+              'Value #A': 'Current Receive Bandwidth',
+              'Value #B': 'Current Transmit Bandwidth',
+              'Value #C': 'Rate of Received Packets',
+              'Value #D': 'Rate of Transmitted Packets',
+              'Value #E': 'Rate of Received Packets Dropped',
+              'Value #F': 'Rate of Transmitted Packets Dropped',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Bandwidth/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'Bps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Packets/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'pps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Pod',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.pod],
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Receive Bandwidth')
+        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Transmit Bandwidth')
+        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', 'sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', 'sum by (namespace) (rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))' % $._config)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+      ];
+
+      g.dashboard.new('%(dashboardNamePrefix)sNetworking / Namespace (Pods)' % $._config.grafanaK8s)
+      + g.dashboard.withUid($._config.grafanaDashboardIDs['namespace-by-pod.json'])
+      + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
+      + g.dashboard.withEditable(false)
+      + g.dashboard.time.withFrom('now-1h')
+      + g.dashboard.time.withTo('now')
+      + g.dashboard.withRefresh($._config.grafanaK8s.refresh)
+      + g.dashboard.withVariables([variables.datasource, variables.cluster, variables.namespace])
+      + g.dashboard.withPanels(g.util.grid.wrapPanels(panels, panelWidth=12, panelHeight=9)),
   },
 }


### PR DESCRIPTION
Part of:

- #898 

Following on from:

- #918

**BEFORE**

<img width="1604" alt="Screenshot 2024-04-29 at 15 35 58" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/8077abe4-885b-4caa-ae25-b52d4fba937c">

**AFTER**

<img width="1604" alt="Screenshot 2024-04-29 at 15 33 08" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/62df3f27-53e1-4e9b-afef-2f9f8ed5475c">


