### PR TITLE
feat(kubejobnotcompleted): add kubeJobExcludedSelector

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -309,6 +309,8 @@ local utils = import '../lib/utils.libsonnet';
               time() - max by(namespace, job_name, %(clusterLabel)s) (kube_job_status_start_time{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
                 and
               kube_job_status_active{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s} > 0) > %(kubeJobTimeoutDuration)s
+                unless on(namespace, job_name, %(clusterLabel)s)
+              max by(namespace, job_name, %(clusterLabel)s) (kube_job_labels{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s,%(kubeJobExcludedSelector)s} == 1)
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -148,6 +148,11 @@
     // Default timeout value for k8s Jobs. The jobs which are active beyond this duration would trigger KubeJobNotCompleted alert.
     kubeJobTimeoutDuration: 12 * 60 * 60,
 
+    // This selector allows an admin to 'pre-mark' a Job (e.g. a long-running batch/Spark job)
+    // so that the KubeJobNotCompleted alert will not fire for it. With the default selector,
+    // adding a label `excluded-from-alerts: 'true'` to the Job will have the desired effect.
+    kubeJobExcludedSelector: 'label_excluded_from_alerts="true"',
+
     // Controls workload_type label value format: false = lowercase, true = PascalCase
     usePascalCaseForWorkloadTypeLabelValues: false,
   },

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1301,6 +1301,19 @@ tests:
   - eval_time: 12h
     alertname: KubeJobNotCompleted
 
+  # Don't alert when Job has been labelled as excluded from alerts
+- interval: 1m
+  input_series:
+  - series: 'kube_job_status_start_time{cluster="kubernetes",namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '0+0x740'
+  - series: 'kube_job_status_active{cluster="kubernetes",namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1"}'
+    values: '1+0x740'
+  - series: 'kube_job_labels{cluster="kubernetes",namespace="ns1", job="kube-state-metrics", instance="instance1", job_name="job1",label_excluded_from_alerts="true"}'
+    values: '1+0x740'
+  alert_rule_test:
+  - eval_time: 12h1m
+    alertname: KubeJobNotCompleted
+
 - interval: 1m
   input_series:
   - series: 'apiserver_request_terminations_total{cluster="kubernetes",job="kube-apiserver",apiserver="kube-apiserver"}'


### PR DESCRIPTION
Implemented exclusion support for KubeJobNotCompleted, mirroring the [existing PVC pattern](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/1e6b0e57f9730995e794596bea6d356ced784cc9/alerts/storage_alerts.libsonnet#L80-L81).  This is useful for people who intentionally have long-running Jobs.
```
  ...
unless
  kube_job_labels{label_excluded_from_alerts=true} == 1
```