### PR TITLE
feat: add KubeProxyInstanceUnreachable alert

### DIFF
--- a/alerts/kube_proxy.libsonnet
+++ b/alerts/kube_proxy.libsonnet
@@ -12,6 +12,18 @@
             componentName:: 'KubeProxy',
             selector:: $._config.kubeProxySelector,
           },
+          {
+            alert: 'KubeProxyInstanceUnreachable',
+            expr: 'up{%s} == 0' % $._config.kubeProxySelector,
+            'for': '15m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              description: 'A KubeProxy instance has been unreachable for more than 15 minutes.',
+              summary: 'KubeProxy instance is unreachable.',
+            },
+          },
         ],
       },
     ],

--- a/runbook.md
+++ b/runbook.md
@@ -37,6 +37,10 @@ This page collects this repositories alerts and begins the process of describing
 + *Severity*: critical
 + *Runbook*: [Link](https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeproxydown/)
 
+##### Alert Name: "KubeProxyInstanceUnreachable"
++ *Message*: `A KubeProxy instance has been unreachable for more than 15 minutes.`
++ *Severity*: warning
+
 ### Group Name: kubernetes-apps
 
 ##### Alert Name: KubePodCrashLooping

--- a/tests/absent_alert-test.yaml
+++ b/tests/absent_alert-test.yaml
@@ -168,3 +168,33 @@ tests:
         description: "KubeProxy has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxydown"
+
+- interval: 1m
+  name: KubeProxyInstanceUnreachable fires when kube-proxy scrape fails
+  input_series:
+  - series: 'up{job="kube-proxy", instance="proxy1"}'
+    values: '1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: KubeProxyInstanceUnreachable
+  - eval_time: 25m
+    alertname: KubeProxyInstanceUnreachable
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        job: "kube-proxy"
+        instance: "proxy1"
+      exp_annotations:
+        description: "A KubeProxy instance has been unreachable for more than 15 minutes."
+        summary: "KubeProxy instance is unreachable."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxyinstanceunreachable"
+
+- interval: 1m
+  name: KubeProxyInstanceUnreachable does not fire when kube-proxy is up
+  input_series:
+  - series: 'up{job="kube-proxy", instance="proxy1"}'
+    values: '1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1'
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: KubeProxyInstanceUnreachable
+    exp_alerts: []


### PR DESCRIPTION
Sometimes I end up with some of my rke2 nodes losing their kube-proxy container. But the pods appear healthy to k8s or in other words the targets do not disappear, they simply cannot be scraped. So current `KubeProxyDown` is of no help.

As for the generic Prometheus `TargetDown` alert, it can catch it only if > than 10% of kube-proxy pods are down. 

Thus, there is a hole when I can remain unaware of the issues. 

This PR attempts to patch this hole by adding an alert for kube-proxy pods failing scape attempt, so this rule can be ported to Prometheus helm-chart per https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/hack