### PR TITLE
Add alert KubeEvictionRateHigh

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -221,6 +221,24 @@ local utils = import '../lib/utils.libsonnet';
               summary: 'Kubelet has failed to renew its server certificate.',
             },
           },
+          {
+            alert: 'KubeletEvictingPods',
+            expr: |||
+              changes(kubelet_evictions{%(kubeletSelector)s}[10m]) > 0
+              and
+              resets(kubelet_evictions{%(kubeletSelector)s}[10m]) == 0
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            'for': '2m',
+            annotations: {
+              description: 'Kubelet on node {{ $labels.node }} is evicting pods due to resource pressure.' % [
+                utils.ifShowMultiCluster($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
+              ],
+              summary: 'Kubelet is evicting pods.',
+            },
+          },
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'Kubelet',
             selector:: $._config.kubeletSelector,

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -225,24 +225,6 @@ local utils = import '../lib/utils.libsonnet';
               summary: 'Kubelet has failed to renew its server certificate.',
             },
           },
-          {
-            alert: 'KubeletEvictingPods',
-            expr: |||
-              changes(kubelet_evictions{%(kubeletSelector)s}[10m]) > 0
-              and
-              resets(kubelet_evictions{%(kubeletSelector)s}[10m]) == 0
-            ||| % $._config,
-            labels: {
-              severity: 'warning',
-            },
-            'for': '2m',
-            annotations: {
-              description: 'Kubelet on node {{ $labels.node }} is evicting pods due to resource pressure.%s' % [
-                utils.ifShowMultiCluster($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
-              ],
-              summary: 'Kubelet is evicting pods.',
-            },
-          },
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'Kubelet',
             selector:: $._config.kubeletSelector,

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -233,7 +233,7 @@ local utils = import '../lib/utils.libsonnet';
             },
             'for': '2m',
             annotations: {
-              description: 'Kubelet on node {{ $labels.node }} is evicting pods due to resource pressure.' % [
+              description: 'Kubelet on node {{ $labels.node }} is evicting pods due to resource pressure.%s' % [
                 utils.ifShowMultiCluster($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
               ],
               summary: 'Kubelet is evicting pods.',

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -228,7 +228,7 @@ local utils = import '../lib/utils.libsonnet';
           {
             alert: 'KubeEvictionRateHigh',
             expr: |||
-              sum(rate(kubelet_evictions[15m])) by (%(clusterLabel)s) > %(highEvictionRateThreshold)s
+              sum(rate(kubelet_evictions{%(kubeletSelector)s}[15m])) by (%(clusterLabel)s) > %(highEvictionRateThreshold)s
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -17,6 +17,8 @@ local utils = import '../lib/utils.libsonnet';
     // See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler
     // for more details.
     ignoringOverprovisionedWorkloadSelector: '',
+    // Max evictions per second that will trigger an alert. The default value generally allows for only one pod occasionally being evicted. Any more evictions than that will trigger the alert.
+    highEvictionRateThreshold: 0.002,
   },
 
   prometheusAlerts+:: {
@@ -221,6 +223,22 @@ local utils = import '../lib/utils.libsonnet';
                 utils.ifShowMultiCluster($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
               ],
               summary: 'Processes experience elevated CPU throttling.',
+            },
+          },
+          {
+            alert: 'KubeEvictionRateHigh',
+            expr: |||
+              sum(rate(kubelet_evictions[15m])) by (%(clusterLabel)s) > %(highEvictionRateThreshold)s
+            ||| % $._config,
+            labels: {
+              severity: 'warning',
+            },
+            'for': '1m',
+            annotations: {
+              description: 'The cluster is evicting Pods at an unexpectedly high rate. This is typically caused by pods frequently exceeding RAM/ephemeral-storage limits or by nodes being NotReady for extended periods.%s' % [
+                utils.ifShowMultiCluster($._config, ' on cluster {{ $labels.%(clusterLabel)s }}' % $._config),
+              ],
+              summary: 'Cluster is evicting pods at an unexpectedly high rate.',
             },
           },
         ],


### PR DESCRIPTION
This PR is (mostly) a copy of https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/760.  As best I can tell it was closed because it wanted to route eviction alerts to individual teams rather than to infra.  I want to reopen this conversation on the grounds that I believe it's more correct to route to infra on the basis that eviction scenarios have the potential to impact the entire cluster.  Furthermore, it's very possible that the evicted pod (chosen by kubelet) isn't the one applying undue pressure to the Node - in this scenario we could alert this team since they're impacted, but they wouldn't be the correct team to fix the issue.  There may be further discussion points but these are the big ones in my mind.

There's some parts that I'd appreciate feedback on
* I read the runbook.md is supposed to be auto-generated but I'm not seeing that behavior.
* I think a runbook needs to be created for prometheus-operator.  Can someone point me to the repo/path that needs a PR?
* I haven't tested the `0.002` threshold from the previous PR, it does however sound sufficiently low to me.