### PR TITLE
fix: exclude SchedulingGated pods from KubePodNotReady

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -66,6 +66,8 @@ local utils = import '../lib/utils.libsonnet';
                   1, max by(namespace, pod, owner_kind, %(clusterLabel)s) (kube_pod_owner{owner_kind!="Job"})
                 )
               ) > 0
+              unless on(namespace, pod, %(clusterLabel)s)
+              kube_pod_status_reason{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, reason="SchedulingGated"} == 1
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -827,7 +827,14 @@ tests:
     values: '0+0x20'
   - series: 'kube_pod_owner{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",owner_is_controller="false",owner_kind="Deployment",owner_name="running-and-ready-example",pod="pod-running-and-ready",service="ksm"}'
     values: '1+0x20'
-    
+  # Pod held by scheduling gates - phase is Pending by design - should not trigger alert
+  - series: 'kube_pod_status_phase{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",phase="Pending",pod="pod-scheduling-gated",service="ksm"}'
+    values: '1+0x20'
+  - series: 'kube_pod_status_reason{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",reason="SchedulingGated",pod="pod-scheduling-gated",service="ksm"}'
+    values: '1+0x20'
+  - series: 'kube_pod_owner{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",owner_is_controller="true",owner_kind="StatefulSet",owner_name="scheduling-gated-example",pod="pod-scheduling-gated",service="ksm"}'
+    values: '1+0x20'
+
   alert_rule_test:
   - eval_time: 15m
     alertname: KubePodNotReady


### PR DESCRIPTION
## What

Exclude pods held by [scheduling gates](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/) from the `KubePodNotReady` alert

Fix #1255

## Why

A scheduling-gated pod (`status.conditions[PodScheduled].reason == "SchedulingGated"`) is intentionally held by a controller/webhook. Its `.status.phase` is genuinely `Pending`, so it matches `phase=~"Pending|Unknown"` and fires a false "non-ready for >15m" alert.

kube-state-metrics added a `SchedulingGated` value to `kube_pod_status_reason` in kubernetes/kube-state-metrics#2880, which lets the rule distinguish "intentionally held" from "genuinely stuck".

## How

Append to the `KubePodNotReady` expr:

```
) > 0
unless on(namespace, pod, <clusterLabel>)
kube_pod_status_reason{<selectors>, reason="SchedulingGated"} == 1
```

**Backward compatible:** on kube-state-metrics versions predating kubernetes/kube-state-metrics#2880 the `SchedulingGated` series doesn't exist, so `unless` excludes nothing and the alert behaves exactly as before. No minimum-ksm requirement and no config change for existing users.

## Testing

Adds a promtool unit test for a scheduling-gated pod (phase `Pending` + `kube_pod_status_reason{reason="SchedulingGated"}`) asserting it does not fire.