### PR TITLE
fix(dashboards): apply defaults to windows dashboards

### DIFF
--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -6,5 +6,5 @@
 (import 'scheduler.libsonnet') +
 (import 'proxy.libsonnet') +
 (import 'kubelet.libsonnet') +
-(import 'defaults.libsonnet') +
-(import 'windows.libsonnet')
+(import 'windows.libsonnet') +
+(import 'defaults.libsonnet')


### PR DESCRIPTION
fixes an issue where `dashboards/defaults.libsonnet` isn't being applied to `dashboards/windows.libsonnet`.  I'm guessing windows was added later and this was a simple oversight.  Below is the rendered diff

<details>

```
mike@HM90:/tmp/kubernetes-mixin$ diff -r dashboards_out.orig dashboards_out
diff -r dashboards_out.orig/k8s-resources-windows-cluster.json dashboards_out/k8s-resources-windows-cluster.json
2a3,15
>    "links": [
>       {
>          "asDropdown": true,
>          "includeVars": true,
>          "keepTime": true,
>          "tags": [
>             "kubernetes-mixin"
>          ],
>          "targetBlank": false,
>          "title": "Kubernetes",
>          "type": "dashboards"
>       }
>    ],
672c685
<    "timezone": "utc",
---
>    "timezone": "UTC",
diff -r dashboards_out.orig/k8s-resources-windows-namespace.json dashboards_out/k8s-resources-windows-namespace.json
2a3,15
>    "links": [
>       {
>          "asDropdown": true,
>          "includeVars": true,
>          "keepTime": true,
>          "tags": [
>             "kubernetes-mixin"
>          ],
>          "targetBlank": false,
>          "title": "Kubernetes",
>          "type": "dashboards"
>       }
>    ],
439c452
<    "timezone": "utc",
---
>    "timezone": "UTC",
diff -r dashboards_out.orig/k8s-resources-windows-pod.json dashboards_out/k8s-resources-windows-pod.json
2a3,15
>    "links": [
>       {
>          "asDropdown": true,
>          "includeVars": true,
>          "keepTime": true,
>          "tags": [
>             "kubernetes-mixin"
>          ],
>          "targetBlank": false,
>          "title": "Kubernetes",
>          "type": "dashboards"
>       }
>    ],
494c507
<    "timezone": "utc",
---
>    "timezone": "UTC",
diff -r dashboards_out.orig/k8s-windows-cluster-rsrc-use.json dashboards_out/k8s-windows-cluster-rsrc-use.json
2a3,15
>    "links": [
>       {
>          "asDropdown": true,
>          "includeVars": true,
>          "keepTime": true,
>          "tags": [
>             "kubernetes-mixin"
>          ],
>          "targetBlank": false,
>          "title": "Kubernetes",
>          "type": "dashboards"
>       }
>    ],
401c414
<    "timezone": "utc",
---
>    "timezone": "UTC",
diff -r dashboards_out.orig/k8s-windows-node-rsrc-use.json dashboards_out/k8s-windows-node-rsrc-use.json
2a3,15
>    "links": [
>       {
>          "asDropdown": true,
>          "includeVars": true,
>          "keepTime": true,
>          "tags": [
>             "kubernetes-mixin"
>          ],
>          "targetBlank": false,
>          "title": "Kubernetes",
>          "type": "dashboards"
>       }
>    ],
612c625
<    "timezone": "utc",
---
>    "timezone": "UTC",
mike@HM90:/tmp/kubernetes-mixin$
```

</details>