### PR TITLE
fix: release workflow wrong go version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24'
+          go-version-file: "scripts/go.mod"
 
       - name: Build release archive
         run: |


### PR DESCRIPTION
Release workflow failed:

```
Building Grafana Dashboards, Prometheus Rules and Alerts
mkdir -p /home/runner/work/kubernetes-mixin/kubernetes-mixin/tmp/bin
Installing tools from hack/tools.go
go: go.mod requires go >= 1.25.0 (running go 1.24.7; GOTOOLCHAIN=local)
xargs: /home/runner/work/kubernetes-mixin/kubernetes-mixin/tmp/bin/jsonnetfmt: No such file or directory
make: *** [Makefile:72: jsonnet-fmt] Error 127
Error: Process completed with exit code 2.
```

Looks like the wrong go version, so read it from `go.mod` instead.