### PR TITLE
fix: apiserver availability apiserver_request_sli_duration_seconds_count:increase30d

### DIFF
--- a/rules/kube_apiserver-availability.libsonnet
+++ b/rules/kube_apiserver-availability.libsonnet
@@ -50,7 +50,7 @@
           {
             record: 'cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase%s' % SLODays,
             expr: |||
-              sum by (%s, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%s{le="+Inf"} * 24 * %s)
+              sum by (%s, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%s{le="+Inf"})
             ||| % [$._config.clusterLabel, SLODays, $._config.SLOs.apiserver.days],
           },
           {

--- a/rules/kube_apiserver-availability.libsonnet
+++ b/rules/kube_apiserver-availability.libsonnet
@@ -51,7 +51,7 @@
             record: 'cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase%s' % SLODays,
             expr: |||
               sum by (%s, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase%s{le="+Inf"})
-            ||| % [$._config.clusterLabel, SLODays, $._config.SLOs.apiserver.days],
+            ||| % [$._config.clusterLabel, SLODays],
           },
           {
             record: 'apiserver_request:availability%s' % SLODays,


### PR DESCRIPTION
In #976 I introduced a bug because I didn't remove the multiplication by `* 24 * SLODays` from the count expression, despite it now relying on the bucket infinity of the (already multiplied) one.
This causes the `apiserver_request_sli_duration_seconds_count` to end up being multiplied twice by `* 24 * SLODays`, leading to the faulty Availability calculations reported in:
- #990
- https://github.com/prometheus-operator/kube-prometheus/issues/2564
- https://github.com/prometheus-community/helm-charts/issues/5043.

This PR should fix the error