### PR TITLE
fix: cluster variable in resources/cluster

### DIFF
--- a/dashboards/resources/variables/cluster.libsonnet
+++ b/dashboards/resources/variables/cluster.libsonnet
@@ -1,15 +1,10 @@
-local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
-local var = g.dashboard.variable;
 local common = import './common.libsonnet';
 
 {
   cluster(config)::
     local datasource = common.datasource(config);
-    local clusterVar =
-      common.cluster(config, datasource, 'up{%(kubeStateMetricsSelector)s}')
-      + var.query.generalOptions.showOnDashboard.withLabelAndValue();
     {
       datasource: datasource,
-      cluster: clusterVar,
+      cluster: common.cluster(config, datasource),
     },
 }

--- a/dashboards/resources/variables/common.libsonnet
+++ b/dashboards/resources/variables/common.libsonnet
@@ -15,20 +15,16 @@ local var = g.dashboard.variable;
       },
     },
 
-  cluster(config, datasourceVar, selectorTemplate)::
+  cluster(config, datasourceVar)::
     var.query.new('cluster')
     + var.query.withDatasourceFromVariable(datasourceVar)
     + var.query.queryTypes.withLabelValues(
       config.clusterLabel,
-      selectorTemplate % config,
+      'up{%(kubeStateMetricsSelector)s}' % config,
     )
     + var.query.generalOptions.withLabel('cluster')
     + var.query.refresh.onTime()
-    + (
-      if config.showMultiCluster
-      then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-      else var.query.generalOptions.showOnDashboard.withNothing()
-    )
+    + var.query.generalOptions.showOnDashboard.withLabelAndValue()
     + var.query.withSort(type='alphabetical'),
 
   namespace(config, datasourceVar)::

--- a/dashboards/resources/variables/namespace.libsonnet
+++ b/dashboards/resources/variables/namespace.libsonnet
@@ -3,7 +3,7 @@ local common = import './common.libsonnet';
 {
   namespace(config)::
     local datasource = common.datasource(config);
-    local clusterVar = common.cluster(config, datasource, 'up{%(kubeStateMetricsSelector)s}');
+    local clusterVar = common.cluster(config, datasource);
     {
       datasource: datasource,
       cluster: clusterVar,

--- a/dashboards/resources/variables/pod.libsonnet
+++ b/dashboards/resources/variables/pod.libsonnet
@@ -3,7 +3,7 @@ local common = import './common.libsonnet';
 {
   pod(config)::
     local datasource = common.datasource(config);
-    local clusterVar = common.cluster(config, datasource, 'up{%(kubeStateMetricsSelector)s}');
+    local clusterVar = common.cluster(config, datasource);
     {
       datasource: datasource,
       cluster: clusterVar,


### PR DESCRIPTION
The previous refactor broke cluster variable. The cluster dashboard never showed its cluster selector because that dashboard’s variable definition was different from every other dashboard. It was querying label values via cadvisor (`up{job="cadvisor"}`) and hiding the control unless `showMultiCluster` was enabled, so in most setups the query returned nothing and Grafana didn’t render the variable. 

This PR has it pointing at kube-state-metrics and forcing `showOnDashboard.withLabelAndValue()` makes the variable populate and stay visible.