### PR TITLE
Enable option to allow all values for workload dashboard

### DIFF
--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -80,6 +80,7 @@ local var = g.dashboard.variable;
 
         workload:
           var.query.new('workload')
+          + var.query.selectionOptions.withIncludeAll()
           + var.query.withDatasourceFromVariable(self.datasource)
           + var.query.queryTypes.withLabelValues(
             'workload',
@@ -105,7 +106,7 @@ local var = g.dashboard.variable;
         sum(
             max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", namespace="$namespace"})
           * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type=~"$type"}
+            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
         ) by (pod)
       ||| % $._config;
 
@@ -113,7 +114,7 @@ local var = g.dashboard.variable;
         sum(
             max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})
           * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type=~"$type"}
+            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
         ) by (pod)
       ||| % $._config;
 
@@ -123,7 +124,7 @@ local var = g.dashboard.variable;
         sum(
             max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""})
           * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload="$workload", workload_type=~"$type"}
+            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
         ) by (pod)
       ||| % $._config;
       local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');


### PR DESCRIPTION
Other workload dashboards already allow for the include-all option. 
Having this options makes the workload dashboard a better "default" dashboard than the current `Kubernetes / Compute Resources / Namespace (Pods)` dashboard, since it's basically the same, but with the advantage to allow for more easily filtering of specific workloads inside the namespace.

Let me know if there was a reason to not do that. 
I've tried to patch our local generation of the dashboards and I was successful in patching the dashboard wit libsonnet, but I would also need to patch the queries and this would leave more technical debt to keep the queries up to date than is technical feasible.