### PR TITLE
feat(dashboards): standardise network units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev-port-forward:
 	kubectl --context kind-kubernetes-mixin wait --for=condition=Ready pods -l app=lgtm --timeout=300s
 	kubectl --context kind-kubernetes-mixin port-forward service/lgtm 3000:3000 4317:4317 4318:4318 9090:9090
 
-dev-reload: generate lint
+dev-reload: clean-alerts clean-rules generate lint
 	@cp -v prometheus_alerts.yaml scripts/provisioning/prometheus/ && \
 	cp -v prometheus_rules.yaml scripts/provisioning/prometheus/ && \
 	kubectl --context kind-kubernetes-mixin apply -f scripts/lgtm.yaml && \
@@ -73,7 +73,7 @@ clean-dashboards:
 DASHBOARD_SOURCES = $(shell find $(SRC_DIR) -name '*.libsonnet' 2>/dev/null)
 
 .PHONY: generate
-generate: clean-alerts clean-rules prometheus_alerts.yaml prometheus_rules.yaml $(OUT_DIR)/.dashboards-generated
+generate: prometheus_alerts.yaml prometheus_rules.yaml $(OUT_DIR)/.dashboards-generated
 
 $(JSONNET_VENDOR): $(JB_BIN) jsonnetfile.json
 	$(JB_BIN) install

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -90,6 +90,12 @@
       grafanaTimezone: 'UTC',
     },
 
