### PR TITLE
Update multi-cluster.libsonnet

### DIFF
--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -126,7 +126,7 @@ local var = g.dashboard.variable;
             + g.panel.table.queryOptions.withTransformations([
               g.panel.table.queryOptions.transformation.withId('joinByField')
               + g.panel.table.queryOptions.transformation.withOptions({
-                byField: 'cluster',
+                byField: '%(clusterLabel)s',
                 mode: 'outer',
               }),
 
@@ -225,7 +225,7 @@ local var = g.dashboard.variable;
             + g.panel.table.queryOptions.withTransformations([
               g.panel.table.queryOptions.transformation.withId('joinByField')
               + g.panel.table.queryOptions.transformation.withOptions({
-                byField: 'cluster',
+                byField: '%(clusterLabel)s',
                 mode: 'outer',
               }),
 


### PR DESCRIPTION
Since, most of the selectors for the dashboard are overriden by custom variables. 

File in path: dashboards/resources/multi-cluster.libsonnet does have the tranformation "byField" Selector hardcoded as "cluster" but whereas all other clustername selectors use the override variable "%(clusterLabel)s". Apparently, this fork contains the change of converting hard-coded selector to over-ride selector.