### PR TITLE
fix: kubelet rules group_left

### DIFF
--- a/rules/kubelet.libsonnet
+++ b/rules/kubelet.libsonnet
@@ -11,7 +11,12 @@
           {
             record: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile',
             expr: |||
-              histogram_quantile(%(quantile)s, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{%(kubeletSelector)s}[5m])) by (%(clusterLabel)s, instance, le) * on(%(clusterLabel)s, instance) group_left(node) kubelet_node_name{%(kubeletSelector)s})
+              histogram_quantile(
+                %(quantile)s, 
+                sum(rate(kubelet_pleg_relist_duration_seconds_bucket{%(kubeletSelector)s}[5m])) by (%(clusterLabel)s, instance, le) 
+                * on(%(clusterLabel)s, instance) group_left (node) 
+                max by (%(clusterLabel)s, instance, node) (kubelet_node_name{%(kubeletSelector)s})
+              )
             ||| % ({ quantile: quantile } + $._config),
             labels: {
               quantile: quantile,

--- a/tests/kubelet-test.yaml
+++ b/tests/kubelet-test.yaml
@@ -1,0 +1,28 @@
+rule_files:
+- ../prometheus_rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+- interval: 1m
+  input_series:
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{cluster="cluster",instance="ip-172-0-0-1",job="kubelet",le="+Inf",source="kubernetes"}'
+    values: '0+60x5'
+  - series: 'kubelet_pleg_relist_duration_seconds_bucket{cluster="cluster",instance="ip-172-0-0-1",job="kubelet",le="1",source="kubernetes"}'
+    values: '0+60x5'
+  - series: 'kubelet_pleg_relist_duration_seconds_count{cluster="cluster",instance="ip-172-0-0-1",job="kubelet",source="kubernetes"}'
+    values: '0+1x5'
+  - series: 'kubelet_node_name{cluster="cluster",node="ip-172-0-0-1",instance="ip-172-0-0-1",job="kubelet",source="kubernetes"}'
+    values: '1x5'
+  - series: 'kubelet_node_name{cluster="cluster",node="ip-172-0-0-1",instance="ip-172-0-0-1",job="kubelet",source="kubernetes2"}'
+    values: '1x5'
+  promql_expr_test:
+  - eval_time: 5m
+    expr: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+    exp_samples:
+    - value: 0.5
+      labels: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{cluster="cluster",instance="ip-172-0-0-1", node="ip-172-0-0-1", quantile="0.5"}'
+    - value: 0.9
+      labels: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{cluster="cluster",instance="ip-172-0-0-1", node="ip-172-0-0-1", quantile="0.9"}'
+    - value: 0.99
+      labels: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{cluster="cluster",instance="ip-172-0-0-1", node="ip-172-0-0-1", quantile="0.99"}'


### PR DESCRIPTION
**Why**

When the right hand-side of the operations returns multiple matches, the rules fail. 

This fix aim to prevent such failure.