### PR TITLE
dashboards: resources: cluster: change CPU utilization panel to percentage value

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -79,7 +79,7 @@ local var = g.dashboard.variable;
       local panels = [
         statPanel(
           'CPU Utilisation',
-          'none',
+          'percentunit',
           'cluster:node_cpu:ratio_rate5m{%(clusterLabel)s="$cluster"}' % $._config
         )
         + stat.gridPos.withW(4)


### PR DESCRIPTION
simple change for you folks. At some point (I suspect [here](https://github.com/kubernetes-monitoring/kubernetes-mixin/commit/fa681a4e62bc04c0ca6c56875bd9a5f0e88521dc?diff=split&w=0#diff-7f81f0d98a75508ce07419242b2c64000afcb1f32cd0ce4fb79b0056210ccd7cR82) but not sure) the CPU util panel stopped showing a % value. This[ wasnt the case before](https://github.com/helm/charts/issues/18377). 