### PR TITLE
fix(cluster-total dashboard): remove joined kube_pod_info in TCP queries

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -440,11 +440,6 @@ local var = g.dashboard.variable;
             '${datasource}', |||
               sum by (instance) (
                   rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_OutSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
               )
             ||| % $._config
           )
@@ -458,11 +453,6 @@ local var = g.dashboard.variable;
             '${datasource}', |||
               sum by (instance) (
                   rate(node_netstat_TcpExt_TCPSynRetrans{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
               )
             ||| % $._config
           )


### PR DESCRIPTION
This fixes [issue 949](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/949) by removing the mismatching `kube_pod_info` join in the TCP-queries of dashboard `cluster-total.json`.
The `kube_pod_info` join seems to be unused, as the resulting metric is only summed per instance.

At least in my case, the node-exporter only returns 1 metric per instance for 
`node_netstat_TcpExt_TCPSynRetrans`, `node_netstat_Tcp_RetransSegs` and `node_netstat_Tcp_OutSegs`.
