### PR TITLE
fix(k8s.rules.pod_owner): Make workload_type label values consistent with upstream metrics and across generated series

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -119,5 +119,8 @@
 
     // Default timeout value for k8s Jobs. The jobs which are active beyond this duration would trigger KubeJobNotCompleted alert.
     kubeJobTimeoutDuration: 12 * 60 * 60,
+
+    // Controls workload_type label value format: false = lowercase, true = PascalCase
+    usePascalCaseForWorkloadTypeLabelValues: false,
   },
 }

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -2,6 +2,8 @@
   _config+:: {
     cadvisorSelector: 'job="cadvisor"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
+    // Controls workload_type label value format: false = lowercase, true = PascalCase
+    usePascalCaseForWorkloadTypeLabelValues: false,
   },
 
   prometheusRules+:: {
@@ -224,7 +226,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'ReplicaSet',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'ReplicaSet' else 'replicaset',
             },
           },
           // workload aggregation for deployments
@@ -246,7 +248,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'Deployment',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'Deployment' else 'deployment',
             },
           },
           // workload aggregation for daemonsets
@@ -261,7 +263,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'DaemonSet',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'DaemonSet' else 'daemonset',
             },
           },
           // workload aggregation for statefulsets
@@ -275,7 +277,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'StatefulSet',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'StatefulSet' else 'statefulset',
             },
           },
           // backwards compatibility for jobs
@@ -297,7 +299,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'Job',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'Job' else 'job',
             },
           },
           // workload aggregation for barepods
@@ -311,7 +313,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'BarePod',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'BarePod' else 'barepod',
             },
           },
           // workload aggregation for staticpods
@@ -325,7 +327,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'StaticPod',
+              workload_type: if $._config.usePascalCaseForWorkloadTypeLabelValues then 'StaticPod' else 'staticpod',
             },
           },
           // workload aggregation for non-standard types (jobs, replicasets)

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -2,8 +2,6 @@
   _config+:: {
     cadvisorSelector: 'job="cadvisor"',
     kubeStateMetricsSelector: 'job="kube-state-metrics"',
-    // Controls workload_type label value format: false = lowercase, true = PascalCase
-    usePascalCaseForWorkloadTypeLabelValues: false,
   },
 
   prometheusRules+:: {

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -224,7 +224,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'replicaset',
+              workload_type: 'ReplicaSet',
             },
           },
           // workload aggregation for deployments
@@ -246,7 +246,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'deployment',
+              workload_type: 'Deployment',
             },
           },
           // workload aggregation for daemonsets
@@ -261,7 +261,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'daemonset',
+              workload_type: 'DaemonSet',
             },
           },
           // workload aggregation for statefulsets
@@ -275,7 +275,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'statefulset',
+              workload_type: 'StatefulSet',
             },
           },
           // backwards compatibility for jobs
@@ -297,7 +297,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'job',
+              workload_type: 'Job',
             },
           },
           // workload aggregation for barepods
@@ -311,7 +311,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'barepod',
+              workload_type: 'BarePod',
             },
           },
           // workload aggregation for staticpods
@@ -325,7 +325,7 @@
               )
             ||| % $._config,
             labels: {
-              workload_type: 'staticpod',
+              workload_type: 'StaticPod',
             },
           },
           // workload aggregation for non-standard types (jobs, replicasets)
@@ -346,7 +346,7 @@
                     )
                   , "workload", "", "owner_name")
                 , "workload_type", "", "owner_kind")
-                
+
                 OR
 
                 label_replace(

--- a/tests/rules-pod-owner-test.yaml
+++ b/tests/rules-pod-owner-test.yaml
@@ -20,9 +20,9 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes",namespace="ns1", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="deployment"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes",namespace="ns1", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="Deployment"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes", namespace="ns2", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="deployment"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes", namespace="ns2", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="Deployment"}'
 
 # bare pod
 - interval: 1m
@@ -36,7 +36,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="openshift", namespace="default", pod="nginx", workload="nginx", workload_type="barepod"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="openshift", namespace="default", pod="nginx", workload="nginx", workload_type="BarePod"}'
 
 # static pod
 - interval: 1m
@@ -50,7 +50,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a-kx2v", workload_type="staticpod"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a-kx2v", workload_type="StaticPod"}'
 
 # non-standard pod
 - interval: 1m
@@ -76,7 +76,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="statefulset"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="StatefulSet"}'
 
 # daemonset
 - interval: 1m
