### PR TITLE
fix: KubeletTooManyPods respect clusterLabels

### DIFF
--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -61,15 +61,15 @@ local utils = import '../lib/utils.libsonnet';
             // We have to ignore this special node in the KubeletTooManyPods alert.
             expr: |||
               (
-                max by (cluster, instance) (
+                max by (%(clusterLabel)s, instance) (
                   kubelet_running_pods{%(kubeletSelector)s} > 1
                 )
-                * on (cluster, instance) group_left(node)
-                max by (cluster, instance, node) (
+                * on (%(clusterLabel)s, instance) group_left(node)
+                max by (%(clusterLabel)s, instance, node) (
                   kubelet_node_name{%(kubeletSelector)s}
                 )
               )
-              / on (cluster, node) group_left()
+              / on (%(clusterLabel)s, node) group_left()
               max by (%(clusterLabel)s, node) (
                 kube_node_status_capacity{%(kubeStateMetricsSelector)s, resource="pods"} != 1
               ) > 0.95


### PR DESCRIPTION
Corrected the issue in #1021  where `KubeletTooManyPods` did not use `%(clusterLabel)s` and instead specified `cluster`.