### PR TITLE
fix: pint lint issue temporary workaround

### DIFF
--- a/.pint.hcl
+++ b/.pint.hcl
@@ -1,0 +1,3 @@
+checks {
+  disabled = ["promql/fragile"]
+}


### PR DESCRIPTION
## Change
Since pint lint is failing all the time because of the same lint issue, I think that we could temporarily disable that specific lint check to stop having the CI always fail.

I followed the docs [here](https://cloudflare.github.io/pint/ignoring.html#disabling-checks-globally) to understand how to disable it.

## References
- #986
- #985 