### PR TITLE
fix(dashboards): Graph mem usage w and w/o cache

### DIFF
--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -175,7 +175,7 @@ local var = g.dashboard.variable;
           },
         ]),
 
-        tsPanel.new('Memory Usage (w/o cache)')
+        tsPanel.new('Memory Usage (w/cache)')
         + tsPanel.standardOptions.withUnit('bytes')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
@@ -187,6 +187,33 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             'sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node", container!=""}) by (pod)' % $._config,
+          )
+          + prometheus.withLegendFormat('{{pod}}'),
+        ])
+        + tsPanel.fieldConfig.defaults.custom.withStacking({ mode: 'normal' })
+        + tsPanel.standardOptions.withOverrides([
+          fieldOverride.byName.new('max capacity')
+          + fieldOverride.byName.withPropertiesFromOptions(
+            timeSeries.standardOptions.color.withMode('fixed')
+            + timeSeries.standardOptions.color.withFixedColor('red')
+          )
+          + fieldOverride.byName.withProperty('custom.stacking', { mode: 'none' })
+          + fieldOverride.byName.withProperty('custom.hideFrom', { tooltip: true, viz: false, legend: false })
+          + fieldOverride.byName.withProperty('custom.lineStyle', { fill: 'dash', dash: [10, 10] }),
+        ]),
+
+        tsPanel.new('Memory Usage (w/o cache)')
+        + tsPanel.standardOptions.withUnit('bytes')
+        + tsPanel.queryOptions.withTargets([
+          prometheus.new(
+            '${datasource}',
+            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+          )
+          + prometheus.withLegendFormat('max capacity'),
+
+          prometheus.new(
+            '${datasource}',
+            'sum(node_namespace_pod_container:container_memory_rss{%(clusterLabel)s="$cluster", node=~"$node", container!=""}) by (pod)' % $._config,
           )
           + prometheus.withLegendFormat('{{pod}}'),
         ])


### PR DESCRIPTION
Fixes #999

Changes:

- Fixed incorrect panel title
- We now have two memory charts on the node (pods) dashboard, one with cache and one without

<img width="1563" alt="Screenshot 2024-12-16 at 18 07 52" src="https://github.com/user-attachments/assets/06331d2a-2f7b-4dbe-ad6c-da174ad8afed" />
