### PR TITLE
refactor: have repeated cluster queries reference itself

### DIFF
--- a/dashboards/resources/cluster.libsonnet
+++ b/dashboards/resources/cluster.libsonnet
@@ -530,7 +530,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfReceivedPackets($._config)
+            queries.networkReceivePackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -540,7 +540,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfTransmittedPackets($._config)
+            queries.networkTransmitPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -550,7 +550,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfReceivedPacketsDropped($._config)
+            queries.networkReceivePacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -560,7 +560,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfTransmittedPacketsDropped($._config)
+            queries.networkTransmitPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/resources/namespace.libsonnet
+++ b/dashboards/resources/namespace.libsonnet
@@ -571,7 +571,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfReceivedPackets($._config)
+            queries.networkReceivePackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -581,7 +581,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfTransmittedPackets($._config)
+            queries.networkTransmitPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -591,7 +591,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfReceivedPacketsDropped($._config)
+            queries.networkReceivePacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -601,7 +601,7 @@ local timeSeries = g.panel.timeSeries;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            queries.rateOfTransmittedPacketsDropped($._config)
+            queries.networkTransmitPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/resources/queries/cluster.libsonnet
+++ b/dashboards/resources/queries/cluster.libsonnet
@@ -82,18 +82,6 @@
   avgContainerTransmitBandwidth(config)::
     'avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
 
-  rateOfReceivedPackets(config)::
-    self.networkReceivePackets(config),
-
-  rateOfTransmittedPackets(config)::
-    self.networkTransmitPackets(config),
-
-  rateOfReceivedPacketsDropped(config)::
-    self.networkreceivepacketsdropped(config),
-
-  rateOfTransmittedPacketsDropped(config)::
-    self.networkTransmitPacketsDropped(config),
-
   // Storage Queries
   iopsReadsWrites(config)::
     'ceil(sum by(namespace) (rate(container_fs_reads_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace!=""}[%(grafanaIntervalVar)s]) + rate(container_fs_writes_total{%(cadvisorSelector)s, %(containerfsSelector)s, %(clusterLabel)s="$cluster", namespace!=""}[%(grafanaIntervalVar)s])))' % config,

--- a/dashboards/resources/queries/namespace.libsonnet
+++ b/dashboards/resources/queries/namespace.libsonnet
@@ -92,18 +92,6 @@
   networkTransmitBandwidthTimeSeries(config)::
     'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
 
-  rateOfReceivedPackets(config)::
-    'sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
-
-  rateOfTransmittedPackets(config)::
-    'sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
-
-  rateOfReceivedPacketsDropped(config)::
-    'sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
-
-  rateOfTransmittedPacketsDropped(config)::
-    'sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
-
   // Storage TimeSeries Queries
   iopsReadsWrites(config)::
     'ceil(sum by(pod) (rate(container_fs_reads_total{%(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]) + rate(container_fs_writes_total{%(containerfsSelector)s, %(diskDeviceSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])))' % config,


### PR DESCRIPTION
`irate` drops data and we want to avoid using that. See [this issue](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/679). When changing from `irate` to `rate`, there are repeated queries. The ones that are repeated are not referencing self instead