### PR TITLE
Added source_tenants for use with Grafana Mimir multitenancy

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -14,6 +14,7 @@ local utils = import '../lib/utils.libsonnet';
       {
         name: 'kubernetes-apps',
         rules: [utils.wrap_rule_for_labels(rule, $._config) for rule in self.rules_],
+        source_tenants: $._config['sourceTenants'],
         rules_:: [
           {
             expr: |||

--- a/alerts/kube_apiserver.libsonnet
+++ b/alerts/kube_apiserver.libsonnet
@@ -12,6 +12,7 @@ local utils = import '../lib/utils.libsonnet';
     groups+: [
       {
         name: 'kube-apiserver-slos',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             alert: 'KubeAPIErrorBudgetBurn',

--- a/alerts/kube_controller_manager.libsonnet
+++ b/alerts/kube_controller_manager.libsonnet
@@ -7,6 +7,7 @@
     groups+: [
       {
         name: 'kubernetes-system-controller-manager',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeControllerManager',

--- a/alerts/kube_proxy.libsonnet
+++ b/alerts/kube_proxy.libsonnet
@@ -7,6 +7,7 @@
     groups+: [
       {
         name: 'kubernetes-system-kube-proxy',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeProxy',

--- a/alerts/kube_scheduler.libsonnet
+++ b/alerts/kube_scheduler.libsonnet
@@ -7,6 +7,7 @@
     groups+: [
       {
         name: 'kubernetes-system-scheduler',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           (import '../lib/absent_alert.libsonnet') {
             componentName:: 'KubeScheduler',

--- a/alerts/kubelet.libsonnet
+++ b/alerts/kubelet.libsonnet
@@ -21,6 +21,7 @@ local utils = import '../lib/utils.libsonnet';
     groups+: [
       {
         name: 'kubernetes-system-kubelet',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             expr: |||

--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -23,6 +23,7 @@ local utils = import '../lib/utils.libsonnet';
     groups+: [
       {
         name: 'kubernetes-resources',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             alert: 'KubeCPUOvercommit',

--- a/alerts/storage_alerts.libsonnet
+++ b/alerts/storage_alerts.libsonnet
@@ -15,6 +15,7 @@
     groups+: [
       {
         name: 'kubernetes-storage',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             alert: 'KubePersistentVolumeFillingUp',

--- a/alerts/system_alerts.libsonnet
+++ b/alerts/system_alerts.libsonnet
@@ -10,6 +10,7 @@ local utils = import '../lib/utils.libsonnet';
     groups+: [
       {
         name: 'kubernetes-system',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             alert: 'KubeVersionMismatch',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -119,5 +119,8 @@
 
     // Default timeout value for k8s Jobs. The jobs which are active beyond this duration would trigger KubeJobNotCompleted alert.
     kubeJobTimeoutDuration: 12 * 60 * 60,
+
+    // Source tenants parameter for Grafana Mimir
+    sourceTenants: []
   },
 }

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -8,6 +8,7 @@
     groups+: [
       {
         name: 'k8s.rules.container_cpu_usage_seconds_total',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             // Reduces cardinality of this timeseries by #cores, which makes it

--- a/rules/kube_apiserver-availability.libsonnet
+++ b/rules/kube_apiserver-availability.libsonnet
@@ -9,6 +9,7 @@
     groups+: [
       {
         name: 'kube-apiserver-availability.rules',
+        source_tenants: $._config['sourceTenants'],
         interval: '3m',
         rules: [
           {

--- a/rules/kube_apiserver-burnrate.libsonnet
+++ b/rules/kube_apiserver-burnrate.libsonnet
@@ -3,6 +3,7 @@
     groups+: [
       {
         name: 'kube-apiserver-burnrate.rules',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             record: 'apiserver_request:burnrate%(window)s' % w,

--- a/rules/kube_apiserver-histogram.libsonnet
+++ b/rules/kube_apiserver-histogram.libsonnet
@@ -8,6 +8,7 @@
     groups+: [
       {
         name: 'kube-apiserver-histogram.rules',
+        source_tenants: $._config['sourceTenants'],
         rules:
           [
             {

--- a/rules/kube_scheduler.libsonnet
+++ b/rules/kube_scheduler.libsonnet
@@ -8,6 +8,7 @@
     groups+: [
       {
         name: 'kube-scheduler.rules',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             record: 'cluster_quantile:%s:histogram_quantile' % metric,

--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -7,6 +7,7 @@
     groups+: [
       {
         name: 'kubelet.rules',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile',

--- a/rules/node.libsonnet
+++ b/rules/node.libsonnet
@@ -9,6 +9,7 @@
     groups+: [
       {
         name: 'node.rules',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             // This rule results in the tuples (node, namespace, instance) => 1.

--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -3,6 +3,7 @@
     groups+: [
       {
         name: 'windows.node.rules',
+        source_tenants: $._config['sourceTenants'],
         rules: [
           {
             // This rule gives the number of windows nodes


### PR DESCRIPTION
Grafana Mimir implements multitenant monitoring where each rule group's `source_tenants` attribute specifies names of tenants used as metric source:

https://grafana.com/docs/mimir/latest/references/architecture/components/ruler/#federated-rule-groups

This PR adds this attribute to generated alerts. Does this make sense from maintainer's point of view?