### PR TITLE
build(deps): Enable dependabot for Golang

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+  - package-ecosystem: gomod
+    directory: /scripts
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Configures Dependabot to keep an eye on `scripts/go.mod` (we're currently checking only GitHub Actions).