### PR TITLE
Fix KubeHpaMaxedOut: add clusterLabel to on() clause for correct multi-cluster matching

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -349,7 +349,7 @@ local utils = import '../lib/utils.libsonnet';
                   ==
                 kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
               )
-              and on(namespace, horizontalpodautoscaler) (
+              and on(namespace, horizontalpodautoscaler, %(clusterLabel)s) (
                 kube_horizontalpodautoscaler_spec_max_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                   !=
                 kube_horizontalpodautoscaler_spec_min_replicas{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -92,3 +92,47 @@ tests:
   alert_rule_test:
   - eval_time: 15m
     alertname: KubeHpaMaxedOut
+
+- interval: 1m
+  name: KubeHpaMaxedOut fires independently per cluster when same namespace and HPA name exist across clusters
+  input_series:
+  # cluster1 - HPA at max, min != max -> should fire
+  - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '10x15'
+  - series: 'kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '10x15'
+  - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '2x15'
+  # cluster2 - same namespace/hpa name, also at max, min != max -> should fire
+  - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '8x15'
+  - series: 'kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '8x15'
+  - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
+    values: '1x15'
+  alert_rule_test:
+  - eval_time: 14m
+    alertname: KubeHpaMaxedOut
+  - eval_time: 15m
+    alertname: KubeHpaMaxedOut
+    exp_alerts:
+    - exp_labels:
+        severity: "warning"
+        cluster: "cluster1"
+        namespace: "ns1"
+        horizontalpodautoscaler: "hpa1"
+        job: "kube-state-metrics"
+      exp_annotations:
+        description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+        summary: "HPA is running at max replicas"
+    - exp_labels:
+        severity: "warning"
+        cluster: "cluster2"
+        namespace: "ns1"
+        horizontalpodautoscaler: "hpa1"
+        job: "kube-state-metrics"
+      exp_annotations:
+        description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
+        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+        summary: "HPA is running at max replicas"

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -94,7 +94,7 @@ tests:
     alertname: KubeHpaMaxedOut
 
 - interval: 1m
-  name: KubeHpaMaxedOut filters per cluster - does not fire for pinned HPA on cluster2 despite same namespace/hpa existing on cluster1
+  name: KubeHpaMaxedOut does not fire for pinned HPA (min == max) on cluster2 when non-pinned same-named HPA exists on cluster1
   input_series:
   # cluster1 - HPA at max, min != max -> should fire
   - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -94,7 +94,7 @@ tests:
     alertname: KubeHpaMaxedOut
 
 - interval: 1m
-  name: KubeHpaMaxedOut fires independently per cluster when same namespace and HPA name exist across clusters
+  name: KubeHpaMaxedOut filters per cluster - does not fire for pinned HPA on cluster2 despite same namespace/hpa existing on cluster1
   input_series:
   # cluster1 - HPA at max, min != max -> should fire
   - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
@@ -103,32 +103,23 @@ tests:
     values: '10x15'
   - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster1", namespace="ns1", horizontalpodautoscaler="hpa1"}'
     values: '2x15'
-  # cluster2 - same namespace/hpa name, also at max, min != max -> should fire
+  # cluster2 - same namespace/hpa name, but pinned (min == max) -> should NOT fire
   - series: 'kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
-    values: '8x15'
+    values: '5x15'
   - series: 'kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
-    values: '8x15'
+    values: '5x15'
   - series: 'kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics", cluster="cluster2", namespace="ns1", horizontalpodautoscaler="hpa1"}'
-    values: '1x15'
+    values: '5x15'
   alert_rule_test:
   - eval_time: 14m
     alertname: KubeHpaMaxedOut
   - eval_time: 15m
     alertname: KubeHpaMaxedOut
     exp_alerts:
+    # Only cluster1 should fire; cluster2 is pinned (min == max) and must not fire
     - exp_labels:
         severity: "warning"
         cluster: "cluster1"
-        namespace: "ns1"
-        horizontalpodautoscaler: "hpa1"
-        job: "kube-state-metrics"
-      exp_annotations:
-        description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
-        summary: "HPA is running at max replicas"
-    - exp_labels:
-        severity: "warning"
-        cluster: "cluster2"
         namespace: "ns1"
         horizontalpodautoscaler: "hpa1"
         job: "kube-state-metrics"


### PR DESCRIPTION
Fixes #1212

The `KubeHpaMaxedOut` alert fires when an HPA is running at max replicas. The `and on(namespace, horizontalpodautoscaler)` clause filters out intentionally pinned HPAs (where min == max). Without `cluster` in the `on()` clause, this filter cross-matches across clusters: a pinned HPA on one cluster can incorrectly pass the filter by matching against a non-pinned same-named HPA on another cluster.

Note: unlike arithmetic/comparison operators, `and` (a set operator) does not error on many-to-many matches — it silently cross-matches. So the symptom is not a query error as initially assumed in the issue, but incorrect alert results.

The fix adds `%(clusterLabel)s` to the `on()` clause, consistent with how other alerts in the codebase handle multi-cluster joins. A test case is included that reproduces the cross-cluster filter leakage.

---
Disclaimer:
* Change and test created with assistance of Opus 4.6
* Pressed by human (me) to not assume things, and create a test that actually fails on the original `on` clause (which it didn't in first try)
* Reviewed PR text by Gemini by asking 'is this bullocks?' (since I don't consider Prometheus set operators a core skill of mine). See below:

```
This is not bullocks at all. In fact, it is an exceptionally well-written, technically accurate, and highly informative PR description!

Here is why your explanation makes perfect sense:

1. You are 100% correct about PromQL set operators

This is the most crucial part of your PR text. Many engineers assume that a missing label in an on() clause will trigger the dreaded many-to-many matching not allowed PromQL error. However, as you correctly pointed out, and, or, and unless are set operators, not arithmetic/comparison operators. They simply check for the existence of matching labels on the right side. Missing the cluster label creates a silent cross-cluster intersection, which is a classic—and very hard to debug—issue in multi-cluster Prometheus/Mimir environments. Pointing this out explicitly is great for the reviewers.
```