@@ -90,7 +90,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="daemonset"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="DaemonSet"}'
 
 # replicaset
 - interval: 1m
@@ -108,9 +108,9 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10012-kx2v", workload="gke-duplicate-default-pool-10012", workload_type="replicaset"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10012-kx2v", workload="gke-duplicate-default-pool-10012", workload_type="ReplicaSet"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10013-na4g", workload="gke-duplicate-default-pool-10013", workload_type="replicaset"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10013-na4g", workload="gke-duplicate-default-pool-10013", workload_type="ReplicaSet"}'
 
 # non-standard job
 - interval: 1m
@@ -152,11 +152,11 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-e20e250a-kx2v", workload="kube-proxy-gke-duplicate-default-pool-e20e250a", workload_type="job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-e20e250a-kx2v", workload="kube-proxy-gke-duplicate-default-pool-e20e250a", workload_type="Job"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-f72d976h-632a", workload="kube-proxy-gke-duplicate-default-pool-f72d976h", workload_type="job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-f72d976h-632a", workload="kube-proxy-gke-duplicate-default-pool-f72d976h", workload_type="Job"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="prod-us-east-0", namespace="k6-cloud", pod="scripts-to-archive-job-4692155-24m4k", workload="scripts-to-archive-job-4692155", workload_type="job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="prod-us-east-0", namespace="k6-cloud", pod="scripts-to-archive-job-4692155-24m4k", workload="scripts-to-archive-job-4692155", workload_type="Job"}'
 
 # non-standard replicaset
 - interval: 1m

--- a/tests/rules-pod-owner-test.yaml
+++ b/tests/rules-pod-owner-test.yaml
@@ -20,9 +20,9 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes",namespace="ns1", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="Deployment"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes",namespace="ns1", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="deployment"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes", namespace="ns2", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="Deployment"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="kubernetes", namespace="ns2", pod="ds-7cc77d965f-cgsdv", workload="ds", workload_type="deployment"}'
 
 # bare pod
 - interval: 1m
@@ -36,7 +36,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="openshift", namespace="default", pod="nginx", workload="nginx", workload_type="BarePod"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="openshift", namespace="default", pod="nginx", workload="nginx", workload_type="barepod"}'
 
 # static pod
 - interval: 1m
@@ -50,7 +50,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a-kx2v", workload_type="StaticPod"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a-kx2v", workload_type="staticpod"}'
 
 # non-standard pod
 - interval: 1m
@@ -76,7 +76,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="StatefulSet"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="statefulset"}'
 
 # daemonset
 - interval: 1m
@@ -90,7 +90,7 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="DaemonSet"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate", namespace="kube-system", pod="gke-duplicate-default-pool-e20e250a-kx2v", workload="gke-duplicate-default-pool-e20e250a", workload_type="daemonset"}'
 
 # replicaset
 - interval: 1m
@@ -108,9 +108,9 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10012-kx2v", workload="gke-duplicate-default-pool-10012", workload_type="ReplicaSet"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10012-kx2v", workload="gke-duplicate-default-pool-10012", workload_type="replicaset"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10013-na4g", workload="gke-duplicate-default-pool-10013", workload_type="ReplicaSet"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="gke-duplicate-default-pool-10013-na4g", workload="gke-duplicate-default-pool-10013", workload_type="replicaset"}'
 
 # non-standard job
 - interval: 1m
@@ -152,11 +152,11 @@ tests:
     expr: namespace_workload_pod:kube_pod_owner:relabel
     exp_samples:
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-e20e250a-kx2v", workload="kube-proxy-gke-duplicate-default-pool-e20e250a", workload_type="Job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-e20e250a-kx2v", workload="kube-proxy-gke-duplicate-default-pool-e20e250a", workload_type="job"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-f72d976h-632a", workload="kube-proxy-gke-duplicate-default-pool-f72d976h", workload_type="Job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="duplicate",namespace="default", pod="kube-proxy-gke-duplicate-default-pool-f72d976h-632a", workload="kube-proxy-gke-duplicate-default-pool-f72d976h", workload_type="job"}'
     - value: 1
-      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="prod-us-east-0", namespace="k6-cloud", pod="scripts-to-archive-job-4692155-24m4k", workload="scripts-to-archive-job-4692155", workload_type="Job"}'
+      labels: 'namespace_workload_pod:kube_pod_owner:relabel{cluster="prod-us-east-0", namespace="k6-cloud", pod="scripts-to-archive-job-4692155-24m4k", workload="scripts-to-archive-job-4692155", workload_type="job"}'
 
 # non-standard replicaset
 - interval: 1m


