### PR TITLE
Fix broken rules with Prometheus v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 | release-0.11   | v1.23+                   | v2.11.0+                 | v2.0+                            |
 | release-0.12   | v1.23+                   | v2.11.0+                 | v2.0+                            |
 | release-0.13   | v1.23+                   | v2.11.0+                 | v2.0+                            |
-| master         | v1.26+                   | v2.11.0+                 | v2.0+                            |
+| master         | v1.26+                   | v3.0.0+                  | v2.0+                            |
 
 In Kubernetes 1.14 there was a major [metrics overhaul](https://github.com/kubernetes/enhancements/issues/1206) implemented. Therefore v0.1.x of this repository is the last release to support Kubernetes 1.13 and previous version on a best effort basis.
 
 Some alerts now use Prometheus filters made available in Prometheus 2.11.0, which makes this version of Prometheus a dependency.
+
+With Prometheus v3, [histograms are normalized](https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values)
+This breaks some of the recording rules that select on the `le` label.
 
 Warning: This compatibility matrix was initially created based on experience, we do not guarantee the compatibility, it may be updated based on new learnings.
 

--- a/rules/kube_apiserver-config.libsonnet
+++ b/rules/kube_apiserver-config.libsonnet
@@ -8,9 +8,9 @@
     // These are buckets that exist on the apiserver_request_sli_duration_seconds_bucket histogram.
     // They are what the Kubernetes SIG Scalability is using to measure availability of Kubernetes clusters.
     // If you want to change these, make sure the "le" buckets exist on the histogram!
-    kubeApiserverReadResourceLatency: '1',
-    kubeApiserverReadNamespaceLatency: '5',
-    kubeApiserverReadClusterLatency: '30',
-    kubeApiserverWriteLatency: '1',
+    kubeApiserverReadResourceLatency: '1.0',
+    kubeApiserverReadNamespaceLatency: '5.0',
+    kubeApiserverReadClusterLatency: '30.0',
+    kubeApiserverWriteLatency: '1.0',
   },
 }


### PR DESCRIPTION
With Prometheus v3 [histograms are normalized](https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values) and this breaks rules that
select on the `le` label.
This PR updates the label selectors to use the new normalized value.

Before:
```
{le="1"}
```
Now with Prometheus v3:
```
{le="1.0"}
```

Fixes issue: https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/1005

Signed-off-by: leonnicolas <leonloechner@gmx.de>
