### PR TITLE
feat: add cluster to alerts description (when possible)

### DIFF
--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -59,7 +59,10 @@ local utils = import '../lib/utils.libsonnet';
               severity: 'warning',
             },
             annotations: {
-              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationWarningSeconds)),
+              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s%s.' % [
+                (utils.humanizeSeconds($._config.certExpirationWarningSeconds)),
+                utils.ifClusterLabelSet($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
+              ],
               summary: 'Client certificate is about to expire.',
             },
           },
@@ -75,7 +78,10 @@ local utils = import '../lib/utils.libsonnet';
               severity: 'critical',
             },
             annotations: {
-              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s.' % (utils.humanizeSeconds($._config.certExpirationCriticalSeconds)),
+              description: 'A client certificate used to authenticate to kubernetes apiserver is expiring in less than %s%s.' % [
+                (utils.humanizeSeconds($._config.certExpirationCriticalSeconds)),
+                utils.ifClusterLabelSet($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
+              ],
               summary: 'Client certificate is about to expire.',
             },
           },

--- a/lib/utils.libsonnet
+++ b/lib/utils.libsonnet
@@ -56,4 +56,8 @@
           metric: labels.metric,
         },
       },
+
+  // if clusterLabel is set, return the string, otherwise return an empty string
+  ifClusterLabelSet(config, string)::
+    if std.length(config.clusterLabel) > 0 then string else '',
 }


### PR DESCRIPTION
Addressing this comment: https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/941#issuecomment-2462078334.

---
@skl I think something like this might work, although maybe there's more elegant solutions possible.