### PR TITLE
fix(alerts): prevent `KubeHpaMaxedOut` false positive when `minReplicas` equals `maxReplicas`

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -344,9 +344,16 @@ local utils = import '../lib/utils.libsonnet';
           },
           {
             expr: |||
-              kube_horizontalpodautoscaler_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
-                ==
-              kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              (
+                kube_horizontalpodautoscaler_status_current_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                  ==
+                kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              )
+              and on(namespace, horizontalpodautoscaler) (
+                kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+                  !=
+                kube_horizontalpodautoscaler_spec_min_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              )
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -53,3 +53,42 @@ tests:
         description: "StatefulSet ns1/ss1 update has not been rolled out."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout"
         summary: "StatefulSet update has not been rolled out."
+
+- interval: 1m
+  name: KubeHpaMaxedOut fires when current replicas hit max and min is not equal to max
+  input_series:
+  - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '10x15'
+  - series: 'kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '10x15'
+  - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '2x15'
+  alert_rule_test:
+  - eval_time: 14m
+    alertname: KubeHpaMaxedOut
+  - eval_time: 15m
+    alertname: KubeHpaMaxedOut
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        cluster: "cluster1"
+        namespace: "ns1"
+        horizontalpodautoscaler: "hpa1"
+        job: "kube-state-metrics"
+      exp_annotations:
+        description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+        summary: "HPA is running at max replicas"
+
+- interval: 1m
+  name: KubeHpaMaxedOut does not fire when HPA is intentionally pinned to a fixed scale (min == max)
+  input_series:
+  - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa2"}'
+    values: '5x15'
+  - series: 'kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa2"}'
+    values: '5x15'
+  - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa2"}'
+    values: '5x15'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubeHpaMaxedOut


### PR DESCRIPTION
## Description
This PR fixes a false positive in the `KubeHpaMaxedOut` alert that causes unnecessary alert fatigue. 

Currently, if an HPA is intentionally pinned to a fixed scale by setting `minReplicas == maxReplicas` (a common practice during incident response or load testing), the alert evaluates to true and fires continuously after 15 minutes. This change updates the PromQL expression to explicitly filter out HPAs where the minimum equals the maximum, ensuring the alert only fires for dynamic HPAs that are unexpectedly starving for resources.

Fixes #1193

## Changes Proposed
* Appended a `min != max` check to the `KubeHpaMaxedOut` expression.
* Prevented the alert from firing on fixed-scale HPAs.

## Logic Diff
**Before:**
```promql
kube_horizontalpodautoscaler_status_current_replicas == kube_horizontalpodautoscaler_spec_max_replicas
```
## ❤️ Proudly Sponsored By

<p align="left">
  <a href="https://obmondo.com/">
    <img src="https://avatars.githubusercontent.com/u/13882947?s=200&v=4" alt="Obmondo Logo" width="70" align="left" style="margin-right: 15px;">
  </a>
  <a href="https://obmondo.com/"><b>Obmondo.com</b></a>
  <br>
</p>
<br clear="left"/>