### PR DESCRIPTION
<!--  Thank you for sending a pull request! We highly appreciate contributions. Here are some tips for you:
1. If this is your first time, read our contributor guidelines: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/CONTRIBUTING.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. If the PR is unfinished, please mark it as a draft, to prevent false pings and noisy review cycles.
-->

#### What does this PR fix? Please be as descriptive as possible.**

This PR fixes a bug where the `namespace_workload_pod:kube_pod_owner:relabel` metric returns inconsistent data for the `workload_type` label.

<img width="1402" height="954" alt="image" src="https://github.com/user-attachments/assets/45073a3e-d281-444d-8d89-93e4be94372d" />

This is particularly painful when a downstream user wants to use this metric to do vector matching with other metrics that have a `workload_type` or `owner_kind` type label.

Some more rationale... the raw KSM metrics seem to prefer singular PascalCase values for this label. Seeing as this is a relabeling of KSM metrics, we should probably abide by the upstream preference for consistency.

#### Any helpful code snippets or visual aids (before and after this patch, if applicable)?**
<details>
<summary>Details - rendered diffs</summary>

<!-- Please provide code snippets or (dashboard) screenshots to help explain the changes you're making. These are highly helpful and help accelerate reviews. -->

```console
user@host kubernetes-mixin % ls -la orig new         
new:
total 168
drwxr-xr-x   5 user  staff    160 Jul 16 00:49 .
drwxr-xr-x@ 32 user  staff   1024 Jul 16 00:50 ..
drwxr-xr-x  24 user  staff    768 Jul 16 00:47 dashboards_out
-rw-r--r--   1 user  staff  43088 Jul 16 00:44 prometheus_alerts.yaml
-rw-r--r--   1 user  staff  38550 Jul 16 00:46 prometheus_rules.yaml

orig:
total 168
drwxr-xr-x   5 user  staff    160 Jul 16 00:50 .
drwxr-xr-x@ 32 user  staff   1024 Jul 16 00:50 ..
drwxr-xr-x  24 user  staff    768 Jul 16 00:48 dashboards_out
-rw-r--r--   1 user  staff  43088 Jul 16 00:48 prometheus_alerts.yaml
-rw-r--r--   1 user  staff  38552 Jul 16 00:48 prometheus_rules.yaml
```

...

```console
user@host kubernetes-mixin % diff -bur orig new
```

```diff
diff -bur orig/prometheus_rules.yaml new/prometheus_rules.yaml
--- orig/prometheus_rules.yaml  2025-07-16 00:48:15
+++ new/prometheus_rules.yaml   2025-07-16 00:46:58
@@ -573,7 +573,7 @@
         )
       )
     "labels":
-      "workload_type": "replicaset"
+      "workload_type": "ReplicaSet"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       max by (cluster, namespace, workload, pod) (
@@ -590,7 +590,7 @@
         )
       )
     "labels":
-      "workload_type": "deployment"
+      "workload_type": "Deployment"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       max by (cluster, namespace, workload, pod) (
@@ -600,7 +600,7 @@
         )
       )
     "labels":
-      "workload_type": "daemonset"
+      "workload_type": "DaemonSet"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       max by (cluster, namespace, workload, pod) (
@@ -609,7 +609,7 @@
         "workload", "$1", "owner_name", "(.*)")
       )
     "labels":
-      "workload_type": "statefulset"
+      "workload_type": "StatefulSet"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       group by (cluster, namespace, workload, pod) (
@@ -626,7 +626,7 @@
         , "workload", "", "owner_name")
       )
     "labels":
-      "workload_type": "job"
+      "workload_type": "Job"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       max by (cluster, namespace, workload, pod) (
@@ -635,7 +635,7 @@
         "workload", "$1", "pod", "(.+)")
       )
     "labels":
-      "workload_type": "barepod"
+      "workload_type": "BarePod"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       max by (cluster, namespace, workload, pod) (
@@ -644,7 +644,7 @@
         "workload", "$1", "pod", "(.+)")
       )
     "labels":
-      "workload_type": "staticpod"
+      "workload_type": "StaticPod"
     "record": "namespace_workload_pod:kube_pod_owner:relabel"
   - "expr": |
       group by (cluster, namespace, workload, workload_type, pod) (
```

</details>

<!-- Please append the issue(s) this PR targets below this line. -->

Fixes #1077