### PR TITLE
chore: automate-release-process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "version-*" # Trigger the workflow on push events to version-* tags
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release on kubernetes-mixin
+        uses: softprops/action-gh-release@v2
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          repository: kubernetes-monitoring/kubernetes-mixin
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Maintainers can trigger the [release workflow](.github/workflows/release.yaml) b
     ```
 2. Create a tag following sem-ver versioning for the version and trigger release. 
     ```bash
-	# replace MAJOR.MINOR.PATCH with e.g. 1.2.3
+	  # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
     tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag
     ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 
 ## Releases
+> Note: Releases up until `release-0.12` are changes in their own branches. There are changelogs in releases starting from `version-0.13.0`. 
 
 | Release branch | Kubernetes Compatibility | Prometheus Compatibility | Kube-state-metrics Compatibility |
 |----------------|--------------------------|--------------------------|----------------------------------|
@@ -32,6 +33,22 @@ Some alerts now use Prometheus filters made available in Prometheus 2.11.0, whic
 Warning: This compatibility matrix was initially created based on experience, we do not guarantee the compatibility, it may be updated based on new learnings.
 
 Warning: By default the expressions will generate *grafana 7.2+* compatible rules using the *$__rate_interval* variable for rate functions. If you need backward compatible rules please set *grafana72: false* in your *_config*
+
+### Release steps
+
+Maintainers can run release when it's time to do so. 
+
+1. Checkout `master` branch and pull for latest.
+    ```bash
+    git checkout master
+    ```
+2. Create a tag following sem-ver versioning for the version and trigger release. 
+    ```bash
+    tag=version=${x.x.x}; git tag $tag && git push origin $tag
+    ```
+
+#### Decisions on backfilling releases
+We wanted to backfill `release-0.1` to `release-0.12` to have a changelog, but we were not able to use a github action in a newer commit to trigger a release that generates a changelog on older commits. We have also tried adding a github action in existing release branches to trigger a release with changelog when a tag is created and pushed in a branch, but the generated changelog was empty as there were no previous releases. Since `release-0.12` was updated 3 years ago, we decided to start release and changelog from `version-0.13.0`
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Warning: By default the expressions will generate *grafana 7.2+* compatible rule
 
 ### Release steps
 
-Maintainers can run release when it's time to do so. 
+Maintainers can trigger the [release workflow](.github/workflows/release.yaml) by pushing a git tag that matches the pattern: `version-*`.
 
 1. Checkout `master` branch and pull for latest.
     ```bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Maintainers can trigger the [release workflow](.github/workflows/release.yaml) b
     ```
 2. Create a tag following sem-ver versioning for the version and trigger release. 
     ```bash
-	  # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
+    # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
     tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag
     ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Maintainers can trigger the [release workflow](.github/workflows/release.yaml) b
     ```
 
 #### Decisions on backfilling releases
-We wanted to backfill `release-0.1` to `release-0.12` to have a changelog, but we were not able to use a github action in a newer commit to trigger a release that generates a changelog on older commits. We have also tried adding a github action in existing release branches to trigger a release with changelog when a tag is created and pushed in a branch, but the generated changelog was empty as there were no previous releases. Since `release-0.12` was updated 3 years ago, we decided to start release and changelog from `version-0.13.0`
+We wanted to backfill `release-0.1` to `release-0.12` to have a changelog, but we were not able to use a GitHub action in a newer commit to trigger a release that generates a changelog on older commits. See #489 for full discussion.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 
 ## Releases
-> Note: Releases up until `release-0.12` are changes in their own branches. There are changelogs in releases starting from [version-0.13.0](https://github.com/kubernetes-monitoring/kubernetes-mixin/releases/tag/version-0.13.0).
+> Note: Releases up until `release-0.12` are changes in their own branches. Changelogs are included in releases starting from [version-0.13.0](https://github.com/kubernetes-monitoring/kubernetes-mixin/releases/tag/version-0.13.0).
 
 | Release branch | Kubernetes Compatibility | Prometheus Compatibility | Kube-state-metrics Compatibility |
 |----------------|--------------------------|--------------------------|----------------------------------|

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 
 ## Releases
-> Note: Releases up until `release-0.12` are changes in their own branches. There are changelogs in releases starting from `version-0.13.0`. 
+> Note: Releases up until `release-0.12` are changes in their own branches. There are changelogs in releases starting from [version-0.13.0](https://github.com/kubernetes-monitoring/kubernetes-mixin/releases/tag/version-0.13.0).
 
 | Release branch | Kubernetes Compatibility | Prometheus Compatibility | Kube-state-metrics Compatibility |
 |----------------|--------------------------|--------------------------|----------------------------------|

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 A set of Grafana dashboards and Prometheus alerts for Kubernetes.
 
 ## Releases
+
 > Note: Releases up until `release-0.12` are changes in their own branches. Changelogs are included in releases starting from [version-0.13.0](https://github.com/kubernetes-monitoring/kubernetes-mixin/releases/tag/version-0.13.0).
 
 | Release branch | Kubernetes Compatibility | Prometheus Compatibility | Kube-state-metrics Compatibility |
@@ -39,16 +40,18 @@ Warning: By default the expressions will generate *grafana 7.2+* compatible rule
 Maintainers can trigger the [release workflow](.github/workflows/release.yaml) by pushing a git tag that matches the pattern: `version-*`.
 
 1. Checkout `master` branch and pull for latest.
-    ```bash
-    git checkout master
-    ```
+   ```bash
+   git checkout master
+   ```
+
 2. Create a tag following sem-ver versioning for the version and trigger release. 
-    ```bash
-    # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
-    tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag
-    ```
+   ```bash
+   # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
+   tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag
+   ```
 
 #### Decisions on backfilling releases
+
 We wanted to backfill `release-0.1` to `release-0.12` to have a changelog, but we were not able to use a GitHub action in a newer commit to trigger a release that generates a changelog on older commits. See #489 for full discussion.
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Maintainers can trigger the [release workflow](.github/workflows/release.yaml) b
    git checkout master
    ```
 
-3. Create a tag following sem-ver versioning for the version and trigger release.
+2. Create a tag following sem-ver versioning for the version and trigger release.
 
    ```bash
    # replace MAJOR.MINOR.PATCH with e.g. 1.2.3

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Warning: By default the expressions will generate *grafana 7.2+* compatible rule
 Maintainers can trigger the [release workflow](.github/workflows/release.yaml) by pushing a git tag that matches the pattern: `version-*`.
 
 1. Checkout `master` branch and pull for latest.
+
    ```bash
    git checkout master
    ```
 
-2. Create a tag following sem-ver versioning for the version and trigger release. 
+3. Create a tag following sem-ver versioning for the version and trigger release.
+
    ```bash
    # replace MAJOR.MINOR.PATCH with e.g. 1.2.3
    tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Maintainers can run release when it's time to do so.
     ```
 2. Create a tag following sem-ver versioning for the version and trigger release. 
     ```bash
-    tag=version=${x.x.x}; git tag $tag && git push origin $tag
+	# replace MAJOR.MINOR.PATCH with e.g. 1.2.3
+    tag=version-MAJOR.MINOR.PATCH; git tag $tag && git push origin $tag
     ```
 
 #### Decisions on backfilling releases


### PR DESCRIPTION
This PR:
- Adds a github action that is triggered when a new tag is pushed. The github action autogenerates a changelog on release.
- Adds the command for releasing in readme.