### PR TITLE
fix: CPUThrottlingHigh multiple series error

### DIFF
--- a/tests/resource_alerts-test.yaml
+++ b/tests/resource_alerts-test.yaml
@@ -1,0 +1,31 @@
+rule_files:
+- ../prometheus_alerts.yaml
+
+tests:
+- interval: 1m
+  name: CPUThrottlingHigh fires when CPU throttling exceeds threshold
+  input_series:
+  - series: 'container_cpu_cfs_throttled_periods_total{cluster="cluster1", namespace="default", pod="test-pod", container="test-container", instance="node1", job="cadvisor"}'
+    values: '0+30x20'
+  - series: 'container_cpu_cfs_periods_total{cluster="cluster1", namespace="default", pod="test-pod", container="test-container", instance="node1", job="cadvisor"}'
+    values: '0+100x20'
+  # Ensure the alert rule can still be evaluated with duplicate series.
+  - series: 'container_cpu_cfs_periods_total{cluster="cluster1", namespace="default", pod="test-pod", container="test-container", instance="node1", job="cadvisor", node_kubernetes_io_exclude_from_external_load_balancers="karpenter"}'
+    values: '0+100x20'
+  alert_rule_test:
+  - eval_time: 14m
+    alertname: CPUThrottlingHigh
+  - eval_time: 20m
+    alertname: CPUThrottlingHigh
+    exp_alerts:
+    - exp_labels:
+        severity: "info"
+        cluster: "cluster1"
+        namespace: "default"
+        pod: "test-pod"
+        container: "test-container"
+        instance: "node1"
+      exp_annotations:
+        description: "30% throttling of CPU in namespace default for container test-container in pod test-pod."
+        summary: "Processes experience elevated CPU throttling."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"


### PR DESCRIPTION
This PR:

- Adds unit test coverage for CPUThrottlingHigh
- Adds a test case for multiple series
- Uses `topk` to prevent multiple series on both sides of the PromQL join
- Reformat the query for readability 

Fixes #1113.