+    // Units for panels
+    units: {
+      // Use 'bps' for bits per second (SI), or 'binBps' for bytes per second (IEC).
+      network: 'bps',
+    },
+
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
     clusterLabel: 'cluster',

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -63,7 +63,7 @@ local var = g.dashboard.variable;
 
       local panels = [
         tsPanel.new('Current Rate of Bytes Received')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -81,7 +81,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Current Rate of Bytes Transmitted')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -267,7 +267,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'binBps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -298,7 +298,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Rate of Bytes Received')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -316,7 +316,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Rate of Bytes Transmitted')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -334,7 +334,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -352,7 +352,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -80,24 +80,24 @@ local var = g.dashboard.variable;
       local panels = [
         gauge.new('Current Rate of Bytes Received')
         + gauge.standardOptions.withDisplayName('$namespace')
-        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
-        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.withMax(10000000000)  // 10Gbps
         + gauge.standardOptions.thresholds.withSteps([
           {
             color: 'dark-green',
             index: 0,
-            value: null,  // 0GBs
+            value: null,  // 0Gbps
           },
           {
             color: 'dark-yellow',
             index: 1,
-            value: 5000000000,  // 5GBs
+            value: 5000000000,  // 5Gbps
           },
           {
             color: 'dark-red',
             index: 2,
-            value: 7000000000,  // 7GBs
+            value: 7000000000,  // 7Gbps
           },
         ])
         + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -119,25 +119,25 @@ local var = g.dashboard.variable;
 
         gauge.new('Current Rate of Bytes Transmitted')
         + gauge.standardOptions.withDisplayName('$namespace')
-        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
-        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.withMax(10000000000)  // 10Gbps
         + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.standardOptions.thresholds.withSteps([
           {
             color: 'dark-green',
             index: 0,
-            value: null,  // 0GBs
+            value: null,  // 0Gbps
           },
           {
             color: 'dark-yellow',
             index: 1,
-            value: 5000000000,  // 5GBs
+            value: 5000000000,  // 5Gbps
           },
           {
             color: 'dark-red',
             index: 2,
-            value: 7000000000,  // 7GBs
+            value: 7000000000,  // 7Gbps
           },
         ])
         + gauge.queryOptions.withTargets([
@@ -304,7 +304,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -335,7 +335,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
@@ -353,7 +353,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -120,7 +120,7 @@ local var = g.dashboard.variable;
         barGauge.new('Current Rate of Bytes Received')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -144,7 +144,7 @@ local var = g.dashboard.variable;
         barGauge.new('Current Rate of Bytes Transmitted')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -271,7 +271,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'binBps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -302,7 +302,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -321,7 +321,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -340,7 +340,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Workload: Received')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -359,7 +359,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Workload: Transmitted')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -81,24 +81,24 @@ local var = g.dashboard.variable;
       local panels = [
         gauge.new('Current Rate of Bytes Received')
         + gauge.standardOptions.withDisplayName('$pod')
-        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
-        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.withMax(10000000000)  // 10Gbps
         + gauge.standardOptions.thresholds.withSteps([
           {
             color: 'dark-green',
             index: 0,
-            value: null,  // 0GBs
+            value: null,  // 0Gbps
           },
           {
             color: 'dark-yellow',
             index: 1,
-            value: 5000000000,  // 5GBs
+            value: 5000000000,  // 5Gbps
           },
           {
             color: 'dark-red',
             index: 2,
-            value: 7000000000,  // 7GBs
+            value: 7000000000,  // 7Gbps
           },
         ])
         + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -112,24 +112,24 @@ local var = g.dashboard.variable;
 
         gauge.new('Current Rate of Bytes Transmitted')
         + gauge.standardOptions.withDisplayName('$pod')
-        + gauge.standardOptions.withUnit('Bps')
+        + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
-        + gauge.standardOptions.withMax(10000000000)  // 10GBs
+        + gauge.standardOptions.withMax(10000000000)  // 10Gbps
         + gauge.standardOptions.thresholds.withSteps([
           {
             color: 'dark-green',
             index: 0,
-            value: null,  // 0GBs
+            value: null,  // 0Gbps
           },
           {
             color: 'dark-yellow',
             index: 1,
-            value: 5000000000,  // 5GBs
+            value: 5000000000,  // 5Gbps
           },
           {
             color: 'dark-red',
             index: 2,
-            value: 7000000000,  // 7GBs
+            value: 7000000000,  // 7Gbps
           },
         ])
         + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -142,7 +142,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -152,7 +152,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -97,7 +97,7 @@ local var = g.dashboard.variable;
         barGauge.new('Current Rate of Bytes Received')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -116,7 +116,7 @@ local var = g.dashboard.variable;
         barGauge.new('Current Rate of Bytes Transmitted')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -135,7 +135,7 @@ local var = g.dashboard.variable;
         barGauge.new('Average Rate of Bytes Received')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -154,7 +154,7 @@ local var = g.dashboard.variable;
         barGauge.new('Average Rate of Bytes Transmitted')
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
-        + barGauge.standardOptions.withUnit('Bps')
+        + barGauge.standardOptions.withUnit($._config.units.network)
         + barGauge.standardOptions.color.withMode('fixed')
         + barGauge.standardOptions.color.withFixedColor('green')
         + barGauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
@@ -171,7 +171,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -185,7 +185,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('binBps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -475,7 +475,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -506,7 +506,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -516,7 +516,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -526,7 +526,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Namespace: Received')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -536,7 +536,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Namespace: Transmitted')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -698,7 +698,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -547,7 +547,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -578,7 +578,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -588,7 +588,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -751,7 +751,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },

--- a/dashboards/resources/pod.libsonnet
+++ b/dashboards/resources/pod.libsonnet
@@ -448,7 +448,7 @@ local var = g.dashboard.variable;
 
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -458,7 +458,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -600,7 +600,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -631,7 +631,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -645,7 +645,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -659,7 +659,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Workload: Received')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -673,7 +673,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Workload: Transmitted')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -430,7 +430,7 @@ local var = g.dashboard.variable;
             properties: [
               {
                 id: 'unit',
-                value: 'Bps',
+                value: $._config.units.network,
               },
             ],
           },
@@ -461,7 +461,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Receive Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -475,7 +475,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Transmit Bandwidth')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -489,7 +489,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Pod: Received')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -503,7 +503,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Average Container Bandwidth by Pod: Transmitted')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',

--- a/dashboards/windows.libsonnet
+++ b/dashboards/windows.libsonnet
@@ -896,7 +896,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Net Utilisation (Transmitted)')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -906,7 +906,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Net Utilisation (Dropped)')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -1067,7 +1067,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Net Utilisation (Transmitted)')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
@@ -1077,7 +1077,7 @@ local var = g.dashboard.variable;
         ]),
 
         tsPanel.new('Net Saturation (Dropped)')
-        + tsPanel.standardOptions.withUnit('Bps')
+        + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',


### PR DESCRIPTION
Network units were inconsistent, I standardised on bits/sec (SI) as per #1097. New configuration option introduced so that this can be easily changed for those that prefer bytes/sec (IEC).

Fixes #1097