### PR TITLE
fix: rename windows_system_system_up_time metric

### DIFF
--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -68,7 +68,7 @@ local var = g.dashboard.variable;
       + var.query.withDatasourceFromVariable(self.datasource)
       + var.query.queryTypes.withLabelValues(
         'instance',
-        'windows_system_system_up_time{%(clusterLabel)s="$cluster"}' % $._config
+        'windows_system_boot_time_timestamp_seconds{%(clusterLabel)s="$cluster"}' % $._config
       )
       + var.query.generalOptions.withLabel('instance')
       + var.query.refresh.onTime()

--- a/rules/windows.libsonnet
+++ b/rules/windows.libsonnet
@@ -9,7 +9,7 @@
             record: 'node:windows_node:sum',
             expr: |||
               count by (%(clusterLabel)s) (
-                windows_system_system_up_time{%(windowsExporterSelector)s}
+                windows_system_boot_time_timestamp_seconds{%(windowsExporterSelector)s}
               )
             ||| % $._config,
           },


### PR DESCRIPTION
Since **windows-exporter 0.30.0**, the `windows_system_system_up_time` metric has been renamed to `windows_system_boot_time_timestamp_seconds`.

https://github.com/prometheus-community/windows_exporter/releases/tag/v0.30.0