### PR TITLE
replaced deprecated scheduler_binding_duration_seconds metric

### DIFF
--- a/dashboards/scheduler.libsonnet
+++ b/dashboards/scheduler.libsonnet
@@ -89,7 +89,7 @@ local var = g.dashboard.variable;
           prometheus.new('${datasource}', 'sum(rate(scheduler_scheduling_attempt_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance)' % $._config)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}} {{instance}} e2e' % $._config),
 
-          prometheus.new('${datasource}', 'sum(rate(scheduler_binding_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance)' % $._config)
+          prometheus.new('${datasource}', 'sum(rate(scheduler_pod_scheduling_sli_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance)' % $._config)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}} {{instance}} binding' % $._config),
 
           prometheus.new('${datasource}', 'sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s, instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance)' % $._config)
@@ -106,7 +106,7 @@ local var = g.dashboard.variable;
           prometheus.new('${datasource}', 'histogram_quantile(0.99, sum(rate(scheduler_scheduling_attempt_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance, le))' % $._config)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}} {{instance}} e2e' % $._config),
 
-          prometheus.new('${datasource}', 'histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance, le))' % $._config)
+          prometheus.new('${datasource}', 'histogram_quantile(0.99, sum(rate(scheduler_pod_scheduling_sli_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance, le))' % $._config)
           + prometheus.withLegendFormat('{{%(clusterLabel)s}} {{instance}} binding' % $._config),
 
           prometheus.new('${datasource}', 'histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{%(clusterLabel)s="$cluster", %(kubeSchedulerSelector)s,instance=~"$instance"}[%(grafanaIntervalVar)s])) by (%(clusterLabel)s, instance, le))' % $._config)

--- a/rules/kube_scheduler.libsonnet
+++ b/rules/kube_scheduler.libsonnet
@@ -22,7 +22,7 @@
           for metric in [
             'scheduler_scheduling_attempt_duration_seconds',
             'scheduler_scheduling_algorithm_duration_seconds',
-            'scheduler_binding_duration_seconds',
+            'scheduler_pod_scheduling_sli_duration_seconds',
           ]
         ],
       },

--- a/tests/kube_scheduler-test.yaml
+++ b/tests/kube_scheduler-test.yaml
@@ -88,44 +88,44 @@ tests:
     - value: 0.99
       labels: 'cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.99"}'
 
-# Test scheduler_binding_duration_seconds quantile 0.5
+# Test scheduler_pod_scheduling_sli_duration_seconds quantile 0.5
 - interval: 1m
   input_series:
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
     values: '0+60x5'
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="1"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="1"}'
     values: '0+60x5'
   promql_expr_test:
   - eval_time: 5m
-    expr: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{quantile="0.5"}
+    expr: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{quantile="0.5"}
     exp_samples:
     - value: 0.5
-      labels: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.5"}'
+      labels: 'cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.5"}'
 
-# Test scheduler_binding_duration_seconds quantile 0.9
+# Test scheduler_pod_scheduling_sli_duration_seconds quantile 0.9
 - interval: 1m
   input_series:
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
     values: '0+60x5'
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="1"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="1"}'
     values: '0+60x5'
   promql_expr_test:
   - eval_time: 5m
-    expr: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{quantile="0.9"}
+    expr: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{quantile="0.9"}
     exp_samples:
     - value: 0.9
-      labels: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.9"}'
+      labels: 'cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.9"}'
 
-# Test scheduler_binding_duration_seconds quantile 0.99
+# Test scheduler_pod_scheduling_sli_duration_seconds quantile 0.99
 - interval: 1m
   input_series:
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="+Inf"}'
     values: '0+60x5'
-  - series: 'scheduler_binding_duration_seconds_bucket{job="kube-scheduler",le="1"}'
+  - series: 'scheduler_pod_scheduling_sli_duration_seconds_bucket{job="kube-scheduler",le="1"}'
     values: '0+60x5'
   promql_expr_test:
   - eval_time: 5m
-    expr: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{quantile="0.99"}
+    expr: cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{quantile="0.99"}
     exp_samples:
     - value: 0.99
-      labels: 'cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.99"}'
+      labels: 'cluster_quantile:scheduler_pod_scheduling_sli_duration_seconds:histogram_quantile{job="kube-scheduler",quantile="0.99"}'


### PR DESCRIPTION
replaced `scheduler_binding_duration_seconds` metrics with `scheduler_pod_scheduling_sli_duration_seconds`, which was deprecated and removed