### PR TITLE
fix(alerts): KubeletDown alert missing cluster label

### DIFF
--- a/tests/absent_alert-test.yaml
+++ b/tests/absent_alert-test.yaml
@@ -22,10 +22,14 @@ tests:
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
 
 - interval: 1m
-  name: KubeletDown fires when kubelet target is absent
+  name: KubeletDown fires when kubelet target is absent but nodes exist
   input_series:
-  - series: 'up{job="kubelet", instance="node1"}'
-    values: '1 1 1 1 1 0 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _'
+  # kube_node_info from kube-state-metrics - stays present to indicate nodes exist
+  - series: 'kube_node_info{job="kube-state-metrics", cluster="test-cluster", node="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  # kubelet up metric - goes absent after 5 minutes
+  - series: 'up{job="kubelet", cluster="test-cluster", instance="node1"}'
+    values: '1 1 1 1 1 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _'
   alert_rule_test:
   - eval_time: 10m
     alertname: KubeletDown
@@ -34,11 +38,79 @@ tests:
     exp_alerts:
     - exp_labels:
         severity: "critical"
-        job: "kubelet"
+        cluster: "test-cluster"
       exp_annotations:
         description: "Kubelet has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+
+- interval: 1m
+  name: KubeletDown does not fire when kubelet is up
+  input_series:
+  - series: 'kube_node_info{job="kube-state-metrics", cluster="test-cluster", node="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  - series: 'up{job="kubelet", cluster="test-cluster", instance="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: KubeletDown
+    exp_alerts: []
+
+- interval: 1m
+  name: KubeletDown does not fire when no nodes exist (no kube_node_info)
+  input_series:
+  # No kube_node_info means no nodes in this cluster - kubelet absence is expected
+  - series: 'up{job="kubelet", cluster="test-cluster", instance="node1"}'
+    values: '1 1 1 1 1 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _'
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: KubeletDown
+    exp_alerts: []
+
+- interval: 1m
+  name: KubeletDown fires without cluster label (single-cluster setup)
+  input_series:
+  # Metrics without cluster label - common in single-cluster setups without external_labels
+  - series: 'kube_node_info{job="kube-state-metrics", node="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  - series: 'up{job="kubelet", instance="node1"}'
+    values: '1 1 1 1 1 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _'
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: KubeletDown
+  - eval_time: 25m
+    alertname: KubeletDown
+    exp_alerts:
+    - exp_labels:
+        severity: "critical"
+      exp_annotations:
+        description: "Kubelet has disappeared from Prometheus target discovery."
+        summary: "Target disappeared from Prometheus target discovery."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+
+- interval: 1m
+  name: KubeletDown does not fire when kubelet is up (single-cluster setup)
+  input_series:
+  # Metrics without cluster label - healthy single-cluster setup
+  - series: 'kube_node_info{job="kube-state-metrics", node="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  - series: 'up{job="kubelet", instance="node1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: KubeletDown
+    exp_alerts: []
+
+- interval: 1m
+  name: KubeletDown does not fire when no nodes exist (single-cluster setup)
+  input_series:
+  # No kube_node_info and no cluster label - kubelet absence is expected
+  - series: 'up{job="kubelet", instance="node1"}'
+    values: '1 1 1 1 1 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _'
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: KubeletDown
+    exp_alerts: []
 
 - interval: 1m
   name: KubeSchedulerDown fires when kube-scheduler target is absent


### PR DESCRIPTION
Fixes #1112

cc @Footur

Note this removes the `job` label from the KubeletDown alert, but it should be obvious from the alert name which job this is. Requires a healthy kube-state-metrics scrape job.

`cluster` label confirmed locally by removing Kubelet scrape job:

<img width="1392" height="748" alt="Screenshot 2026-02-17 at 14 24 25" src="https://github.com/user-attachments/assets/c72699fb-c5a5-448a-8ca1-d47123d61f1e" />
