### PR TITLE
chore(ci): pinact run

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
   - package-ecosystem: gomod
     directory: /scripts
     schedule:
-      interval: monthly
+      interval: weekly

--- a/.github/workflows/check-with-upstream.yaml
+++ b/.github/workflows/check-with-upstream.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check if KSM selectors are present on applicable metrics.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
     - run: make --always-make check-selectors-ksm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,10 @@ jobs:
             run: make --always-make test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: scripts/go.mod
           cache-dependency-path: scripts/go.sum

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 name: ci
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release on kubernetes-mixin
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 30
           days-before-close: 7


### PR DESCRIPTION
Improve the security of GitHub Actions on this repo:

- `pinact run` ran a tool to pin GitHub Actions to known hashes
- Increase Dependabot updates to weekly (was monthly)
- Prevent duplicate workflow execution