### PR TITLE
respect the minimum interval in gauge graphs

### DIFF
--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -100,6 +100,7 @@ local var = g.dashboard.variable;
             value: 7000000000,  // 7GBs
           },
         ])
+        + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -121,6 +122,7 @@ local var = g.dashboard.variable;
         + gauge.standardOptions.withUnit('Bps')
         + gauge.standardOptions.withMin(0)
         + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.standardOptions.thresholds.withSteps([
           {
             color: 'dark-green',

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -150,6 +150,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -173,6 +174,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -101,6 +101,7 @@ local var = g.dashboard.variable;
             value: 7000000000,  // 7GBs
           },
         ])
+        + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -131,6 +132,7 @@ local var = g.dashboard.variable;
             value: 7000000000,  // 7GBs
           },
         ])
+        + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -100,6 +100,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -118,6 +119,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -136,6 +138,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -154,6 +157,7 @@ local var = g.dashboard.variable;
         + barGauge.standardOptions.withUnit('Bps')
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
+        + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',


### PR DESCRIPTION
This fixes a bug where the gauge graphs in the networking dashboards do not respect the configurable minimum time interval