### PR TITLE
refactor: allow overrides in otel-portable dashboards

### DIFF
--- a/dashboards/network-usage/cluster-total.libsonnet
+++ b/dashboards/network-usage/cluster-total.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/cluster-total.libsonnet';
+local defaultVariables = import './variables/cluster-total.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -35,36 +36,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'cluster-total.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.clusterTotal, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'clusterTotal')
+      then $._queries.clusterTotal
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(cadvisorSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.clusterTotal, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'clusterTotal')
+      then $._variables.clusterTotal($._config)
+      else defaultVariables.clusterTotal($._config);
 
       local links = {
         namespace: {
@@ -81,16 +61,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (namespace) (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -99,16 +70,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (namespace) (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -116,107 +78,35 @@ local var = g.dashboard.variable;
         table.new('Current Status')
         + table.gridPos.withW(24)
         + table.queryOptions.withTargets([
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
+          prometheus.new('${datasource}', queries.receiveBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
+          prometheus.new('${datasource}', queries.transmitBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            avg by (namespace) (
-                (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
+          prometheus.new('${datasource}', queries.avgReceiveBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            avg by (namespace) (
-                (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % ($._config { multiplier: $._config.units.networkMultiplier }))
+          prometheus.new('${datasource}', queries.avgTransmitBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.receivePackets($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.transmitPackets($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.receivePacketsDropped($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.transmitPacketsDropped($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
         ])
@@ -316,16 +206,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              avg by (namespace) (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.avgReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -334,16 +215,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              avg by (namespace) (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.avgTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -352,16 +224,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (namespace) (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -370,16 +233,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (namespace) (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -387,64 +241,28 @@ local var = g.dashboard.variable;
         tsPanel.new('Rate of Received Packets')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.receivePackets($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Transmitted Packets')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.transmitPackets($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Received Packets Dropped')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.receivePacketsDropped($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Transmitted Packets Dropped')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', |||
-            sum by (namespace) (
-                rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                topk by (%(clusterLabel)s,namespace,pod) (
-                  1,
-                  max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
-                )
-            )
-          ||| % $._config)
+          prometheus.new('${datasource}', queries.transmitPacketsDropped($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
@@ -452,11 +270,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('percentunit')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (instance) (
-                  rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_OutSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
-              )
-            ||| % $._config
+            '${datasource}', queries.tcpRetransmitRate($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -465,11 +279,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('percentunit')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (instance) (
-                  rate(node_netstat_TcpExt_TCPSynRetrans{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
-              )
-            ||| % $._config
+            '${datasource}', queries.tcpSynRetransmitRate($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/namespace-by-pod.libsonnet
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/namespace-by-pod.libsonnet';
+local defaultVariables = import './variables/namespace-by-pod.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local gauge = g.panel.gauge;
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -36,51 +37,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'namespace-by-pod.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.namespaceByPod, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'namespaceByPod')
+      then $._queries.namespaceByPod
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(cadvisorSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.selectionOptions.withIncludeAll(true, '.+')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withCurrent('kube-system')
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-      };
+      // Allow overriding variables via $._variables.namespaceByPod, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'namespaceByPod')
+      then $._variables.namespaceByPod($._config)
+      else defaultVariables.namespaceByPod($._config);
 
       local links = {
         pod: {
@@ -118,16 +83,7 @@ local var = g.dashboard.variable;
         + gauge.queryOptions.withInterval($._config.grafanaK8s.minimumTimeInterval)
         + gauge.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.gaugeReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -157,16 +113,7 @@ local var = g.dashboard.variable;
         ])
         + gauge.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.gaugeTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -174,93 +121,27 @@ local var = g.dashboard.variable;
         table.new('Current Network Usage')
         + table.gridPos.withW(24)
         + table.queryOptions.withTargets([
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
-          )
+          prometheus.new('${datasource}', queries.receiveBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
-          )
+          prometheus.new('${datasource}', queries.transmitBandwidth($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
-          )
+          prometheus.new('${datasource}', queries.receivePackets($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
-          )
+          prometheus.new('${datasource}', queries.transmitPackets($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
-          )
+          prometheus.new('${datasource}', queries.receivePacketsDropped($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
 
-          prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
-          )
+          prometheus.new('${datasource}', queries.transmitPacketsDropped($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
         ])
@@ -353,16 +234,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -371,16 +243,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit($._config.units.network)
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            '${datasource}', queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -389,16 +252,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
+            '${datasource}', queries.receivePackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -407,16 +261,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
+            '${datasource}', queries.transmitPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -425,16 +270,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
+            '${datasource}', queries.receivePacketsDroppedTimeSeries($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -443,16 +279,7 @@ local var = g.dashboard.variable;
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
-            '${datasource}', |||
-              sum by (pod) (
-                  rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-                * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              )
-            ||| % $._config
+            '${datasource}', queries.transmitPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/namespace-by-workload.libsonnet
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/namespace-by-workload.libsonnet';
+local defaultVariables = import './variables/namespace-by-workload.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local barGauge = g.panel.barGauge;
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -39,63 +40,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'namespace-by-workload.json':
+      // Allow overriding queries via $._queries.namespaceByWorkload, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'namespaceByWorkload')
+      then $._queries.namespaceByWorkload
+      else defaultQueries;
 
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
-
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(cadvisorSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withCurrent('kube-system')
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload_type:
-          var.query.new('type')
-          + var.query.selectionOptions.withIncludeAll()
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload_type',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload_type')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.namespaceByWorkload, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'namespaceByWorkload')
+      then $._variables.namespaceByWorkload($._config)
+      else defaultVariables.namespaceByWorkload($._config);
 
       local links = {
         workload: {
@@ -107,33 +60,7 @@ local var = g.dashboard.variable;
         },
       };
 
-      local columnQuery(aggFunc, metric, multiplier) =
-        local rateExpr = 'sum by (%%(clusterLabel)s, namespace, pod) (%(multiplier)s * rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s]))' % { metric: metric, multiplier: multiplier };
-        |||
-          sort_desc(
-            %(aggFunc)s by (workload, workload_type) (
-              %(rateExpr)s
-              * on (%%(clusterLabel)s, namespace, pod)
-              topk by (%%(clusterLabel)s, namespace, pod) (
-                1,
-                max by (%%(clusterLabel)s, namespace, pod) (kube_pod_info{%%(clusterLabel)s="$cluster",namespace="$namespace",host_network="false"})
-              )
-              * on (%%(clusterLabel)s, namespace, pod) group_left (workload, workload_type)
-              namespace_workload_pod:kube_pod_owner:relabel{%%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}
-            )
-          )
-        ||| % { aggFunc: aggFunc, rateExpr: rateExpr } % $._config;
-
-      local colQueries = [
-        columnQuery('sum', 'container_network_receive_bytes_total', $._config.units.networkMultiplier),
-        columnQuery('sum', 'container_network_transmit_bytes_total', $._config.units.networkMultiplier),
-        columnQuery('avg', 'container_network_receive_bytes_total', $._config.units.networkMultiplier),
-        columnQuery('avg', 'container_network_transmit_bytes_total', $._config.units.networkMultiplier),
-        columnQuery('sum', 'container_network_receive_packets_total', 1),
-        columnQuery('sum', 'container_network_transmit_packets_total', 1),
-        columnQuery('sum', 'container_network_receive_packets_dropped_total', 1),
-        columnQuery('sum', 'container_network_transmit_packets_dropped_total', 1),
-      ];
+      local colQueries = queries.currentStatusColumns($._config);
 
       local panels = [
         barGauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
@@ -146,16 +73,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -170,16 +88,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -325,16 +234,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -344,16 +244,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -363,16 +254,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -382,16 +264,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -401,16 +274,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateReceivedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -420,16 +284,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateTransmittedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -439,16 +294,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateReceivedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -458,16 +304,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s,namespace,pod) group_left ()
-                  topk by (%(clusterLabel)s,namespace,pod) (
-                    1,
-                    max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
-                  )
-              * on (%(clusterLabel)s,namespace,pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateTransmittedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/network-usage/pod-total.libsonnet
+++ b/dashboards/network-usage/pod-total.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/pod-total.libsonnet';
+local defaultVariables = import './variables/pod-total.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local gauge = g.panel.gauge;
 local prometheus = g.query.prometheus;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -35,63 +36,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'pod-total.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.podTotal, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'podTotal')
+      then $._queries.podTotal
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(cadvisorSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.selectionOptions.withIncludeAll(true, '.+')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withCurrent('kube-system')
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        pod:
-          var.query.new('pod')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'pod',
-            'container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}' % $._config,
-          )
-          + var.query.generalOptions.withCurrent('kube-system')
-          + var.query.generalOptions.withLabel('pod')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.podTotal, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'podTotal')
+      then $._variables.podTotal($._config)
+      else defaultVariables.podTotal($._config);
 
       local panels = [
         gauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
@@ -120,7 +73,7 @@ local var = g.dashboard.variable;
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.gaugeReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -151,7 +104,7 @@ local var = g.dashboard.variable;
         + gauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.gaugeTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -161,7 +114,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -171,7 +124,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -179,28 +132,28 @@ local var = g.dashboard.variable;
         tsPanel.new('Rate of Received Packets')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.receivePackets($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Transmitted Packets')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.transmitPackets($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Received Packets Dropped')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.receivePacketsDropped($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
 
         tsPanel.new('Rate of Transmitted Packets Dropped')
         + tsPanel.standardOptions.withUnit('pps')
         + tsPanel.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.transmitPacketsDropped($._config))
           + prometheus.withLegendFormat('__auto'),
         ]),
       ];

--- a/dashboards/network-usage/queries/cluster-total.libsonnet
+++ b/dashboards/network-usage/queries/cluster-total.libsonnet
@@ -1,0 +1,116 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  receiveBandwidth(config):: |||
+    sum by (namespace) (
+        (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    sum by (namespace) (
+        (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgReceiveBandwidth(config):: |||
+    avg by (namespace) (
+        (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgTransmitBandwidth(config):: |||
+    avg by (namespace) (
+        (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  receivePackets(config):: |||
+    sum by (namespace) (
+        rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % config,
+
+  transmitPackets(config):: |||
+    sum by (namespace) (
+        rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % config,
+
+  receivePacketsDropped(config):: |||
+    sum by (namespace) (
+        rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % config,
+
+  transmitPacketsDropped(config):: |||
+    sum by (namespace) (
+        rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false",%(clusterLabel)s="$cluster"})
+        )
+    )
+  ||| % config,
+
+  tcpRetransmitRate(config):: |||
+    sum by (instance) (
+        rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_OutSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
+    )
+  ||| % config,
+
+  tcpSynRetransmitRate(config):: |||
+    sum by (instance) (
+        rate(node_netstat_TcpExt_TCPSynRetrans{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s]) / rate(node_netstat_Tcp_RetransSegs{%(clusterLabel)s="$cluster"}[%(grafanaIntervalVar)s])
+    )
+  ||| % config,
+}

--- a/dashboards/network-usage/queries/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/queries/namespace-by-pod.libsonnet
@@ -1,0 +1,118 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // Gauge queries (cluster-wide sum, no `by`)
+  gaugeReceiveBandwidth(config):: |||
+    sum (
+        (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  gaugeTransmitBandwidth(config):: |||
+    sum (
+        (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  // Per-pod bandwidth / packet queries (table + timeseries)
+  receiveBandwidth(config):: |||
+    sum by (pod) (
+        (%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    sum by (pod) (
+        (%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  receivePackets(config):: |||
+    sum by (pod) (
+        rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % config,
+
+  transmitPackets(config):: |||
+    sum by (pod) (
+        rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % config,
+
+  receivePacketsDropped(config):: |||
+    sum by (pod) (
+        rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % config,
+
+  transmitPacketsDropped(config):: |||
+    sum by (pod) (
+        rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % config,
+
+  // Timeseries "Rate of Received Packets Dropped" uses namespace!="" (differs from the table column)
+  receivePacketsDroppedTimeSeries(config):: |||
+    sum by (pod) (
+        rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace!=""}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    )
+  ||| % config,
+}

--- a/dashboards/network-usage/queries/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/queries/namespace-by-workload.libsonnet
@@ -1,0 +1,134 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local columnQuery(config, aggFunc, metric, multiplier) =
+  local rateExpr = 'sum by (%%(clusterLabel)s, namespace, pod) (%(multiplier)s * rate(%(metric)s{%%(clusterLabel)s="$cluster",namespace="$namespace"}[%%(grafanaIntervalVar)s]))' % { metric: metric, multiplier: multiplier };
+  |||
+    sort_desc(
+      %(aggFunc)s by (workload, workload_type) (
+        %(rateExpr)s
+        * on (%%(clusterLabel)s, namespace, pod)
+        topk by (%%(clusterLabel)s, namespace, pod) (
+          1,
+          max by (%%(clusterLabel)s, namespace, pod) (kube_pod_info{%%(clusterLabel)s="$cluster",namespace="$namespace",host_network="false"})
+        )
+        * on (%%(clusterLabel)s, namespace, pod) group_left (workload, workload_type)
+        namespace_workload_pod:kube_pod_owner:relabel{%%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}
+      )
+    )
+  ||| % { aggFunc: aggFunc, rateExpr: rateExpr } % config;
+
+{
+  // Current Status table columns
+  currentStatusColumns(config):: [
+    columnQuery(config, 'sum', 'container_network_receive_bytes_total', config.units.networkMultiplier),
+    columnQuery(config, 'sum', 'container_network_transmit_bytes_total', config.units.networkMultiplier),
+    columnQuery(config, 'avg', 'container_network_receive_bytes_total', config.units.networkMultiplier),
+    columnQuery(config, 'avg', 'container_network_transmit_bytes_total', config.units.networkMultiplier),
+    columnQuery(config, 'sum', 'container_network_receive_packets_total', 1),
+    columnQuery(config, 'sum', 'container_network_transmit_packets_total', 1),
+    columnQuery(config, 'sum', 'container_network_receive_packets_dropped_total', 1),
+    columnQuery(config, 'sum', 'container_network_transmit_packets_dropped_total', 1),
+  ],
+
+  // Bandwidth / packet TimeSeries + bar gauge queries
+  receiveBandwidth(config):: |||
+    sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerReceiveBandwidth(config):: |||
+    sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerTransmitBandwidth(config):: |||
+    sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  rateReceivedPackets(config):: |||
+    sort_desc(sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateTransmittedPackets(config):: |||
+    sort_desc(sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateReceivedPacketsDropped(config):: |||
+    sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateTransmittedPacketsDropped(config):: |||
+    sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s,namespace,pod) group_left ()
+        topk by (%(clusterLabel)s,namespace,pod) (
+          1,
+          max by (%(clusterLabel)s,namespace,pod) (kube_pod_info{host_network="false"})
+        )
+    * on (%(clusterLabel)s,namespace,pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+}

--- a/dashboards/network-usage/queries/pod-total.libsonnet
+++ b/dashboards/network-usage/queries/pod-total.libsonnet
@@ -1,0 +1,42 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // Gauge queries (no `by`)
+  gaugeReceiveBandwidth(config)::
+    'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % (config { multiplier: config.units.networkMultiplier }),
+
+  gaugeTransmitBandwidth(config)::
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])))' % (config { multiplier: config.units.networkMultiplier }),
+
+  // Per-pod TimeSeries queries
+  receiveBandwidth(config)::
+    'sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config)::
+    'sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s]))) by (pod)' % (config { multiplier: config.units.networkMultiplier }),
+
+  receivePackets(config)::
+    'sum(rate(container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+
+  transmitPackets(config)::
+    'sum(rate(container_network_transmit_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+
+  receivePacketsDropped(config)::
+    'sum(rate(container_network_receive_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+
+  transmitPacketsDropped(config)::
+    'sum(rate(container_network_transmit_packets_dropped_total{%(clusterLabel)s="$cluster",namespace=~"$namespace", pod=~"$pod"}[%(grafanaIntervalVar)s])) by (pod)' % config,
+}

--- a/dashboards/network-usage/queries/workload-total.libsonnet
+++ b/dashboards/network-usage/queries/workload-total.libsonnet
@@ -1,0 +1,64 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  receiveBandwidth(config):: |||
+    sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgReceiveBandwidth(config):: |||
+    sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgTransmitBandwidth(config):: |||
+    sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  rateReceivedPackets(config):: |||
+    sort_desc(sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateTransmittedPackets(config):: |||
+    sort_desc(sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateReceivedPacketsDropped(config):: |||
+    sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateTransmittedPacketsDropped(config):: |||
+    sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+}

--- a/dashboards/network-usage/variables/cluster-total.libsonnet
+++ b/dashboards/network-usage/variables/cluster-total.libsonnet
@@ -1,0 +1,50 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  clusterTotal(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(cadvisorSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/network-usage/variables/namespace-by-pod.libsonnet
+++ b/dashboards/network-usage/variables/namespace-by-pod.libsonnet
@@ -1,0 +1,64 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  namespaceByPod(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(cadvisorSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.selectionOptions.withIncludeAll(true, '.+')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'namespace',
+        'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % config,
+      )
+      + var.query.generalOptions.withCurrent('kube-system')
+      + var.query.generalOptions.withLabel('namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/network-usage/variables/namespace-by-workload.libsonnet
+++ b/dashboards/network-usage/variables/namespace-by-workload.libsonnet
@@ -1,0 +1,76 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  namespaceByWorkload(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(cadvisorSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'namespace',
+        'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % config,
+      )
+      + var.query.generalOptions.withCurrent('kube-system')
+      + var.query.generalOptions.withLabel('namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    workload_type:
+      var.query.new('type')
+      + var.query.selectionOptions.withIncludeAll()
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload_type',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload_type')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/network-usage/variables/pod-total.libsonnet
+++ b/dashboards/network-usage/variables/pod-total.libsonnet
@@ -1,0 +1,77 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  podTotal(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(cadvisorSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.selectionOptions.withIncludeAll(true, '.+')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'namespace',
+        'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % config,
+      )
+      + var.query.generalOptions.withCurrent('kube-system')
+      + var.query.generalOptions.withLabel('namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    pod:
+      var.query.new('pod')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'pod',
+        'container_network_receive_packets_total{%(clusterLabel)s="$cluster",namespace=~"$namespace"}' % config,
+      )
+      + var.query.generalOptions.withCurrent('kube-system')
+      + var.query.generalOptions.withLabel('pod')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/network-usage/variables/workload-total.libsonnet
+++ b/dashboards/network-usage/variables/workload-total.libsonnet
@@ -1,0 +1,89 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  workloadTotal(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'kube_pod_info{%(kubeStateMetricsSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.selectionOptions.withIncludeAll(true, '.+')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'namespace',
+        'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % config,
+      )
+      + var.query.generalOptions.withCurrent('kube-system')
+      + var.query.generalOptions.withLabel('namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    workload:
+      var.query.new('workload')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    workload_type:
+      var.query.new('type')
+      + var.query.selectionOptions.withIncludeAll(true, '.+')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload_type',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~"$workload"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload_type')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/network-usage/workload-total.libsonnet
+++ b/dashboards/network-usage/workload-total.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/workload-total.libsonnet';
+local defaultVariables = import './variables/workload-total.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local barGauge = g.panel.barGauge;
 local prometheus = g.query.prometheus;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -38,75 +39,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'workload-total.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.workloadTotal, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'workloadTotal')
+      then $._queries.workloadTotal
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'kube_pod_info{%(kubeStateMetricsSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.selectionOptions.withIncludeAll(true, '.+')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'container_network_receive_packets_total{%(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withCurrent('kube-system')
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload:
-          var.query.new('workload')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~".+"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload_type:
-          var.query.new('type')
-          + var.query.selectionOptions.withIncludeAll(true, '.+')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload_type',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace=~"$namespace", workload=~"$workload"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload_type')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.workloadTotal, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'workloadTotal')
+      then $._variables.workloadTotal($._config)
+      else defaultVariables.workloadTotal($._config);
 
       local panels = [
         barGauge.new('Current Rate of %(unit)s Received' % { unit: $._config.units.networkUnitLabel })
@@ -119,11 +60,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -138,11 +75,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -157,11 +90,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -176,11 +105,7 @@ local var = g.dashboard.variable;
         + barGauge.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -190,11 +115,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -204,11 +125,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -218,11 +135,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateReceivedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -232,11 +145,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateTransmittedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -246,11 +155,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateReceivedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -260,11 +165,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sort_desc(sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster",namespace=~"$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster",namespace=~"$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateTransmittedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/persistentvolumesusage.libsonnet';
+local defaultVariables = import './variables/persistentvolumesusage.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local prometheus = g.query.prometheus;
 local gauge = g.panel.gauge;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local gaugePanel(title, unit, query) =
@@ -47,95 +48,32 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'persistentvolumesusage.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.persistentVolume, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'persistentVolume')
+      then $._queries.persistentVolume
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('Namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        volume:
-          var.query.new('volume')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'persistentvolumeclaim',
-            'kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('PersistentVolumeClaim')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.persistentVolume, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'persistentVolume')
+      then $._variables.persistentVolume($._config)
+      else defaultVariables.persistentVolume($._config);
 
       local panels = {
         tsUsage:
           tsPanel.new('Volume Space Usage')
           + tsPanel.standardOptions.withUnit('bytes')
           + tsPanel.queryOptions.withTargets([
-            prometheus.new('${datasource}', |||
-              (
-                sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-                -
-                sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-              )
-            ||| % $._config)
+            prometheus.new('${datasource}', queries.volumeSpaceUsageUsed($._config))
             + prometheus.withLegendFormat('Used Space'),
 
-            prometheus.new('${datasource}', |||
-              sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-            ||| % $._config)
+            prometheus.new('${datasource}', queries.volumeSpaceUsageFree($._config))
             + prometheus.withLegendFormat('Free Space'),
           ]),
         gaugeUsage:
           gaugePanel(
             'Volume Space Usage',
             'percent',
-            |||
-              max without(instance,node) (
-              (
-                topk(1, kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
-                -
-                topk(1, kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
-              )
-              /
-              topk(1, kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
-              * 100)
-            ||| % $._config
+            queries.volumeSpaceUsagePercent($._config)
           )
           + gauge.standardOptions.withMin(0)
           + gauge.standardOptions.withMax(100)
@@ -158,29 +96,17 @@ local var = g.dashboard.variable;
           tsPanel.new('Volume inodes Usage')
           + tsPanel.standardOptions.withUnit('none')
           + tsPanel.queryOptions.withTargets([
-            prometheus.new('${datasource}', 'sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))' % $._config)
+            prometheus.new('${datasource}', queries.volumeInodesUsageUsed($._config))
             + prometheus.withLegendFormat('Used inodes'),
 
-            prometheus.new('${datasource}', |||
-              (
-                sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-                -
-                sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
-              )
-            ||| % $._config)
+            prometheus.new('${datasource}', queries.volumeInodesUsageFree($._config))
             + prometheus.withLegendFormat('Free inodes'),
           ]),
         gaugeInodes:
           gaugePanel(
             'Volume inodes Usage',
             'percent',
-            |||
-              max without(instance,node) (
-              topk(1, kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
-              /
-              topk(1, kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
-              * 100)
-            ||| % $._config
+            queries.volumeInodesUsagePercent($._config)
           )
           + gauge.standardOptions.withMin(0)
           + gauge.standardOptions.withMax(100)

--- a/dashboards/queries/persistentvolumesusage.libsonnet
+++ b/dashboards/queries/persistentvolumesusage.libsonnet
@@ -1,0 +1,61 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // Volume Space Usage
+  volumeSpaceUsageUsed(config):: |||
+    (
+      sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
+      -
+      sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
+    )
+  ||| % config,
+
+  volumeSpaceUsageFree(config):: |||
+    sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
+  ||| % config,
+
+  volumeSpaceUsagePercent(config):: |||
+    max without(instance,node) (
+    (
+      topk(1, kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
+      -
+      topk(1, kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
+    )
+    /
+    topk(1, kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
+    * 100)
+  ||| % config,
+
+  // Volume inodes Usage
+  volumeInodesUsageUsed(config)::
+    'sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))' % config,
+
+  volumeInodesUsageFree(config):: |||
+    (
+      sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
+      -
+      sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})))
+    )
+  ||| % config,
+
+  volumeInodesUsagePercent(config):: |||
+    max without(instance,node) (
+    topk(1, kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
+    /
+    topk(1, kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace", persistentvolumeclaim="$volume"})
+    * 100)
+  ||| % config,
+}

--- a/dashboards/resources/multi-cluster.libsonnet
+++ b/dashboards/resources/multi-cluster.libsonnet
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/multi-cluster.libsonnet';
+local defaultVariables = import './variables/multi-cluster.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 
 local prometheus = g.query.prometheus;
 local stat = g.panel.stat;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local statPanel(title, unit, query) =
@@ -47,20 +48,15 @@ local var = g.dashboard.variable;
   grafanaDashboards+::
     if $._config.showMultiCluster then {
       'k8s-resources-multicluster.json':
-        local variables = {
-          datasource:
-            var.datasource.new('datasource', 'prometheus')
-            + var.datasource.withRegex($._config.datasourceFilterRegex)
-            + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-            + var.datasource.generalOptions.withLabel('Data source')
-            + {
-              current: {
-                selected: true,
-                text: $._config.datasourceName,
-                value: $._config.datasourceName,
-              },
-            },
-        };
+        // Allow overriding queries via $._queries.multiCluster, otherwise use default
+        local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'multiCluster')
+        then $._queries.multiCluster
+        else defaultQueries;
+
+        // Allow overriding variables via $._variables.multiCluster, otherwise use default
+        local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'multiCluster')
+        then $._variables.multiCluster($._config)
+        else defaultVariables.multiCluster($._config);
 
         local links = {
           cluster: {
@@ -77,44 +73,44 @@ local var = g.dashboard.variable;
             statPanel(
               'CPU Utilisation',
               'none',
-              'sum(cluster:node_cpu:ratio_rate5m) / count(cluster:node_cpu:ratio_rate5m)'
+              queries.cpuUtilisation($._config)
             ),
 
             statPanel(
               'CPU Requests Commitment',
               'percentunit',
-              'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="cpu"})' % $._config
+              queries.cpuRequestsCommitment($._config)
             ),
 
             statPanel(
               'CPU Limits Commitment',
               'percentunit',
-              'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="cpu"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="cpu"})' % $._config
+              queries.cpuLimitsCommitment($._config)
             ),
 
             statPanel(
               'Memory Utilisation',
               'percentunit',
-              '1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(node_memory_MemTotal_bytes{%(nodeExporterSelector)s})' % $._config
+              queries.memoryUtilisation($._config)
             ),
 
             statPanel(
               'Memory Requests Commitment',
               'percentunit',
-              'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="memory"})' % $._config
+              queries.memoryRequestsCommitment($._config)
             ),
 
             statPanel(
               'Memory Limits Commitment',
               'percentunit',
-              'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="memory"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="memory"})' % $._config
+              queries.memoryLimitsCommitment($._config)
             ),
           ],
 
           cpuUsage: [
             tsPanel.new('CPU Usage')
             + tsPanel.queryOptions.withTargets([
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m)) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuUsageByCluster($._config))
               + prometheus.withLegendFormat('__auto'),
             ]),
           ],
@@ -122,19 +118,19 @@ local var = g.dashboard.variable;
           cpuQuota: [
             g.panel.table.new('CPU Quota')
             + g.panel.table.queryOptions.withTargets([
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m)) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuUsageByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuRequestsByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m)) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuUsageVsRequests($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuLimitsByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m)) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.cpuUsageVsLimits($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
             ])
@@ -212,7 +208,7 @@ local var = g.dashboard.variable;
             + tsPanel.standardOptions.withUnit('bytes')
             + tsPanel.queryOptions.withTargets([
               // Not using container_memory_usage_bytes here because that includes page cache
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_rss{%(cadvisorSelector)s, container!=""})) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryUsageByCluster($._config))
               + prometheus.withLegendFormat('__auto'),
             ]),
           ],
@@ -221,19 +217,19 @@ local var = g.dashboard.variable;
             g.panel.table.new('Memory Requests by Cluster')
             + g.panel.table.standardOptions.withUnit('bytes')
             + g.panel.table.queryOptions.withTargets([
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_rss{%(cadvisorSelector)s, container!=""})) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryUsageByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryRequestsByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_rss{%(cadvisorSelector)s, container!=""})) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryUsageVsRequests($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryLimitsByCluster($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
-              prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_rss{%(cadvisorSelector)s, container!=""})) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % $._config)
+              prometheus.new('${datasource}', queries.memoryUsageVsLimits($._config))
               + prometheus.withInstant(true)
               + prometheus.withFormat('table'),
             ])

--- a/dashboards/resources/node.libsonnet
+++ b/dashboards/resources/node.libsonnet
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/node.libsonnet';
+local defaultVariables = import './variables/node.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 
 local fieldOverride = g.panel.timeSeries.fieldOverride;
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -40,46 +41,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'k8s-resources-node.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(kubeStateMetricsSelector)s}' % $._config
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-        node:
-          var.query.new('node')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'node',
-            'kube_node_info{%(clusterLabel)s="$cluster"}' % $._config
-          )
-          + var.query.generalOptions.withLabel('node')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.selectionOptions.withMulti(true),
-      };
+      // Allow overriding queries via $._queries.node, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'node')
+      then $._queries.node
+      else defaultQueries;
+
+      // Allow overriding variables via $._variables.node, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'node')
+      then $._variables.node($._config)
+      else defaultVariables.node($._config);
 
       local links = {
         pod: {
@@ -96,19 +66,19 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % $._config,
+            queries.cpuCapacity($._config),
           )
           + prometheus.withLegendFormat('max capacity'),
 
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % $._config,
+            queries.cpuAllocatable($._config),
           )
           + prometheus.withLegendFormat('max allocatable'),
 
           prometheus.new(
             '${datasource}',
-            'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config,
+            queries.cpuUsageByPod($._config),
           )
           + prometheus.withLegendFormat('{{pod}}'),
         ])
@@ -135,19 +105,19 @@ local var = g.dashboard.variable;
 
         table.new('CPU Quota')
         + table.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.cpuUsageByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.cpuRequestsByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod) / sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.cpuUsageVsRequests($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.cpuLimitsByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod) / sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.cpuUsageVsLimits($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
         ])
@@ -210,19 +180,19 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+            queries.memoryCapacity($._config),
           )
           + prometheus.withLegendFormat('max capacity'),
 
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+            queries.memoryAllocatable($._config),
           )
           + prometheus.withLegendFormat('max allocatable'),
 
           prometheus.new(
             '${datasource}',
-            'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node", container!=""})) by (pod)' % $._config,
+            queries.memoryUsageWSByPod($._config),
           )
           + prometheus.withLegendFormat('{{pod}}'),
         ])
@@ -252,19 +222,19 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+            queries.memoryCapacity($._config),
           )
           + prometheus.withLegendFormat('max capacity'),
 
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % $._config,
+            queries.memoryAllocatable($._config),
           )
           + prometheus.withLegendFormat('max allocatable'),
 
           prometheus.new(
             '${datasource}',
-            'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_rss{%(clusterLabel)s="$cluster", node=~"$node", container!=""})) by (pod)' % $._config,
+            queries.memoryUsageRSSByPod($._config),
           )
           + prometheus.withLegendFormat('{{pod}}'),
         ])
@@ -292,28 +262,28 @@ local var = g.dashboard.variable;
         table.new('Memory Quota')
         + table.standardOptions.withUnit('bytes')
         + table.queryOptions.withTargets([
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageWSByPodTable($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryRequestsByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod) / sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageVsRequests($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryLimitsByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod) / sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageVsLimits($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_rss{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageRSSByPodTable($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_cache{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageCacheByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
-          prometheus.new('${datasource}', 'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_swap{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % $._config)
+          prometheus.new('${datasource}', queries.memoryUsageSwapByPod($._config))
           + prometheus.withInstant(true)
           + prometheus.withFormat('table'),
         ])

--- a/dashboards/resources/nodes-overview.libsonnet
+++ b/dashboards/resources/nodes-overview.libsonnet
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/nodes-overview.libsonnet';
+local defaultVariables = import './variables/nodes-overview.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 
 local fieldOverride = g.panel.timeSeries.fieldOverride;
 local prometheus = g.query.prometheus;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -39,35 +40,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'k8s-resources-nodes-overview.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(kubeStateMetricsSelector)s}' % $._config
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding queries via $._queries.nodesOverview, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'nodesOverview')
+      then $._queries.nodesOverview
+      else defaultQueries;
+
+      // Allow overriding variables via $._variables.nodesOverview, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'nodesOverview')
+      then $._variables.nodesOverview($._config)
+      else defaultVariables.nodesOverview($._config);
 
       local panels = [
         // Node and pod count over time (dual y-axis)
@@ -78,13 +59,13 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'count(kube_node_info{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s})' % $._config,
+            queries.nodeCount($._config),
           )
           + prometheus.withLegendFormat('nodes'),
 
           prometheus.new(
             '${datasource}',
-            'sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % $._config,
+            queries.podCount($._config),
           )
           + prometheus.withLegendFormat('pods'),
         ])
@@ -100,19 +81,19 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="cpu"})' % $._config,
+            queries.cpuAllocatable($._config),
           )
           + prometheus.withLegendFormat('allocatable'),
 
           prometheus.new(
             '${datasource}',
-            'sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster"})' % $._config,
+            queries.cpuRequests($._config),
           )
           + prometheus.withLegendFormat('requests'),
 
           prometheus.new(
             '${datasource}',
-            'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster"})' % $._config,
+            queries.cpuUsage($._config),
           )
           + prometheus.withLegendFormat('usage'),
         ]),
@@ -123,19 +104,19 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="memory"})' % $._config,
+            queries.memoryAllocatable($._config),
           )
           + prometheus.withLegendFormat('allocatable'),
 
           prometheus.new(
             '${datasource}',
-            'sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster"})' % $._config,
+            queries.memoryRequests($._config),
           )
           + prometheus.withLegendFormat('requests'),
 
           prometheus.new(
             '${datasource}',
-            'sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", container!=""})' % $._config,
+            queries.memoryUsage($._config),
           )
           + prometheus.withLegendFormat('usage'),
         ]),
@@ -146,11 +127,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sum by (node) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster"})
-              /
-              sum by (node) (kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="cpu"})
-            ||| % $._config,
+            queries.cpuUtilizationPerNode($._config),
           )
           + prometheus.withLegendFormat('{{node}}'),
         ]),
@@ -161,11 +138,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              sum by (node) (node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", container!=""})
-              /
-              sum by (node) (kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="memory"})
-            ||| % $._config,
+            queries.memoryUtilizationPerNode($._config),
           )
           + prometheus.withLegendFormat('{{node}}'),
         ]),

--- a/dashboards/resources/queries/multi-cluster.libsonnet
+++ b/dashboards/resources/queries/multi-cluster.libsonnet
@@ -1,0 +1,67 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // Highlight stat queries
+  cpuUtilisation(config)::
+    'sum(cluster:node_cpu:ratio_rate5m) / count(cluster:node_cpu:ratio_rate5m)',
+
+  cpuRequestsCommitment(config)::
+    'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="cpu"})' % config,
+
+  cpuLimitsCommitment(config)::
+    'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="cpu"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="cpu"})' % config,
+
+  memoryUtilisation(config)::
+    '1 - sum(:node_memory_MemAvailable_bytes:sum) / sum(node_memory_MemTotal_bytes{%(nodeExporterSelector)s})' % config,
+
+  memoryRequestsCommitment(config)::
+    'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="memory"})' % config,
+
+  memoryLimitsCommitment(config)::
+    'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="memory"}) / sum(kube_node_status_allocatable{%(kubeStateMetricsSelector)s, resource="memory"})' % config,
+
+  // CPU Usage / Quota
+  cpuUsageByCluster(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m)) by (%(clusterLabel)s)' % config,
+
+  cpuRequestsByCluster(config)::
+    'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % config,
+
+  cpuUsageVsRequests(config)::
+    '%s / %s' % [self.cpuUsageByCluster(config), self.cpuRequestsByCluster(config)],
+
+  cpuLimitsByCluster(config)::
+    'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="cpu"}) by (%(clusterLabel)s)' % config,
+
+  cpuUsageVsLimits(config)::
+    '%s / %s' % [self.cpuUsageByCluster(config), self.cpuLimitsByCluster(config)],
+
+  // Memory Usage / Quota
+  memoryUsageByCluster(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_rss{%(cadvisorSelector)s, container!=""})) by (%(clusterLabel)s)' % config,
+
+  memoryRequestsByCluster(config)::
+    'sum(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % config,
+
+  memoryUsageVsRequests(config)::
+    '%s / %s' % [self.memoryUsageByCluster(config), self.memoryRequestsByCluster(config)],
+
+  memoryLimitsByCluster(config)::
+    'sum(kube_pod_container_resource_limits{%(kubeStateMetricsSelector)s, resource="memory"}) by (%(clusterLabel)s)' % config,
+
+  memoryUsageVsLimits(config)::
+    '%s / %s' % [self.memoryUsageByCluster(config), self.memoryLimitsByCluster(config)],
+}

--- a/dashboards/resources/queries/node.libsonnet
+++ b/dashboards/resources/queries/node.libsonnet
@@ -1,0 +1,77 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // CPU Queries
+  cpuCapacity(config)::
+    'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % config,
+
+  cpuAllocatable(config)::
+    'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="cpu"})' % config,
+
+  cpuUsageByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % config,
+
+  // CPU Quota Table Queries
+  cpuRequestsByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % config,
+
+  cpuUsageVsRequests(config)::
+    '%s / %s' % [self.cpuUsageByPod(config), self.cpuRequestsByPod(config)],
+
+  cpuLimitsByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % config,
+
+  cpuUsageVsLimits(config)::
+    '%s / %s' % [self.cpuUsageByPod(config), self.cpuLimitsByPod(config)],
+
+  // Memory Queries
+  memoryCapacity(config)::
+    'sum(kube_node_status_capacity{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % config,
+
+  memoryAllocatable(config)::
+    'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, node=~"$node", resource="memory"})' % config,
+
+  memoryUsageWSByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node", container!=""})) by (pod)' % config,
+
+  memoryUsageRSSByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_rss{%(clusterLabel)s="$cluster", node=~"$node", container!=""})) by (pod)' % config,
+
+  // Memory Quota Table Queries
+  memoryUsageWSByPodTable(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % config,
+
+  memoryRequestsByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % config,
+
+  memoryUsageVsRequests(config)::
+    '%s / %s' % [self.memoryUsageWSByPodTable(config), self.memoryRequestsByPod(config)],
+
+  memoryLimitsByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{%(clusterLabel)s="$cluster", node=~"$node"})) by (pod)' % config,
+
+  memoryUsageVsLimits(config)::
+    '%s / %s' % [self.memoryUsageWSByPodTable(config), self.memoryLimitsByPod(config)],
+
+  memoryUsageRSSByPodTable(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_rss{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % config,
+
+  memoryUsageCacheByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_cache{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % config,
+
+  memoryUsageSwapByPod(config)::
+    'sum(max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_memory_swap{%(clusterLabel)s="$cluster", node=~"$node",container!=""})) by (pod)' % config,
+}

--- a/dashboards/resources/queries/nodes-overview.libsonnet
+++ b/dashboards/resources/queries/nodes-overview.libsonnet
@@ -1,0 +1,56 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // Node & Pod Count
+  nodeCount(config)::
+    'count(kube_node_info{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s})' % config,
+
+  podCount(config)::
+    'sum(kubelet_running_pods{%(clusterLabel)s="$cluster", %(kubeletSelector)s})' % config,
+
+  // CPU
+  cpuAllocatable(config)::
+    'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="cpu"})' % config,
+
+  cpuRequests(config)::
+    'sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster"})' % config,
+
+  cpuUsage(config)::
+    'sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster"})' % config,
+
+  // Memory
+  memoryAllocatable(config)::
+    'sum(kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="memory"})' % config,
+
+  memoryRequests(config)::
+    'sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{%(clusterLabel)s="$cluster"})' % config,
+
+  memoryUsage(config)::
+    'sum(node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", container!=""})' % config,
+
+  // Per-node utilisation
+  cpuUtilizationPerNode(config):: |||
+    sum by (node) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster"})
+    /
+    sum by (node) (kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="cpu"})
+  ||| % config,
+
+  memoryUtilizationPerNode(config):: |||
+    sum by (node) (node_namespace_pod_container:container_memory_working_set_bytes{%(clusterLabel)s="$cluster", container!=""})
+    /
+    sum by (node) (kube_node_status_allocatable{%(clusterLabel)s="$cluster", %(kubeStateMetricsSelector)s, resource="memory"})
+  ||| % config,
+}

--- a/dashboards/resources/queries/workload-namespace.libsonnet
+++ b/dashboards/resources/queries/workload-namespace.libsonnet
@@ -1,0 +1,143 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // CPU / Memory Queries
+  cpuUsage(config):: |||
+    sum(
+      max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", namespace="$namespace"})
+    * on(%(clusterLabel)s, namespace, pod)
+      group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
+    ) by (workload, workload_type)
+  ||| % config,
+
+  cpuRequests(config):: |||
+    sum(
+      max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})
+    * on(%(clusterLabel)s, namespace, pod)
+      group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
+    ) by (workload, workload_type)
+  ||| % config,
+
+  podCount(config)::
+    'count(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}) by (workload, workload_type)' % config,
+
+  cpuLimits(config):: std.strReplace(self.cpuRequests(config), 'requests', 'limits'),
+
+  memUsage(config):: |||
+    sum(
+        max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_working_set_bytes{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""})
+      * on(%(clusterLabel)s, namespace, pod)
+        group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
+    ) by (workload, workload_type)
+  ||| % config,
+
+  memRequests(config):: std.strReplace(self.cpuRequests(config), 'cpu', 'memory'),
+
+  memLimits(config):: std.strReplace(self.cpuLimits(config), 'cpu', 'memory'),
+
+  // Resource Quota Queries
+  cpuQuotaRequests(config)::
+    'scalar(max(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource=~"requests.cpu|cpu"}))' % config,
+
+  cpuQuotaLimits(config):: std.strReplace(self.cpuQuotaRequests(config), 'requests.cpu|cpu', 'limits.cpu'),
+
+  memoryQuotaRequests(config):: std.strReplace(self.cpuQuotaRequests(config), 'requests.cpu|cpu', 'requests.memory|memory'),
+
+  memoryQuotaLimits(config):: std.strReplace(self.cpuQuotaRequests(config), 'requests.cpu|cpu', 'limits.memory'),
+
+  // Current Network Usage table columns
+  networkColumns(config):: [
+    |||
+      (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % (config { multiplier: config.units.networkMultiplier }),
+    |||
+      (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % (config { multiplier: config.units.networkMultiplier }),
+    |||
+      (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % config,
+    |||
+      (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % config,
+    |||
+      (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % config,
+    |||
+      (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
+    ||| % config,
+  ],
+
+  // Network TimeSeries Queries
+  receiveBandwidth(config):: |||
+    (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerReceiveBandwidth(config):: |||
+    (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerTransmitBandwidth(config):: |||
+    (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  rateReceivedPackets(config):: |||
+    (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateTransmittedPackets(config):: |||
+    (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateReceivedPacketsDropped(config):: |||
+    (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+
+  rateTransmittedPacketsDropped(config):: |||
+    (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
+  ||| % config,
+}

--- a/dashboards/resources/queries/workload.libsonnet
+++ b/dashboards/resources/queries/workload.libsonnet
@@ -1,0 +1,130 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  // CPU / Memory Queries
+  cpuUsage(config):: |||
+    sum(
+        max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", namespace="$namespace"})
+      * on(%(clusterLabel)s, namespace, pod)
+        group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
+    ) by (pod)
+  ||| % config,
+
+  cpuRequests(config):: |||
+    sum(
+        max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})
+      * on(%(clusterLabel)s, namespace, pod)
+        group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
+    ) by (pod)
+  ||| % config,
+
+  cpuLimits(config):: std.strReplace(self.cpuRequests(config), 'requests', 'limits'),
+
+  memUsage(config):: |||
+    sum(
+        max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""})
+      * on(%(clusterLabel)s, namespace, pod)
+        group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
+    ) by (pod)
+  ||| % config,
+
+  memRequests(config):: std.strReplace(self.cpuRequests(config), 'cpu', 'memory'),
+
+  memLimits(config):: std.strReplace(self.cpuLimits(config), 'cpu', 'memory'),
+
+  // Current Network Usage table columns
+  networkColumns(config):: [
+    |||
+      (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % (config { multiplier: config.units.networkMultiplier }),
+    |||
+      (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % (config { multiplier: config.units.networkMultiplier }),
+    |||
+      (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % config,
+    |||
+      (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % config,
+    |||
+      (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % config,
+    |||
+      (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
+      * on (%(clusterLabel)s, namespace, pod)
+      group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+    ||| % config,
+  ],
+
+  // Network TimeSeries Queries
+  receiveBandwidth(config):: |||
+    (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  transmitBandwidth(config):: |||
+    (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerReceiveBandwidth(config):: |||
+    (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  avgContainerTransmitBandwidth(config):: |||
+    (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % (config { multiplier: config.units.networkMultiplier }),
+
+  rateReceivedPackets(config):: |||
+    (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateTransmittedPackets(config):: |||
+    (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateReceivedPacketsDropped(config):: |||
+    (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+
+  rateTransmittedPacketsDropped(config):: |||
+    (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
+    * on (%(clusterLabel)s, namespace, pod)
+    group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
+  ||| % config,
+}

--- a/dashboards/resources/variables/multi-cluster.libsonnet
+++ b/dashboards/resources/variables/multi-cluster.libsonnet
@@ -1,0 +1,22 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import './common.libsonnet';
+
+{
+  multiCluster(config):: {
+    datasource: common.datasource(config),
+  },
+}

--- a/dashboards/resources/variables/node.libsonnet
+++ b/dashboards/resources/variables/node.libsonnet
@@ -1,0 +1,52 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+local common = import './common.libsonnet';
+
+{
+  node(config):: {
+    datasource: common.datasource(config),
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(kubeStateMetricsSelector)s}' % config
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    node:
+      var.query.new('node')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'node',
+        'kube_node_info{%(clusterLabel)s="$cluster"}' % config
+      )
+      + var.query.generalOptions.withLabel('node')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.selectionOptions.withMulti(true),
+  },
+}

--- a/dashboards/resources/variables/nodes-overview.libsonnet
+++ b/dashboards/resources/variables/nodes-overview.libsonnet
@@ -1,0 +1,40 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+local common = import './common.libsonnet';
+
+{
+  nodesOverview(config):: {
+    datasource: common.datasource(config),
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(kubeStateMetricsSelector)s}' % config
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/resources/variables/workload-namespace.libsonnet
+++ b/dashboards/resources/variables/workload-namespace.libsonnet
@@ -1,0 +1,55 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+local common = import './common.libsonnet';
+
+{
+  workloadNamespace(config):: {
+    datasource: common.datasource(config),
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(kubeStateMetricsSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace: common.namespace(config, self.datasource),
+
+    workload_type:
+      var.query.new('type')
+      + var.query.selectionOptions.withIncludeAll()
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload_type',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload_type')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/resources/variables/workload.libsonnet
+++ b/dashboards/resources/variables/workload.libsonnet
@@ -1,0 +1,68 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+local common = import './common.libsonnet';
+
+{
+  workload(config):: {
+    datasource: common.datasource(config),
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'up{%(kubeStateMetricsSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace: common.namespace(config, self.datasource),
+
+    workload_type:
+      var.query.new('type')
+      + var.query.selectionOptions.withIncludeAll()
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload_type',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload_type')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    workload:
+      var.query.new('workload')
+      + var.query.selectionOptions.withIncludeAll()
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'workload',
+        'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}' % config,
+      )
+      + var.query.generalOptions.withLabel('workload')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}

--- a/dashboards/resources/workload-namespace.libsonnet
+++ b/dashboards/resources/workload-namespace.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/workload-namespace.libsonnet';
+local defaultVariables = import './variables/workload-namespace.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -38,61 +39,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'k8s-resources-workloads-namespace.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.workloadNamespace, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'workloadNamespace')
+      then $._queries.workloadNamespace
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(kubeStateMetricsSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload_type:
-          var.query.new('type')
-          + var.query.selectionOptions.withIncludeAll()
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload_type',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~".+"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload_type')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.workloadNamespace, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'workloadNamespace')
+      then $._variables.workloadNamespace($._config)
+      else defaultVariables.workloadNamespace($._config);
 
       local links = {
         workload: {
@@ -104,72 +59,22 @@ local var = g.dashboard.variable;
         },
       };
 
-      local cpuUsageQuery = |||
-        sum(
-          max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", namespace="$namespace"})
-        * on(%(clusterLabel)s, namespace, pod)
-          group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
-        ) by (workload, workload_type)
-      ||| % $._config;
+      local cpuUsageQuery = queries.cpuUsage($._config);
+      local cpuRequestsQuery = queries.cpuRequests($._config);
 
-      local cpuRequestsQuery = |||
-        sum(
-          max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})
-        * on(%(clusterLabel)s, namespace, pod)
-          group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
-        ) by (workload, workload_type)
-      ||| % $._config;
+      local podCountQuery = queries.podCount($._config);
+      local cpuLimitsQuery = queries.cpuLimits($._config);
 
-      local podCountQuery = 'count(namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}) by (workload, workload_type)' % $._config;
-      local cpuLimitsQuery = std.strReplace(cpuRequestsQuery, 'requests', 'limits');
+      local memUsageQuery = queries.memUsage($._config);
+      local memRequestsQuery = queries.memRequests($._config);
+      local memLimitsQuery = queries.memLimits($._config);
 
-      local memUsageQuery = |||
-        sum(
-            max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_working_set_bytes{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""})
-          * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}
-        ) by (workload, workload_type)
-      ||| % $._config;
-      local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
-      local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
+      local cpuQuotaRequestsQuery = queries.cpuQuotaRequests($._config);
+      local cpuQuotaLimitsQuery = queries.cpuQuotaLimits($._config);
+      local memoryQuotaRequestsQuery = queries.memoryQuotaRequests($._config);
+      local memoryQuotaLimitsQuery = queries.memoryQuotaLimits($._config);
 
-      local cpuQuotaRequestsQuery = 'scalar(max(kube_resourcequota{%(clusterLabel)s="$cluster", namespace="$namespace", type="hard",resource=~"requests.cpu|cpu"}))' % $._config;
-      local cpuQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu|cpu', 'limits.cpu');
-      local memoryQuotaRequestsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu|cpu', 'requests.memory|memory');
-      local memoryQuotaLimitsQuery = std.strReplace(cpuQuotaRequestsQuery, 'requests.cpu|cpu', 'limits.memory');
-
-      local networkColumns = [
-        |||
-          (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
-        |||
-          (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
-        |||
-          (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload_type=~"$type"}) by (workload))
-        ||| % $._config,
-      ];
+      local networkColumns = queries.networkColumns($._config);
 
       local panels = [
         tsPanel.new('CPU Usage')
@@ -650,11 +555,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -664,11 +565,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -678,11 +575,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -692,11 +585,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -706,11 +595,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateReceivedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -720,11 +605,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateTransmittedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -734,11 +615,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateReceivedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -748,11 +625,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~".+", workload_type=~"$type"}) by (workload))
-            ||| % $._config
+            queries.rateTransmittedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/resources/workload.libsonnet
+++ b/dashboards/resources/workload.libsonnet
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local defaultQueries = import './queries/workload.libsonnet';
+local defaultVariables = import './variables/workload.libsonnet';
 local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
 local prometheus = g.query.prometheus;
 local table = g.panel.table;
 local timeSeries = g.panel.timeSeries;
-local var = g.dashboard.variable;
 
 {
   local tsPanel =
@@ -38,74 +39,15 @@ local var = g.dashboard.variable;
 
   grafanaDashboards+:: {
     'k8s-resources-workload.json':
-      local variables = {
-        datasource:
-          var.datasource.new('datasource', 'prometheus')
-          + var.datasource.withRegex($._config.datasourceFilterRegex)
-          + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.datasource.generalOptions.withLabel('Data source')
-          + {
-            current: {
-              selected: true,
-              text: $._config.datasourceName,
-              value: $._config.datasourceName,
-            },
-          },
+      // Allow overriding queries via $._queries.workload, otherwise use default
+      local queries = if std.objectHas($, '_queries') && std.objectHas($._queries, 'workload')
+      then $._queries.workload
+      else defaultQueries;
 
-        cluster:
-          var.query.new('cluster')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            $._config.clusterLabel,
-            'up{%(kubeStateMetricsSelector)s}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('cluster')
-          + var.query.refresh.onTime()
-          + (
-            if $._config.showMultiCluster
-            then var.query.generalOptions.showOnDashboard.withLabelAndValue()
-            else var.query.generalOptions.showOnDashboard.withNothing()
-          )
-          + var.query.withSort(type='alphabetical'),
-
-        namespace:
-          var.query.new('namespace')
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'namespace',
-            'kube_namespace_status_phase{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('namespace')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload_type:
-          var.query.new('type')
-          + var.query.selectionOptions.withIncludeAll()
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload_type',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload_type')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-
-        workload:
-          var.query.new('workload')
-          + var.query.selectionOptions.withIncludeAll()
-          + var.query.withDatasourceFromVariable(self.datasource)
-          + var.query.queryTypes.withLabelValues(
-            'workload',
-            'namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload_type=~"$type"}' % $._config,
-          )
-          + var.query.generalOptions.withLabel('workload')
-          + var.query.refresh.onTime()
-          + var.query.generalOptions.showOnDashboard.withLabelAndValue()
-          + var.query.withSort(type='alphabetical'),
-      };
+      // Allow overriding variables via $._variables.workload, otherwise use default
+      local variables = if std.objectHas($, '_variables') && std.objectHas($._variables, 'workload')
+      then $._variables.workload($._config)
+      else defaultVariables.workload($._config);
 
       local links = {
         pod: {
@@ -117,66 +59,15 @@ local var = g.dashboard.variable;
         },
       };
 
-      local cpuUsageQuery = |||
-        sum(
-            max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m{%(clusterLabel)s="$cluster", namespace="$namespace"})
-          * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
-        ) by (pod)
-      ||| % $._config;
+      local cpuUsageQuery = queries.cpuUsage($._config);
+      local cpuRequestsQuery = queries.cpuRequests($._config);
+      local cpuLimitsQuery = queries.cpuLimits($._config);
 
-      local cpuRequestsQuery = |||
-        sum(
-            max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(kube_pod_container_resource_requests{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", resource="cpu"})
-          * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
-        ) by (pod)
-      ||| % $._config;
+      local memUsageQuery = queries.memUsage($._config);
+      local memRequestsQuery = queries.memRequests($._config);
+      local memLimitsQuery = queries.memLimits($._config);
 
-      local cpuLimitsQuery = std.strReplace(cpuRequestsQuery, 'requests', 'limits');
-
-      local memUsageQuery = |||
-        sum(
-            max by (%(clusterLabel)s, %(namespaceLabel)s, pod, container)(container_memory_working_set_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container!="", image!=""})
-          * on(%(clusterLabel)s, namespace, pod)
-            group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", namespace="$namespace", workload=~"$workload", workload_type=~"$type"}
-        ) by (pod)
-      ||| % $._config;
-      local memRequestsQuery = std.strReplace(cpuRequestsQuery, 'cpu', 'memory');
-      local memLimitsQuery = std.strReplace(cpuLimitsQuery, 'cpu', 'memory');
-
-      local networkColumns = [
-        |||
-          (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
-        |||
-          (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s]))
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % ($._config { multiplier: $._config.units.networkMultiplier }),
-        |||
-          (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-        |||
-          (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace"}[%(grafanaIntervalVar)s])
-          * on (%(clusterLabel)s, namespace, pod)
-          group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-        ||| % $._config,
-      ];
+      local networkColumns = queries.networkColumns($._config);
 
       local panels = [
         tsPanel.new('CPU Usage')
@@ -481,11 +372,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.receiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -495,11 +382,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.transmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -509,11 +392,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (avg((%(multiplier)s * rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerReceiveBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -523,11 +402,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (avg((%(multiplier)s * rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s]))
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % ($._config { multiplier: $._config.units.networkMultiplier })
+            queries.avgContainerTransmitBandwidth($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -537,11 +412,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_receive_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateReceivedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -551,11 +422,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_transmit_packets_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateTransmittedPackets($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -565,11 +432,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_receive_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateReceivedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),
@@ -579,11 +442,7 @@ local var = g.dashboard.variable;
         + tsPanel.queryOptions.withTargets([
           prometheus.new(
             '${datasource}',
-            |||
-              (sum(rate(container_network_transmit_packets_dropped_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace"}[%(grafanaIntervalVar)s])
-              * on (%(clusterLabel)s, namespace, pod)
-              group_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{%(clusterLabel)s="$cluster", %(namespaceLabel)s="$namespace", workload=~"$workload", workload_type=~"$type"}) by (pod))
-            ||| % $._config
+            queries.rateTransmittedPacketsDropped($._config)
           )
           + prometheus.withLegendFormat('__auto'),
         ]),

--- a/dashboards/variables/persistentvolumesusage.libsonnet
+++ b/dashboards/variables/persistentvolumesusage.libsonnet
@@ -1,0 +1,74 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local var = g.dashboard.variable;
+
+{
+  persistentVolume(config):: {
+    datasource:
+      var.datasource.new('datasource', 'prometheus')
+      + var.datasource.withRegex(config.datasourceFilterRegex)
+      + var.datasource.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.datasource.generalOptions.withLabel('Data source')
+      + {
+        current: {
+          selected: true,
+          text: config.datasourceName,
+          value: config.datasourceName,
+        },
+      },
+
+    cluster:
+      var.query.new('cluster')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        config.clusterLabel,
+        'kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('cluster')
+      + var.query.refresh.onTime()
+      + (
+        if config.showMultiCluster
+        then var.query.generalOptions.showOnDashboard.withLabelAndValue()
+        else var.query.generalOptions.showOnDashboard.withNothing()
+      )
+      + var.query.withSort(type='alphabetical'),
+
+    namespace:
+      var.query.new('namespace')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'namespace',
+        'kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s}' % config,
+      )
+      + var.query.generalOptions.withLabel('Namespace')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+
+    volume:
+      var.query.new('volume')
+      + var.query.withDatasourceFromVariable(self.datasource)
+      + var.query.queryTypes.withLabelValues(
+        'persistentvolumeclaim',
+        'kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, namespace="$namespace"}' % config,
+      )
+      + var.query.generalOptions.withLabel('PersistentVolumeClaim')
+      + var.query.refresh.onTime()
+      + var.query.generalOptions.showOnDashboard.withLabelAndValue()
+      + var.query.withSort(type='alphabetical'),
+  },
+}


### PR DESCRIPTION
Part of:

- https://github.com/grafana/kubernetes-mixin-otel/issues/95

This PR refactors the remaining OTel-portable dashboards to allow for query overrides in downstream projects.

No behavioural changes.