### PR TITLE
fix: Re-add cluster label to KubeStatefulSetUpdateNotRolledOut

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -143,7 +143,7 @@
           {
             expr: |||
               (
-                max by(namespace, statefulset) (
+                max by(namespace, statefulset, job, %(clusterLabel)s) (
                   kube_statefulset_status_current_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                     unless
                   kube_statefulset_status_update_revision{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}


### PR DESCRIPTION
The alert `KubeStatefulSetUpdateNotRolledOut` was modified by the following PR:

- #958

The aggregation labels were changed and several were removed when refactoring from `without` to `by`:

- `job`
- `cluster`
- `instance`

I think the `instance` label is probably not useful, but `job` and `cluster` are certainly useful, so this PR proposes to bring them back.

Here are all the labels from the previous `without` version of the alert expression (my alert wasn't firing so I commented out the irrelevant parts of the PromQL just to see the underlying labels):

<img width="1539" alt="Screenshot 2024-08-28 at 14 20 01" src="https://github.com/user-attachments/assets/162fd00e-f6c2-40f1-aa7c-badd006043d9">

Here is a test of the alert rule generated by this PR, which shows the `job` and `cluster` labels still intact whilst maintaining use of the `by` aggregation as suggested by the `pint` tool:

<img width="1539" alt="Screenshot 2024-08-28 at 14 20 33" src="https://github.com/user-attachments/assets/38bdfef4-4f81-4b28-9007-5648e6c3bc6f">
