### PR TITLE
Limit kube_pod_info queries to specified cluster to prevent timeouts

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -72,7 +72,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -90,7 +90,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -107,7 +107,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -120,7 +120,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -133,7 +133,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -146,7 +146,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -159,7 +159,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -172,7 +172,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -185,7 +185,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -198,7 +198,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -307,7 +307,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -325,7 +325,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -343,7 +343,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -361,7 +361,7 @@ local var = g.dashboard.variable;
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
             ||| % $._config
@@ -378,7 +378,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -394,7 +394,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -410,7 +410,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)
@@ -426,7 +426,7 @@ local var = g.dashboard.variable;
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
           ||| % $._config)


### PR DESCRIPTION
**Description:**
This PR improves dashboard performance and prevents query timeouts by scoping kube_pod_info time series queries to the selected cluster (via clusterLabel), instead of scanning all 150 Kubernetes clusters.

**Problem**
Currently, dashboard queries using kube_pod_info fetch pod metadata across all clusters in our single large Mimir (Prometheus) instance, regardless of the configured clusterLabel. This leads to:

Timeouts on short time ranges (e.g., 5 minutes): ~136,684 time series fetched. Look at below screenshot.

<img width="1411" height="845" alt="image" src="https://github.com/user-attachments/assets/70416a58-dfb7-4a6f-a2df-fde6895f4fd7" />

Backend failures on longer ranges (e.g., 2 hours): exceeds maximum series limit and it causes prometheus backend to go slow often.

**Solution**
Align kube_pod_info filtering with other network metrics by restricting queries to the cluster specified in the clusterLabel dashboard variable.

**Impact**
- Drastically reduces series count and query latency
- Eliminates timeouts and backend errors
- Maintains accuracy for single-cluster dashboards
