### PR TITLE
fix(dashboards): Port networking/namespace (workload) dashboard to new grafonnet

### DIFF
--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -1,592 +1,434 @@
-local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
-local dashboard = grafana.dashboard;
-local row = grafana.row;
-local prometheus = grafana.prometheus;
-local template = grafana.template;
-local graphPanel = grafana.graphPanel;
-local tablePanel = grafana.tablePanel;
-local annotation = grafana.annotation;
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local barGauge = g.panel.barGauge;
+local prometheus = g.query.prometheus;
+local table = g.panel.table;
+local timeSeries = g.panel.timeSeries;
+local var = g.dashboard.variable;
 
 {
-  grafanaDashboards+:: {
+  local tsPanel =
+    timeSeries {
+      new(title):
+        timeSeries.new(title)
+        + timeSeries.options.legend.withShowLegend()
+        + timeSeries.options.legend.withAsTable()
+        + timeSeries.options.legend.withDisplayMode('table')
+        + timeSeries.options.legend.withPlacement('right')
+        + timeSeries.options.legend.withCalcs(['lastNotNull'])
+        + timeSeries.options.tooltip.withMode('single')
+        + timeSeries.fieldConfig.defaults.custom.withShowPoints('never')
+        + timeSeries.fieldConfig.defaults.custom.withFillOpacity(10)
+        + timeSeries.fieldConfig.defaults.custom.withSpanNulls(true)
+        + timeSeries.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval),
+    },
 
+  grafanaDashboards+:: {
     'namespace-by-workload.json':
 
-      local newStyle(
-        alias,
-        colorMode=null,
-        colors=[],
-        dateFormat='YYYY-MM-DD HH:mm:ss',
-        decimals=2,
-        link=false,
-        linkTooltip='Drill down',
-        linkUrl='',
-        thresholds=[],
-        type='number',
-        unit='short'
-            ) = {
-        alias: alias,
-        colorMode: colorMode,
-        colors: colors,
-        dateFormat: dateFormat,
-        decimals: decimals,
-        link: link,
-        linkTooltip: linkTooltip,
-        linkUrl: linkUrl,
-        thresholds: thresholds,
-        type: type,
-        unit: unit,
+      local variables = {
+        datasource:
+          var.datasource.new('datasource', 'prometheus')
+          + var.datasource.withRegex($._config.datasourceFilterRegex)
+          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.datasource.generalOptions.withLabel('Data source')
+          + {
+            current: {
+              selected: true,
+              text: $._config.datasourceName,
+              value: $._config.datasourceName,
+            },
+          },
+
+        cluster:
+          var.query.new('cluster')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            $._config.clusterLabel,
+            'up{%(cadvisorSelector)s}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('cluster')
+          + var.query.refresh.onTime()
+          + (
+            if $._config.showMultiCluster
+            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+            else var.query.generalOptions.showOnDashboard.withNothing()
+          )
+          + var.query.withSort(type='alphabetical'),
+
+        namespace:
+          var.query.new('namespace')
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'namespace',
+            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
+          )
+          + var.query.generalOptions.withCurrent('kube-system')
+          + var.query.generalOptions.withLabel('namespace')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
+
+        workload_type:
+          var.query.new('type')
+          + var.query.selectionOptions.withIncludeAll()
+          + var.query.withDatasourceFromVariable(self.datasource)
+          + var.query.queryTypes.withLabelValues(
+            'workload_type',
+            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % $._config,
+          )
+          + var.query.generalOptions.withLabel('workload_type')
+          + var.query.refresh.onTime()
+          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+          + var.query.withSort(type='alphabetical'),
       };
 
-      local newBarplotPanel(graphTitle, graphQuery, graphFormat='Bps', legendFormat='{{namespace}}') =
-        local target =
-          prometheus.target(
-            graphQuery
-          ) + {
-            intervalFactor: 1,
-            legendFormat: legendFormat,
-            step: 10,
-          };
-
-        graphPanel.new(
-          title=graphTitle,
-          span=24,
-          datasource='$datasource',
-          fill=2,
-          min_span=24,
-          format=graphFormat,
-          min=0,
-          max=null,
-          show_xaxis=false,
-          x_axis_mode='series',
-          x_axis_values='current',
-          lines=false,
-          bars=true,
-          stack=false,
-          legend_show=true,
-          legend_values=true,
-          legend_min=false,
-          legend_max=false,
-          legend_current=true,
-          legend_avg=false,
-          legend_alignAsTable=true,
-          legend_rightSide=true,
-          legend_sort='current',
-          legend_sortDesc=true,
-          nullPointMode='null'
-        ).addTarget(target) + {
-          legend+: {
-            hideEmpty: true,
-            hideZero: true,
+      local links = {
+        workload: {
+          title: 'Drill down',
+          url: '%(prefix)s/d/%(uid)s/kubernetes-networking-workload?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}' % {
+            uid: $._config.grafanaDashboardIDs['workload-total.json'],
+            prefix: $._config.grafanaK8s.linkPrefix,
           },
-          paceLength: 10,
-          tooltip+: {
-            sort: 2,
-          },
-        };
-
-      local newGraphPanel(graphTitle, graphQuery, graphFormat='Bps') =
-        local target =
-          prometheus.target(
-            graphQuery
-          ) + {
-            intervalFactor: 1,
-            legendFormat: '{{workload}}',
-            step: 10,
-          };
-
-        graphPanel.new(
-          title=graphTitle,
-          span=12,
-          datasource='$datasource',
-          fill=2,
-          linewidth=2,
-          min_span=12,
-          format=graphFormat,
-          min=0,
-          max=null,
-          x_axis_mode='time',
-          x_axis_values='total',
-          lines=true,
-          stack=true,
-          legend_show=true,
-          nullPointMode='connected'
-        ).addTarget(target) + {
-          legend+: {
-            hideEmpty: true,
-            hideZero: true,
-          },
-          paceLength: 10,
-          tooltip+: {
-            sort: 2,
-          },
-        };
-
-      local newTablePanel(tableTitle, colQueries) =
-        local buildTarget(index, colQuery) =
-          prometheus.target(
-            colQuery,
-            format='table',
-            instant=true,
-          ) + {
-            legendFormat: '',
-            step: 10,
-            refId: std.char(65 + index),
-          };
-
-        local targets = std.mapWithIndex(buildTarget, colQueries);
-
-        tablePanel.new(
-          title=tableTitle,
-          span=24,
-          min_span=24,
-          datasource='$datasource',
-        )
-        .addColumn(
-          field='Time',
-          style=newStyle(
-            alias='Time',
-            type='hidden'
-          )
-        )
-        .addColumn(
-          field='Value #A',
-          style=newStyle(
-            alias='Current Bandwidth Received',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #B',
-          style=newStyle(
-            alias='Current Bandwidth Transmitted',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #C',
-          style=newStyle(
-            alias='Average Bandwidth Received',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #D',
-          style=newStyle(
-            alias='Average Bandwidth Transmitted',
-            unit='Bps',
-          ),
-        )
-        .addColumn(
-          field='Value #E',
-          style=newStyle(
-            alias='Rate of Received Packets',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #F',
-          style=newStyle(
-            alias='Rate of Transmitted Packets',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #G',
-          style=newStyle(
-            alias='Rate of Received Packets Dropped',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='Value #H',
-          style=newStyle(
-            alias='Rate of Transmitted Packets Dropped',
-            unit='pps',
-          ),
-        )
-        .addColumn(
-          field='workload',
-          style=newStyle(
-            alias='Workload',
-            link=true,
-            linkUrl='d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell'
-          ),
-        ) + {
-
-          fill: 1,
-          fontSize: '90%',
-          lines: true,
-          linewidth: 1,
-          nullPointMode: 'null as zero',
-          renderer: 'flot',
-          scroll: true,
-          showHeader: true,
-          spaceLength: 10,
-          sort: {
-            col: 0,
-            desc: false,
-          },
-          targets: targets,
-        };
-
-      local clusterTemplate =
-        template.new(
-          name='cluster',
-          datasource='$datasource',
-          query='label_values(up{%(cadvisorSelector)s}, %(clusterLabel)s)' % $._config,
-          hide=if $._config.showMultiCluster then '' else '2',
-          refresh=2
-        );
-
-      local namespaceTemplate =
-        template.new(
-          name='namespace',
-          datasource='$datasource',
-          query='label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
-          current='kube-system',
-          hide='',
-          refresh=2,
-          includeAll=false,
-          multi=false,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          definition: 'label_values(container_network_receive_packets_total{%(clusterLabel)s="$cluster"}, namespace)' % $._config,
-          skipUrlSync: false,
-        };
-
-      local typeTemplate =
-        template.new(
-          name='type',
-          datasource='$datasource',
-          query='label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+"}, workload_type)' % $._config,
-          current='',
-          hide='',
-          refresh=2,
-          includeAll=true,
-          sort=0
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          definition: 'label_values(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+"}, workload_type)' % $._config,
-          skipUrlSync: false,
-        };
-
-      local resolutionTemplate =
-        template.new(
-          name='resolution',
-          datasource='$datasource',
-          query='30s,5m,1h',
-          current='5m',
-          hide='',
-          refresh=2,
-          includeAll=false,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          skipUrlSync: false,
-          type: 'interval',
-          options: [
-            {
-              selected: false,
-              text: '30s',
-              value: '30s',
-            },
-            {
-              selected: true,
-              text: '5m',
-              value: '5m',
-            },
-            {
-              selected: false,
-              text: '1h',
-              value: '1h',
-            },
-          ],
-        };
-
-      local intervalTemplate =
-        template.new(
-          name='interval',
-          datasource='$datasource',
-          query='4h',
-          current='5m',
-          hide=2,
-          refresh=2,
-          includeAll=false,
-          sort=1
-        ) + {
-          auto: false,
-          auto_count: 30,
-          auto_min: '10s',
-          skipUrlSync: false,
-          type: 'interval',
-          options: [
-            {
-              selected: true,
-              text: '4h',
-              value: '4h',
-            },
-          ],
-        };
-
-      //#####  Current Bandwidth Row ######
-
-      local currentBandwidthRow =
-        row.new(
-          title='Current Bandwidth'
-        );
-
-      //#####  Average Bandwidth Row ######
-
-      local averageBandwidthRow =
-        row.new(
-          title='Average Bandwidth',
-          collapse=true,
-        );
-
-      //#####  Bandwidth History Row ######
-
-      local bandwidthHistoryRow =
-        row.new(
-          title='Bandwidth HIstory',
-        );
-
-      //##### Packet  Row ######
-      // collapsed, so row must include panels
-      local packetRow =
-        row.new(
-          title='Packets',
-          collapse=true,
-        );
-
-      //##### Error Row ######
-      // collapsed, so row must include panels
-      local errorRow =
-        row.new(
-          title='Errors',
-          collapse=true,
-        );
-
-      dashboard.new(
-        title='%(dashboardNamePrefix)sNetworking / Namespace (Workload)' % $._config.grafanaK8s,
-        tags=($._config.grafanaK8s.dashboardTags),
-        editable=true,
-        schemaVersion=18,
-        refresh=($._config.grafanaK8s.refresh),
-        time_from='now-1h',
-        time_to='now',
-      )
-      .addTemplate(
-        {
-          current: {
-            selected: true,
-            text: $._config.datasourceName,
-            value: $._config.datasourceName,
-          },
-          hide: 0,
-          label: 'Data source',
-          name: 'datasource',
-          options: [],
-          query: 'prometheus',
-          refresh: 1,
-          regex: $._config.datasourceFilterRegex,
-          type: 'datasource',
         },
-      )
-      .addTemplate(clusterTemplate)
-      .addTemplate(namespaceTemplate)
-      .addTemplate(typeTemplate)
-      .addTemplate(resolutionTemplate)
-      .addTemplate(intervalTemplate)
-      .addAnnotation(annotation.default)
-      .addPanel(currentBandwidthRow, gridPos={ h: 1, w: 24, x: 0, y: 0 })
-      .addPanel(
-        newBarplotPanel(
-          graphTitle='Current Rate of Bytes Received',
-          graphQuery=|||
-            sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config,
-          legendFormat='{{ workload }}',
-        ),
-        gridPos={ h: 9, w: 12, x: 0, y: 1 }
-      )
-      .addPanel(
-        newBarplotPanel(
-          graphTitle='Current Rate of Bytes Transmitted',
-          graphQuery=|||
-            sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config,
-          legendFormat='{{ workload }}',
-        ),
-        gridPos={ h: 9, w: 12, x: 12, y: 1 }
-      )
-      .addPanel(
-        newTablePanel(
-          tableTitle='Current Status',
-          colQueries=[
+      };
+
+      local colQueries = [
+        |||
+          sort_desc(sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(avg(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(avg(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+        |||
+          sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+          * on (namespace,pod)
+          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload, workload_type))
+        ||| % $._config,
+      ];
+
+      local panels = [
+        barGauge.new('Current Rate of Bytes Received')
+        + barGauge.options.withDisplayMode('basic')
+        + barGauge.options.withShowUnfilled(false)
+        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.color.withMode('fixed')
+        + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        barGauge.new('Current Rate of Bytes Transmitted')
+        + barGauge.options.withDisplayMode('basic')
+        + barGauge.options.withShowUnfilled(false)
+        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.color.withMode('fixed')
+        + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        table.new('Current Status')
+        + table.gridPos.withW(24)
+        + table.queryOptions.withTargets([
+          prometheus.new('${datasource}', colQueries[0])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[1])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[2])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[3])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[4])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[5])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[6])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+          prometheus.new('${datasource}', colQueries[7])
+          + prometheus.withInstant(true)
+          + prometheus.withFormat('table'),
+        ])
+        + table.queryOptions.withTransformations([
+          table.queryOptions.transformation.withId('joinByField')
+          + table.queryOptions.transformation.withOptions({
+            byField: 'workload',
+            mode: 'outer',
+          }),
+
+          g.panel.table.queryOptions.transformation.withId('organize')
+          + g.panel.table.queryOptions.transformation.withOptions({
+            excludeByName: {
+              Time: true,
+              'Time 1': true,
+              'Time 2': true,
+              'Time 3': true,
+              'Time 4': true,
+              'Time 5': true,
+              'Time 6': true,
+              'Time 7': true,
+              'Time 8': true,
+              'workload_type 2': true,
+              'workload_type 3': true,
+              'workload_type 4': true,
+              'workload_type 5': true,
+              'workload_type 6': true,
+              'workload_type 7': true,
+              'workload_type 8': true,
+            },
+            indexByName: {
+              'Time 1': 0,
+              'Time 2': 1,
+              'Time 3': 2,
+              'Time 4': 3,
+              'Time 5': 4,
+              'Time 6': 5,
+              'Time 7': 6,
+              'Time 8': 7,
+              workload: 8,
+              'workload_type 1': 9,
+              'Value #A': 10,
+              'Value #B': 11,
+              'Value #C': 12,
+              'Value #D': 13,
+              'Value #E': 14,
+              'Value #F': 15,
+              'Value #G': 16,
+              'Value #H': 17,
+              'workload_type 2': 18,
+              'workload_type 3': 19,
+              'workload_type 4': 20,
+              'workload_type 5': 21,
+              'workload_type 6': 22,
+              'workload_type 7': 23,
+              'workload_type 8': 24,
+            },
+            renameByName: {
+              workload: 'Workload',
+              'workload_type 1': 'Type',
+              'Value #A': 'Rx Bytes',
+              'Value #B': 'Tx Bytes',
+              'Value #C': 'Rx Bytes (Avg)',
+              'Value #D': 'Tx Bytes (Avg)',
+              'Value #E': 'Rx Packets',
+              'Value #F': 'Tx Packets',
+              'Value #G': 'Rx Packets Dropped',
+              'Value #H': 'Tx Packets Dropped',
+            },
+          }),
+        ])
+
+        + table.standardOptions.withOverrides([
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Bytes/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'binBps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byRegexp',
+              options: '/Packets/',
+            },
+            properties: [
+              {
+                id: 'unit',
+                value: 'pps',
+              },
+            ],
+          },
+          {
+            matcher: {
+              id: 'byName',
+              options: 'Workload',
+            },
+            properties: [
+              {
+                id: 'links',
+                value: [links.workload],
+              },
+            ],
+          },
+        ]),
+
+        tsPanel.new('Receive Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Transmit Bandwidth')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Workload: Received')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(avg(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Average Container Bandwidth by Workload: Transmitted')
+        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(avg(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
             |||
-              sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+              sort_desc(sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-          ]
-        ),
-        gridPos={ h: 9, w: 24, x: 0, y: 10 }
-      )
-      .addPanel(
-        averageBandwidthRow
-        .addPanel(
-          newBarplotPanel(
-            graphTitle='Average Rate of Bytes Received',
-            graphQuery=|||
-              sort_desc(avg(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Received Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            legendFormat='{{ workload }}',
-          ),
-          gridPos={ h: 9, w: 12, x: 0, y: 20 }
-        )
-        .addPanel(
-          newBarplotPanel(
-            graphTitle='Average Rate of Bytes Transmitted',
-            graphQuery=|||
-              sort_desc(avg(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+
+        tsPanel.new('Rate of Transmitted Packets Dropped')
+        + tsPanel.standardOptions.withUnit('pps')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            |||
+              sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
               * on (namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            legendFormat='{{ workload }}',
-          ),
-          gridPos={ h: 9, w: 12, x: 12, y: 20 }
-        ),
-        gridPos={ h: 1, w: 24, x: 0, y: 19 },
-      )
-      .addPanel(
-        bandwidthHistoryRow, gridPos={ h: 1, w: 24, x: 0, y: 29 }
-      )
-      .addPanel(
-        newGraphPanel(
-          graphTitle='Receive Bandwidth',
-          graphQuery=|||
-            sort_desc(sum(irate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 0, y: 38 }
-      )
-      .addPanel(
-        newGraphPanel(
-          graphTitle='Transmit Bandwidth',
-          graphQuery=|||
-            sort_desc(sum(irate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-            * on (namespace,pod)
-            group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-          ||| % $._config,
-        ),
-        gridPos={ h: 9, w: 12, x: 12, y: 38 }
-      )
-      .addPanel(
-        packetRow
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Received Packets',
-            graphQuery=|||
-              sort_desc(sum(irate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-              * on (namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 9, w: 12, x: 0, y: 40 }
-        )
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Transmitted Packets',
-            graphQuery=|||
-              sort_desc(sum(irate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-              * on (namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 9, w: 12, x: 12, y: 40 }
-        ),
-        gridPos={ h: 1, w: 24, x: 0, y: 39 }
-      )
-      .addPanel(
-        errorRow
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Received Packets Dropped',
-            graphQuery=|||
-              sort_desc(sum(irate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-              * on (namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 9, w: 12, x: 0, y: 41 }
-        )
-        .addPanel(
-          newGraphPanel(
-            graphTitle='Rate of Transmitted Packets Dropped',
-            graphQuery=|||
-              sort_desc(sum(irate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[$interval:$resolution])
-              * on (namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config,
-            graphFormat='pps'
-          ),
-          gridPos={ h: 9, w: 12, x: 12, y: 41 }
-        ),
-        gridPos={ h: 1, w: 24, x: 0, y: 40 }
-      ),
+            ||| % $._config
+          )
+          + prometheus.withLegendFormat('__auto'),
+        ]),
+      ];
+
+      g.dashboard.new('%(dashboardNamePrefix)sNetworking / Namespace (Workload)' % $._config.grafanaK8s)
+      + g.dashboard.withUid($._config.grafanaDashboardIDs['namespace-by-workload.json'])
+      + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
+      + g.dashboard.withEditable(false)
+      + g.dashboard.time.withFrom('now-1h')
+      + g.dashboard.time.withTo('now')
+      + g.dashboard.withRefresh($._config.grafanaK8s.refresh)
+      + g.dashboard.withVariables([variables.datasource, variables.cluster, variables.namespace, variables.workload_type])
+      + g.dashboard.withPanels(g.util.grid.wrapPanels(panels, panelWidth=12, panelHeight=9)),
   },
 }


### PR DESCRIPTION
Part of:

- #898 

Following on from:

- #921

**BEFORE**

<img width="1590" alt="Screenshot 2024-04-30 at 18 54 53" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/5e453d42-e72e-4e46-b178-c3aab6a3d865">


**AFTER**

<img width="1590" alt="Screenshot 2024-04-30 at 18 49 37" src="https://github.com/kubernetes-monitoring/kubernetes-mixin/assets/514343/93c7733b-18da-4fa7-a499-1260763526a2">

