### PR TITLE
fix: broken references to main branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yaml
+++ b/.github/ISSUE_TEMPLATE/bugs.yaml
@@ -6,7 +6,7 @@ body:
     - type: markdown
       attributes:
         value: |
-              Please use this template while reporting a bug and provide as much information as possible. If the matter is security related, please disclose it privately, see the project [security policy](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/main/SECURITY.md).
+              Please use this template while reporting a bug and provide as much information as possible. If the matter is security related, please disclose it privately, see the project [security policy](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/SECURITY.md).
     - type: textarea
       id: cause
       attributes:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ permissions: {}
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 jobs:
   matrix:


### PR DESCRIPTION
There are a couple of places which reference the `main` branch, which doesn't exist at the moment in this repo.