### PR TITLE
fix(dashboards): network rates in bits (x8)

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -94,6 +94,12 @@
     units: {
       // Use 'bps' for bits per second (SI), or 'binBps' for bytes per second (IEC).
       network: 'bps',
+
+      // Use a multiplier of 8 when using a "bits" unit (e.g. 'bps'), or 1 when using a "bytes" unit (e.g. 'binBps').
+      networkMultiplier: 8,
+
+      // Returns "Bytes" if networkMultiplier is 1, or "Bits" if networkMultiplier is 8
+      networkUnitLabel: if self.networkMultiplier == 1 then 'Bytes' else 'Bits',
     },
 
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.

--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -62,38 +62,38 @@ local var = g.dashboard.variable;
       };
 
       local panels = [
-        tsPanel.new('Current Rate of Bytes Received')
+        tsPanel.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
               sum by (namespace) (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        tsPanel.new('Current Rate of Bytes Transmitted')
+        tsPanel.new('Current Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
               sum by (namespace) (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -103,53 +103,53 @@ local var = g.dashboard.variable;
         + table.queryOptions.withTargets([
           prometheus.new('${datasource}', |||
             sum by (namespace) (
-                rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
                   max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
-          ||| % $._config)
+          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
           prometheus.new('${datasource}', |||
             sum by (namespace) (
-                rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
                   max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
-          ||| % $._config)
+          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
           prometheus.new('${datasource}', |||
             avg by (namespace) (
-                rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
                   max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
-          ||| % $._config)
+          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
           prometheus.new('${datasource}', |||
             avg by (namespace) (
-                rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                 topk by (%(clusterLabel)s,namespace,pod) (
                   1,
                   max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                 )
             )
-          ||| % $._config)
+          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
@@ -246,10 +246,10 @@ local var = g.dashboard.variable;
             },
             renameByName: {
               namespace: 'Namespace',
-              'Value #A': 'Rx Bytes',
-              'Value #B': 'Tx Bytes',
-              'Value #C': 'Rx Bytes (Avg)',
-              'Value #D': 'Tx Bytes (Avg)',
+              'Value #A': 'Rx %(unit)s' % { unit: $._config.units.networkUnitLabel },
+              'Value #B': 'Tx %(unit)s' % { unit: $._config.units.networkUnitLabel },
+              'Value #C': 'Rx %(unit)s (Avg)' % { unit: $._config.units.networkUnitLabel },
+              'Value #D': 'Tx %(unit)s (Avg)' % { unit: $._config.units.networkUnitLabel },
               'Value #E': 'Rx Packets',
               'Value #F': 'Tx Packets',
               'Value #G': 'Rx Packets Dropped',
@@ -262,7 +262,7 @@ local var = g.dashboard.variable;
           {
             matcher: {
               id: 'byRegexp',
-              options: '/Bytes/',
+              options: '/%(unit)s/' % { unit: $._config.units.networkUnitLabel },
             },
             properties: [
               {
@@ -297,38 +297,38 @@ local var = g.dashboard.variable;
           },
         ]),
 
-        tsPanel.new('Average Rate of Bytes Received')
+        tsPanel.new('Average Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
               avg by (namespace) (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        tsPanel.new('Average Rate of Bytes Transmitted')
+        tsPanel.new('Average Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}', |||
               avg by (namespace) (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -339,14 +339,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (namespace) (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -357,14 +357,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (namespace) (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -78,7 +78,7 @@ local var = g.dashboard.variable;
       };
 
       local panels = [
-        gauge.new('Current Rate of Bytes Received')
+        gauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + gauge.standardOptions.withDisplayName('$namespace')
         + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
@@ -105,19 +105,19 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        gauge.new('Current Rate of Bytes Transmitted')
+        gauge.new('Current Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + gauge.standardOptions.withDisplayName('$namespace')
         + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
@@ -144,14 +144,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -162,14 +162,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (pod) (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
@@ -177,14 +177,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (pod) (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
@@ -340,14 +340,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (pod) (
-                  rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -358,14 +358,14 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}', |||
               sum by (pod) (
-                  rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
                 * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
                     max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
                   )
               )
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -92,32 +92,33 @@ local var = g.dashboard.variable;
         },
       };
 
-      local columnQuery(aggFunc, metric) =
+      local columnQuery(aggFunc, metric, multiplier) =
+        local rateExpr = '(%(multiplier)s * rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s]))' % { metric: metric, multiplier: multiplier };
         |||
           sort_desc(
             %(aggFunc)s by (workload, workload_type) (
-              rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s])
+              %(rateExpr)s
               * on (%%(clusterLabel)s, namespace, pod) group_left
               kube_pod_info{%%(clusterLabel)s="$cluster",namespace="$namespace",host_network="false"}
               * on (%%(clusterLabel)s, namespace, pod) group_left (workload, workload_type)
               namespace_workload_pod:kube_pod_owner:relabel{%%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}
             )
           )
-        ||| % { aggFunc: aggFunc, metric: metric } % $._config;
+        ||| % { aggFunc: aggFunc, rateExpr: rateExpr } % $._config;
 
       local colQueries = [
-        columnQuery('sum', 'container_network_receive_bytes_total'),
-        columnQuery('sum', 'container_network_transmit_bytes_total'),
-        columnQuery('avg', 'container_network_receive_bytes_total'),
-        columnQuery('avg', 'container_network_transmit_bytes_total'),
-        columnQuery('sum', 'container_network_receive_packets_total'),
-        columnQuery('sum', 'container_network_transmit_packets_total'),
-        columnQuery('sum', 'container_network_receive_packets_dropped_total'),
-        columnQuery('sum', 'container_network_transmit_packets_dropped_total'),
+        columnQuery('sum', 'container_network_receive_bytes_total', $._config.units.networkMultiplier),
+        columnQuery('sum', 'container_network_transmit_bytes_total', $._config.units.networkMultiplier),
+        columnQuery('avg', 'container_network_receive_bytes_total', $._config.units.networkMultiplier),
+        columnQuery('avg', 'container_network_transmit_bytes_total', $._config.units.networkMultiplier),
+        columnQuery('sum', 'container_network_receive_packets_total', 1),
+        columnQuery('sum', 'container_network_transmit_packets_total', 1),
+        columnQuery('sum', 'container_network_receive_packets_dropped_total', 1),
+        columnQuery('sum', 'container_network_transmit_packets_dropped_total', 1),
       ];
 
       local panels = [
-        barGauge.new('Current Rate of Bytes Received')
+        barGauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -128,7 +129,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -136,12 +137,12 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        barGauge.new('Current Rate of Bytes Transmitted')
+        barGauge.new('Current Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -152,7 +153,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -160,7 +161,7 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -250,10 +251,10 @@ local var = g.dashboard.variable;
             renameByName: {
               workload: 'Workload',
               'workload_type 1': 'Type',
-              'Value #A': 'Rx Bytes',
-              'Value #B': 'Tx Bytes',
-              'Value #C': 'Rx Bytes (Avg)',
-              'Value #D': 'Tx Bytes (Avg)',
+              'Value #A': 'Rx %(unit)s' % { unit: $._config.units.networkUnitLabel },
+              'Value #B': 'Tx %(unit)s' % { unit: $._config.units.networkUnitLabel },
+              'Value #C': 'Rx %(unit)s (Avg)' % { unit: $._config.units.networkUnitLabel },
+              'Value #D': 'Tx %(unit)s (Avg)' % { unit: $._config.units.networkUnitLabel },
               'Value #E': 'Rx Packets',
               'Value #F': 'Tx Packets',
               'Value #G': 'Rx Packets Dropped',
@@ -266,7 +267,7 @@ local var = g.dashboard.variable;
           {
             matcher: {
               id: 'byRegexp',
-              options: '/Bytes/',
+              options: '/%(unit)s/' % { unit: $._config.units.networkUnitLabel },
             },
             properties: [
               {
@@ -307,7 +308,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -315,7 +316,7 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -326,7 +327,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -334,7 +335,7 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -345,7 +346,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(avg(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -353,7 +354,7 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -364,7 +365,7 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(avg(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s,namespace,pod) group_left ()
                   topk by (%(clusterLabel)s,namespace,pod) (
                     1,
@@ -372,7 +373,7 @@ local var = g.dashboard.variable;
                   )
               * on (%(clusterLabel)s,namespace,pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -79,7 +79,7 @@ local var = g.dashboard.variable;
       };
 
       local panels = [
-        gauge.new('Current Rate of Bytes Received')
+        gauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + gauge.standardOptions.withDisplayName('$pod')
         + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
@@ -105,12 +105,12 @@ local var = g.dashboard.variable;
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))' % $._config
+            'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        gauge.new('Current Rate of Bytes Transmitted')
+        gauge.new('Current Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + gauge.standardOptions.withDisplayName('$pod')
         + gauge.standardOptions.withUnit($._config.units.network)
         + gauge.standardOptions.withMin(0)
@@ -136,7 +136,7 @@ local var = g.dashboard.variable;
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))' % $._config
+            'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -146,7 +146,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config
+            'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -156,7 +156,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config
+            'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -94,7 +94,7 @@ local var = g.dashboard.variable;
       };
 
       local panels = [
-        barGauge.new('Current Rate of Bytes Received')
+        barGauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -105,15 +105,15 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        barGauge.new('Current Rate of Bytes Transmitted')
+        barGauge.new('Current Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -124,15 +124,15 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        barGauge.new('Average Rate of Bytes Received')
+        barGauge.new('Average Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -143,15 +143,15 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
 
-        barGauge.new('Average Rate of Bytes Transmitted')
+        barGauge.new('Average Rate of %(unit)s Transmitted' % { unit: $._config.units.networkUnitLabel })
         + barGauge.options.withDisplayMode('basic')
         + barGauge.options.withShowUnfilled(false)
         + barGauge.standardOptions.withUnit($._config.units.network)
@@ -162,10 +162,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -176,10 +176,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -190,10 +190,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              sort_desc(sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/resources/queries/cluster.libsonnet
+++ b/dashboards/resources/queries/cluster.libsonnet
@@ -59,10 +59,10 @@
 
   // Network Queries
   networkReceiveBandwidth(config)::
-    'sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
+    'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s]))) by (namespace)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkTransmitBandwidth(config)::
-    'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s]))) by (namespace)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkReceivePackets(config)::
     'sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
@@ -77,10 +77,10 @@
     'sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
 
   avgContainerReceiveBandwidth(config)::
-    'avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
+    'avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s]))) by (namespace)' % (config { multiplier: config.units.networkMultiplier }),
 
   avgContainerTransmitBandwidth(config)::
-    'avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s])) by (namespace)' % config,
+    'avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s=~".+"}[%(grafanaIntervalVar)s]))) by (namespace)' % (config { multiplier: config.units.networkMultiplier }),
 
   // Storage Queries
   iopsReadsWrites(config)::

--- a/dashboards/resources/queries/namespace.libsonnet
+++ b/dashboards/resources/queries/namespace.libsonnet
@@ -69,10 +69,10 @@
 
   // Network Table Queries
   networkReceiveBandwidth(config)::
-    'sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkTransmitBandwidth(config)::
-    'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkReceivePackets(config)::
     'sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
@@ -87,10 +87,10 @@
     'sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
 
   networkReceiveBandwidthTimeSeries(config)::
-    'sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkTransmitBandwidthTimeSeries(config)::
-    'sum(rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   // Storage TimeSeries Queries
   iopsReadsWrites(config)::

--- a/dashboards/resources/queries/pod.libsonnet
+++ b/dashboards/resources/queries/pod.libsonnet
@@ -75,10 +75,10 @@
 
   // Network Queries
   networkReceiveBandwidth(config)::
-    'sum(irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * irate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkTransmitBandwidth(config)::
-    'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
 
   networkReceivePackets(config)::
     'sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -125,15 +125,15 @@ local var = g.dashboard.variable;
 
       local networkColumns = [
         |||
-          (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
           * on (%(clusterLabel)s, namespace, pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
+        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
         |||
-          (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
           * on (%(clusterLabel)s, namespace, pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
+        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
         |||
           (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
           * on (%(clusterLabel)s, namespace, pod)
@@ -636,10 +636,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -650,10 +650,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -664,10 +664,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -678,10 +678,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -132,15 +132,15 @@ local var = g.dashboard.variable;
 
       local networkColumns = [
         |||
-          (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
           * on (%(clusterLabel)s, namespace, pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
+        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
         |||
-          (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+          (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
           * on (%(clusterLabel)s, namespace, pod)
           group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
+        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
         |||
           (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
           * on (%(clusterLabel)s, namespace, pod)
@@ -467,10 +467,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (sum(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -481,10 +481,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -495,10 +495,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (avg(rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -509,10 +509,10 @@ local var = g.dashboard.variable;
           prometheus.new(
             '${datasource}',
             |||
-              (avg(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+              (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
               * on (%(clusterLabel)s, namespace, pod)
               group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
           )
           + prometheus.withLegendFormat('__auto'),
         ]),


### PR DESCRIPTION
The network rates are now in bits (not bytes) by default, but the metrics are still in bytes, this means we need to multiply by 8.

I corrected all cases where the rate is calculated by introducing a new config option `networkMultiplier`. I also made the panel titles and table column headings say "Bits" instead of "Bytes" based on this config option.

Example screenshot showing the changes:

**BEFORE**

<img width="1699" height="826" alt="Screenshot 2026-01-26 at 16 55 46" src="https://github.com/user-attachments/assets/0a964d15-3551-457d-8667-fe4347758c4e" />

**AFTER**

<img width="1699" height="826" alt="Screenshot 2026-01-26 at 16 56 45" src="https://github.com/user-attachments/assets/0fea1fa4-7b1a-48f6-970e-dcae14cab8f9" />

Fixes #1170
cc @rpallai @bewing