### PR TITLE
fix: stale action linebreaks and wording update

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,16 +14,16 @@ jobs:
         with:
           days-before-stale: 30
           days-before-close: 7
-          stale-issue-message: >
+          stale-issue-message: |
             This issue has not had any activity in the past 30 days, so the
             `stale` label has been added to it.
 
             * The `stale` label will be removed if there is new activity
-            * The issue will be closed in 2 days if there is no new activity
+            * The issue will be closed in 7 days if there is no new activity
             * Add the `keepalive` label to exempt this issue from the stale check action
 
             Thank you for your contributions!
-          stale-pr-message: >
+          stale-pr-message: |
             This PR has been automatically marked as stale because it has not
             had any activity in the past 30 days.
 


### PR DESCRIPTION
I noticed a couple of issues with the stale comments:

- line breaks are being removed, breaking the bulleted list
- wording should say `closed in 7 days`, not `2`, to match the action config

Screenshot:

<img width="947" alt="Screenshot 2024-09-04 at 12 28 17" src="https://github.com/user-attachments/assets/dcb69ed4-95f6-4e95-81f1-48628268a89a">
