### PR TITLE
fix(dashboard): filter running containers by container_state

### DIFF
--- a/dashboards/kubelet.libsonnet
+++ b/dashboards/kubelet.libsonnet
@@ -81,7 +81,7 @@ local var = g.dashboard.variable;
         statRunningPods:
           statPanel('Running Pods', 'none', 'sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config),
         statRunningContainers:
-          statPanel('Running Containers', 'none', 'sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance"})' % $._config),
+          statPanel('Running Containers', 'none', 'sum(kubelet_running_containers{%(clusterLabel)s="$cluster", %(kubeletSelector)s, container_state="running", instance=~"$instance"})' % $._config),
         statActualVolumeCount:
           statPanel('Actual Volume Count', 'none', 'sum(volume_manager_total_volumes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, instance=~"$instance", state="actual_state_of_world"})' % $._config),
         statDesiredVolumeCount:


### PR DESCRIPTION
## Summary
- Adds `container_state="running"` filter to the Running Containers stat panel on the kubelet dashboard
- Previously, the query summed all container states (created, exited, running), inflating the displayed count

Fixes #1195

## Test plan
- [x] `make generate` succeeds
- [x] `make test` passes
- [x] Verified generated `kubelet.json` contains the `container_state="running"` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)