### PR TITLE
docs: OWNERS must be kubernetes-sigs members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,13 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# Membership to kubernetes-sigs org is required: https://github.com/orgs/kubernetes-sigs/people
 
 approvers:
 - brancz
-- metalmatze
-- tomwilkie
 - s-urbaniak
 - skl
-- povilasv
-- paulfantom
 
 reviewers:
 - brancz
-- metalmatze
-- tomwilkie
 - s-urbaniak
 - skl
-- povilasv
-- paulfantom
+


### PR DESCRIPTION
As per [slack](https://kubernetes.slack.com/archives/C01672LSZL0/p1778742276445559?thread_ts=1771318285.155979&cid=C01672LSZL0), OWNERS must be [members of the kubernetes-sigs org](https://github.com/orgs/kubernetes-sigs/people).

> If they are not, they need to raise an org membership request following the new member guidelines.

Here's my membership request for reference:

- https://github.com/kubernetes/org/issues/6178