### PR TITLE
fix(dashboards/resources/node): kube_node_status_capacity missing kubeStateMetricsSelector

### DIFF
--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -81,7 +81,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster",%(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % $._config,
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % $._config,
           )
           + prometheus.withLegendFormat('max capacity'),
 
@@ -180,7 +180,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster",%(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
           )
           + prometheus.withLegendFormat('max capacity'),
 

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -81,7 +81,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", node=~"$node", resource="cpu"})' % $._config,
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster",%(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % $._config,
           )
           + prometheus.withLegendFormat('max capacity'),
 
@@ -180,7 +180,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", node=~"$node", resource="memory"})' % $._config,
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster",%(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
           )
           + prometheus.withLegendFormat('max capacity'),
 


### PR DESCRIPTION
The metric `kube_node_status_capacity` comes from `kube-state-metrics` component. However the "resources node dashboard" is missing the `%(kubeStateMetricsSelector)s,`.

This should allow the dashboard to be customised appropriately. 

NOTE: the alert where this metric is used already contains the correct `%(kubeStateMetricsSelector)s,` filter:
https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/ed370f9e5dbd5b3d4964ce1bd91a3043262d020b/alerts/kubelet.libsonnet#L60
