### PR TITLE
fix(dashboard): fix Current Status panel for pods with multiple network interfaces

### DIFF
--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -93,13 +93,16 @@ local var = g.dashboard.variable;
       };
 
       local columnQuery(aggFunc, metric, multiplier) =
-        local rateExpr = '(%(multiplier)s * rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s]))' % { metric: metric, multiplier: multiplier };
+        local rateExpr = 'sum by (%%(clusterLabel)s, namespace, pod) (%(multiplier)s * rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s]))' % { metric: metric, multiplier: multiplier };
         |||
           sort_desc(
             %(aggFunc)s by (workload, workload_type) (
               %(rateExpr)s
-              * on (%%(clusterLabel)s, namespace, pod) group_left
-              kube_pod_info{%%(clusterLabel)s="$cluster",namespace="$namespace",host_network="false"}
+              * on (%%(clusterLabel)s, namespace, pod)
+              topk by (%%(clusterLabel)s, namespace, pod) (
+                1,
+                max by (%%(clusterLabel)s, namespace, pod) (kube_pod_info{%%(clusterLabel)s="$cluster",namespace="$namespace",host_network="false"})
+              )
               * on (%%(clusterLabel)s, namespace, pod) group_left (workload, workload_type)
               namespace_workload_pod:kube_pod_owner:relabel{%%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}
             )


### PR DESCRIPTION
  Fixes #1033
                                                                                                                                       
  The "Current Status" table panel on the Networking / Namespace (Workload) dashboard was computing incorrect averages for workloads   
  that have pods with multiple network interfaces (e.g. pods using Multus or similar CNI plugins).                                     
                                                                                                                                       
  The root cause was that container_network_* metrics expose one time series per interface per pod. The avg by (workload,              
  workload_type) aggregation in the column queries was averaging across all (pod, interface) pairs rather than across pods. For
  example, if a workload has one pod with two interfaces doing 200 Mbps each, the panel would show 200 Mbps average instead of 400     
  Mbps.                                                                                                                              

  The fix pre-aggregates the metric with sum by (cluster, namespace, pod) before the join, collapsing the per-interface series into a  
  single per-pod value. This makes both the sum and avg columns behave correctly. The kube_pod_info join is also updated to use the
  topk by (1, max by (...)) pattern already used in the bar gauge and time series panels in the same dashboard, for consistency and to 
  handle edge cases with duplicate kube-state-metrics entries.                                                                       
