### PR TITLE
fix(CI) Revert to a previous revision of grafana-builder

### DIFF
--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "master"
+      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f"
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This commit of jsonnet-libs/grafana-builder introduced an import which is not used, and not included in a `jsonnetfile.json` for the library, which is causing CI issues here.

As part of #898 we'll eventually remove grafana-builder entirely, but for now this will allow CI linting to complete successfully.

Note that this PR does not resolve a few other linting issues found when running `jsonnet-lint`, those are addressed as drive-by fixes in #918. Thus, when this PR, and #918 are both merged, the master branch should build cleanly.